### PR TITLE
feat: prompt for missing credentials

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -6,10 +6,13 @@ import { commands } from '../src/commands'
 config()
 
 const run = yargs(process.argv.slice(2))
-run.usage(`${chalk.bold('Vercel Doorman')} - Manage Vercel Firewall rules in code`)
+run.usage(`${chalk.bold('▲ Doorman')}\n\n${chalk.dim('Manage Vercel Firewall rules via code')}`)
 
 for (const command of commands) {
   run.command(command as CommandModule)
 }
 
-run.demandCommand(1, 'You need at least one command before moving on').help().argv
+run
+  .demandCommand(1, 'You need at least one command before moving on')
+  .help()
+  .epilogue(chalk.dim(`See ${chalk.bold('https://doorman.griffen.codes/getting-started')} for more info`)).argv

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -56,6 +56,8 @@ export const builder = {
   },
 }
 
+import { promptForCredentials } from '../lib/utils/promptForCredentials'
+
 export const handler = async (argv: Arguments<DownloadOptions>) => {
   try {
     if (argv.debug) {
@@ -64,11 +66,6 @@ export const handler = async (argv: Arguments<DownloadOptions>) => {
 
     logger.debug('Starting download command')
     logger.debug(`Command arguments: ${JSON.stringify(argv)}`)
-
-    const token = argv.token || process.env.VERCEL_TOKEN
-    if (!token) {
-      throw new Error('No Vercel token provided. Use --token or set VERCEL_TOKEN environment variable')
-    }
 
     // Find and read config file
     let configPath = argv.config
@@ -87,16 +84,11 @@ export const handler = async (argv: Arguments<DownloadOptions>) => {
     const existingConfig: FirewallConfig = JSON.parse(configContent)
     logger.debug(`Existing config: ${JSON.stringify(existingConfig)}`)
 
-    const projectId = argv.projectId || existingConfig.projectId
-    const teamId = argv.teamId || existingConfig.teamId
-
-    if (!projectId) {
-      throw new Error('No Project ID provided. Use --projectId or set in config file')
-    }
-
-    if (!teamId) {
-      throw new Error('No Team ID provided. Use --teamId or set in config file')
-    }
+    const { token, projectId, teamId } = await promptForCredentials({
+      token: argv.token,
+      projectId: argv.projectId || existingConfig.projectId,
+      teamId: argv.teamId || existingConfig.teamId,
+    })
 
     logger.debug(`Project ID: ${projectId}, Team ID: ${teamId}`)
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -46,27 +46,19 @@ export const builder = {
   },
 }
 
+import { promptForCredentials } from '../lib/utils/promptForCredentials'
+
 export const handler = async (argv: Arguments<ListOptions>) => {
   try {
-    // Get token from args or environment
-    const token = argv.token || process.env.VERCEL_TOKEN
-    if (!token) {
-      throw new Error('No Vercel token provided. Use --token or set VERCEL_TOKEN environment variable')
-    }
-
-    const projectId = argv.projectId || process.env.VERCEL_PROJECT_ID
-    if (!projectId) {
-      throw new Error('No Vercel project ID provided. Use --projectId or set VERCEL_PROJECT_ID environment variable')
-    }
-
-    const teamId = argv.teamId || process.env.VERCEL_TEAM_ID
-    if (!teamId) {
-      throw new Error('No Vercel team ID provided. Use --teamId or set VERCEL_TEAM_ID environment variable')
-    }
-
     if (argv.debug) {
       logger.level = LogLevels.debug
     }
+
+    const { token, projectId, teamId } = await promptForCredentials({
+      token: argv.token,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
+    })
 
     const client = new VercelClient(projectId, teamId, token)
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -49,13 +49,10 @@ export const builder = {
   },
 }
 
+import { promptForCredentials } from '../lib/utils/promptForCredentials'
+
 export const handler = async (argv: Arguments<SyncOptions>) => {
   try {
-    const token = argv.token || process.env.VERCEL_TOKEN
-    if (!token) {
-      throw new Error('No Vercel token provided. Use --token or set VERCEL_TOKEN environment variable')
-    }
-
     // Find and read config file
     let configPath = argv.config
     if (!configPath) {
@@ -75,16 +72,11 @@ export const handler = async (argv: Arguments<SyncOptions>) => {
     validator.validateConfig(configJson)
     let config: FirewallConfig = configJson
 
-    const projectId = argv.projectId || config.projectId
-    const teamId = argv.teamId || config.teamId
-
-    if (!projectId) {
-      throw new Error('No Project ID provided. Use --projectId or set in config file')
-    }
-
-    if (!teamId) {
-      throw new Error('No Team ID provided. Use --teamId or set in config file')
-    }
+    const { token, projectId, teamId } = await promptForCredentials({
+      token: argv.token,
+      projectId: argv.projectId || config.projectId,
+      teamId: argv.teamId || config.teamId,
+    })
 
     const client = new VercelClient(projectId, teamId, token)
     const service = new FirewallService(client)

--- a/src/lib/utils/promptForCredentials.ts
+++ b/src/lib/utils/promptForCredentials.ts
@@ -1,0 +1,33 @@
+import { prompt } from '../ui/prompt'
+
+export async function promptForCredentials(args: {
+  token?: string
+  teamId?: string
+  projectId?: string
+}): Promise<{ token: string; teamId: string; projectId: string }> {
+  const token =
+    args.token ||
+    process.env.VERCEL_TOKEN ||
+    (await prompt(
+      `What is your Vercel API Auth Token? (https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token#creating-an-access-token)`,
+      { type: 'text' },
+    ))
+
+  const teamId =
+    args.teamId ||
+    process.env.VERCEL_TEAM_ID ||
+    (await prompt(
+      `What is your Vercel Team ID? (See https://vercel.com/docs/accounts/create-a-team#find-your-team-id)`,
+      { type: 'text' },
+    ))
+
+  const projectId =
+    args.projectId ||
+    process.env.VERCEL_PROJECT_ID ||
+    (await prompt(
+      `What is your Vercel Project ID? (See https://vercel.com/docs/projects/project-configuration/general-settings#project-id)`,
+      { type: 'text' },
+    ))
+
+  return { token, teamId, projectId }
+}


### PR DESCRIPTION
Refactor Credential Prompts and Update CLI Messaging

### Refactor Credential Handling
- Centralize credential prompts with `promptForCredentials` to streamline input across commands, removing redundant checks for `token`, `projectId`, and `teamId`. This change ensures credentials are prompted only when not provided via arguments or environment variables. (0907bdd)

### CLI Messaging Updates
- Revise the CLI usage message for improved readability and branding. Update 'Vercel Doorman' to '▲ Doorman' and enhance the description format. Include an epilogue with a link to the getting started guide for additional user support. (0b119fb)