### PR TITLE
fix: remove absolute paths on imports

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,8 +1,8 @@
-import { displayRulesTable } from 'src/lib/ui/table'
 import { Arguments } from 'yargs'
 import { VercelClient } from '../lib/fetchUtility'
 import { logger } from '../lib/logger'
 import { RuleTransformer } from '../lib/transformers/RuleTransformer'
+import { displayRulesTable } from '../lib/ui/table'
 
 interface ListOptions {
   projectId: string

--- a/src/lib/ui/table/index.ts
+++ b/src/lib/ui/table/index.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import Table from 'cli-table3'
-import { logger } from 'src/lib/logger'
+import { logger } from '../../logger'
 import { FirewallConfig } from '../../types/configTypes'
 import { formatAction } from './formatAction'
 import { formatConditionGroups } from './formatConditionGroups'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
+  minify: true,
 })


### PR DESCRIPTION
Resolve Import Issues

### Import Fixes

- **Fix Import Paths**: Remove absolute paths and switch all imports to be relative, ensuring consistency and reliability in module imports.  (a71cc20)
