### PR TITLE
fix(schema): lint and format generated schema inside of prebuild step

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "semi": false,
   "printWidth": 120,
-  "singleQuote": true,
-  "typescript.format.semicolons": "remove"
+  "singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git+ssh://git@github.com/gfargo/vercel-doorman.git"
   },
   "scripts": {
-    "prebuild": "pnpm clean; pnpm build:schema",
+    "prebuild": "pnpm clean; pnpm build:schema; pnpm lint:fix; pnpm format:fix",
     "build": "tsup-node",
     "build:schema": "ts-node ./scripts/generate-schema.ts ",
     "build:watch": "tsup-node --watch",

--- a/schema/firewall-config.schema.json
+++ b/schema/firewall-config.schema.json
@@ -32,9 +32,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "rules"
-      ],
+      "required": ["rules"],
       "additionalProperties": false
     },
     "CustomRule": {
@@ -78,11 +76,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "name",
-        "action",
-        "active"
-      ],
+      "required": ["name", "action", "active"],
       "additionalProperties": false
     },
     "RuleType": {
@@ -121,9 +115,7 @@
           }
         }
       },
-      "required": [
-        "conditions"
-      ],
+      "required": ["conditions"],
       "additionalProperties": false
     },
     "VercelCondition": {
@@ -158,31 +150,12 @@
           ]
         }
       },
-      "required": [
-        "op",
-        "type",
-        "value"
-      ],
+      "required": ["op", "type", "value"],
       "additionalProperties": false
     },
     "RuleOperator": {
       "type": "string",
-      "enum": [
-        "re",
-        "eq",
-        "neq",
-        "ex",
-        "nex",
-        "inc",
-        "ninc",
-        "pre",
-        "suf",
-        "sub",
-        "gt",
-        "gte",
-        "lt",
-        "lte"
-      ]
+      "enum": ["re", "eq", "neq", "ex", "nex", "inc", "ninc", "pre", "suf", "sub", "gt", "gte", "lt", "lte"]
     },
     "RuleAction": {
       "type": "object",
@@ -200,19 +173,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     },
     "RuleActionType": {
       "type": "string",
-      "enum": [
-        "allow",
-        "deny",
-        "challenge",
-        "log"
-      ]
+      "enum": ["allow", "deny", "challenge", "log"]
     },
     "RuleRateLimit": {
       "type": "object",
@@ -224,10 +190,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "requests",
-        "window"
-      ],
+      "required": ["requests", "window"],
       "additionalProperties": false
     },
     "RuleRedirect": {
@@ -240,9 +203,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "location"
-      ],
+      "required": ["location"],
       "additionalProperties": false
     },
     "IPBlockingRule": {
@@ -265,11 +226,7 @@
           "const": "deny"
         }
       },
-      "required": [
-        "ip",
-        "hostname",
-        "action"
-      ],
+      "required": ["ip", "hostname", "action"],
       "additionalProperties": false
     }
   }

--- a/src/constants/schema.ts
+++ b/src/constants/schema.ts
@@ -1,276 +1,233 @@
 export const schema = {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Doorman Config",
-  "description": "Schema for vercel-doorman project configuration files",
-  "$ref": "#/definitions/FirewallConfig",
-  "definitions": {
-    "FirewallConfig": {
-      "type": "object",
-      "properties": {
-        "projectId": {
-          "type": "string"
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Doorman Config',
+  description: 'Schema for vercel-doorman project configuration files',
+  $ref: '#/definitions/FirewallConfig',
+  definitions: {
+    FirewallConfig: {
+      type: 'object',
+      properties: {
+        projectId: {
+          type: 'string',
         },
-        "teamId": {
-          "type": "string"
+        teamId: {
+          type: 'string',
         },
-        "rules": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CustomRule"
-          }
+        rules: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/CustomRule',
+          },
         },
-        "ips": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IPBlockingRule"
-          }
+        ips: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/IPBlockingRule',
+          },
         },
-        "version": {
-          "type": "number"
+        version: {
+          type: 'number',
         },
-        "updatedAt": {
-          "type": "string"
-        }
+        updatedAt: {
+          type: 'string',
+        },
       },
-      "required": [
-        "rules"
-      ],
-      "additionalProperties": false
+      required: ['rules'],
+      additionalProperties: false,
     },
-    "CustomRule": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
+    CustomRule: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
         },
-        "name": {
-          "type": "string"
+        name: {
+          type: 'string',
         },
-        "description": {
-          "type": "string"
+        description: {
+          type: 'string',
         },
-        "type": {
-          "$ref": "#/definitions/RuleType"
+        type: {
+          $ref: '#/definitions/RuleType',
         },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        values: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
         },
-        "conditionGroup": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VercelConditionGroup"
-          }
+        conditionGroup: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/VercelConditionGroup',
+          },
         },
-        "action": {
-          "anyOf": [
+        action: {
+          anyOf: [
             {
-              "$ref": "#/definitions/RuleAction"
+              $ref: '#/definitions/RuleAction',
             },
             {
-              "$ref": "#/definitions/RuleActionType"
-            }
-          ]
+              $ref: '#/definitions/RuleActionType',
+            },
+          ],
         },
-        "active": {
-          "type": "boolean"
-        }
+        active: {
+          type: 'boolean',
+        },
       },
-      "required": [
-        "name",
-        "action",
-        "active"
+      required: ['name', 'action', 'active'],
+      additionalProperties: false,
+    },
+    RuleType: {
+      type: 'string',
+      enum: [
+        'host',
+        'path',
+        'method',
+        'header',
+        'query',
+        'cookie',
+        'target_path',
+        'ip_address',
+        'region',
+        'protocol',
+        'scheme',
+        'environment',
+        'user_agent',
+        'geo_continent',
+        'geo_country',
+        'geo_country_region',
+        'geo_city',
+        'geo_as_number',
+        'ja4_digest',
+        'ja3_digest',
+        'rate_limit_api_id',
       ],
-      "additionalProperties": false
     },
-    "RuleType": {
-      "type": "string",
-      "enum": [
-        "host",
-        "path",
-        "method",
-        "header",
-        "query",
-        "cookie",
-        "target_path",
-        "ip_address",
-        "region",
-        "protocol",
-        "scheme",
-        "environment",
-        "user_agent",
-        "geo_continent",
-        "geo_country",
-        "geo_country_region",
-        "geo_city",
-        "geo_as_number",
-        "ja4_digest",
-        "ja3_digest",
-        "rate_limit_api_id"
-      ]
-    },
-    "VercelConditionGroup": {
-      "type": "object",
-      "properties": {
-        "conditions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VercelCondition"
-          }
-        }
+    VercelConditionGroup: {
+      type: 'object',
+      properties: {
+        conditions: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/VercelCondition',
+          },
+        },
       },
-      "required": [
-        "conditions"
-      ],
-      "additionalProperties": false
+      required: ['conditions'],
+      additionalProperties: false,
     },
-    "VercelCondition": {
-      "type": "object",
-      "properties": {
-        "op": {
-          "$ref": "#/definitions/RuleOperator"
+    VercelCondition: {
+      type: 'object',
+      properties: {
+        op: {
+          $ref: '#/definitions/RuleOperator',
         },
-        "type": {
-          "$ref": "#/definitions/RuleType"
+        type: {
+          $ref: '#/definitions/RuleType',
         },
-        "value": {
-          "anyOf": [
+        value: {
+          anyOf: [
             {
-              "type": "string"
+              type: 'string',
             },
             {
-              "type": "number"
+              type: 'number',
             },
             {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              type: 'array',
+              items: {
+                type: 'string',
+              },
             },
             {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            }
-          ]
-        }
+              type: 'array',
+              items: {
+                type: 'number',
+              },
+            },
+          ],
+        },
       },
-      "required": [
-        "op",
-        "type",
-        "value"
-      ],
-      "additionalProperties": false
+      required: ['op', 'type', 'value'],
+      additionalProperties: false,
     },
-    "RuleOperator": {
-      "type": "string",
-      "enum": [
-        "re",
-        "eq",
-        "neq",
-        "ex",
-        "nex",
-        "inc",
-        "ninc",
-        "pre",
-        "suf",
-        "sub",
-        "gt",
-        "gte",
-        "lt",
-        "lte"
-      ]
+    RuleOperator: {
+      type: 'string',
+      enum: ['re', 'eq', 'neq', 'ex', 'nex', 'inc', 'ninc', 'pre', 'suf', 'sub', 'gt', 'gte', 'lt', 'lte'],
     },
-    "RuleAction": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/RuleActionType"
+    RuleAction: {
+      type: 'object',
+      properties: {
+        type: {
+          $ref: '#/definitions/RuleActionType',
         },
-        "rateLimit": {
-          "$ref": "#/definitions/RuleRateLimit"
+        rateLimit: {
+          $ref: '#/definitions/RuleRateLimit',
         },
-        "redirect": {
-          "$ref": "#/definitions/RuleRedirect"
+        redirect: {
+          $ref: '#/definitions/RuleRedirect',
         },
-        "duration": {
-          "type": "string"
-        }
+        duration: {
+          type: 'string',
+        },
       },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
+      required: ['type'],
+      additionalProperties: false,
     },
-    "RuleActionType": {
-      "type": "string",
-      "enum": [
-        "allow",
-        "deny",
-        "challenge",
-        "log"
-      ]
+    RuleActionType: {
+      type: 'string',
+      enum: ['allow', 'deny', 'challenge', 'log'],
     },
-    "RuleRateLimit": {
-      "type": "object",
-      "properties": {
-        "requests": {
-          "type": "number"
+    RuleRateLimit: {
+      type: 'object',
+      properties: {
+        requests: {
+          type: 'number',
         },
-        "window": {
-          "type": "string"
-        }
+        window: {
+          type: 'string',
+        },
       },
-      "required": [
-        "requests",
-        "window"
-      ],
-      "additionalProperties": false
+      required: ['requests', 'window'],
+      additionalProperties: false,
     },
-    "RuleRedirect": {
-      "type": "object",
-      "properties": {
-        "location": {
-          "type": "string"
+    RuleRedirect: {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'string',
         },
-        "permanent": {
-          "type": "boolean"
-        }
+        permanent: {
+          type: 'boolean',
+        },
       },
-      "required": [
-        "location"
-      ],
-      "additionalProperties": false
+      required: ['location'],
+      additionalProperties: false,
     },
-    "IPBlockingRule": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
+    IPBlockingRule: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
         },
-        "ip": {
-          "type": "string"
+        ip: {
+          type: 'string',
         },
-        "hostname": {
-          "type": "string"
+        hostname: {
+          type: 'string',
         },
-        "notes": {
-          "type": "string"
+        notes: {
+          type: 'string',
         },
-        "action": {
-          "type": "string",
-          "const": "deny"
-        }
+        action: {
+          type: 'string',
+          const: 'deny',
+        },
       },
-      "required": [
-        "ip",
-        "hostname",
-        "action"
-      ],
-      "additionalProperties": false
-    }
-  }
+      required: ['ip', 'hostname', 'action'],
+      additionalProperties: false,
+    },
+  },
 }


### PR DESCRIPTION
Implement Prebuild Linting and Formatting for Schema Consistency

### Build Process Improvements

- **Fix Schema Formatting**: Lint and format the generated schema during the prebuild step to ensure consistent code style and readability. This includes switching JSON schema definitions to single quotes and inlining required properties.  `82d8886`

- **Prebuild Script Update**: Modify the `.prettierrc` to remove TypeScript semicolon formatting and add `lint:fix` and `format:fix` tasks to the `prebuild` script in `package.json`. These updates automate code quality checks and formatting tasks before the build process.  `82d8886`