### PR TITLE
Add Config Version Support and Enhance Firewall Sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,15 +1,17 @@
 import chalk from 'chalk'
+import { LogLevels } from 'consola'
 import { readFileSync, writeFileSync } from 'fs'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import { FirewallConfig } from '../lib/schemas/firewallSchemas'
 import { FirewallService } from '../lib/services/FirewallService'
 import { ValidationService } from '../lib/services/ValidationService'
 import { VercelClient } from '../lib/services/VercelClient'
-import { FirewallConfig } from '../lib/schemas/firewallSchemas'
 import { prompt } from '../lib/ui/prompt'
 import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
 import { ConfigFinder } from '../lib/utils/configFinder'
 import { ErrorFormatter } from '../lib/utils/errorFormatter'
+import { promptForCredentials } from '../lib/utils/promptForCredentials'
 
 interface SyncOptions {
   config?: string
@@ -49,10 +51,12 @@ export const builder = {
   },
 }
 
-import { promptForCredentials } from '../lib/utils/promptForCredentials'
-
 export const handler = async (argv: Arguments<SyncOptions>) => {
   try {
+    if (argv.debug) {
+      logger.level = LogLevels.debug
+    }
+
     // Find and read config file
     let configPath = argv.config
     if (!configPath) {

--- a/src/lib/schemas/firewallSchemas.ts
+++ b/src/lib/schemas/firewallSchemas.ts
@@ -20,6 +20,8 @@ import type {
 } from '../types/vercelTypes'
 
 // Basic schemas
+export const configVersionSchema = z.number().int().positive().optional()
+
 export const ipAddressSchema = z
   .string()
   .ip()

--- a/src/lib/services/FirewallService.ts
+++ b/src/lib/services/FirewallService.ts
@@ -368,15 +368,14 @@ export class FirewallService {
     // Update IP rules with remote IDs
     if (updatedConfig.ips) {
       updatedConfig.ips = updatedConfig.ips.map((localRule): IPBlockingRule => {
-        if (!localRule.id || localRule.id === '-') {
-          // Find matching remote rule by comparing content without IDs
-          const matchingRemoteRule = remoteIPRules.find((remoteRule) =>
-            isDeepEqual(omitId(remoteRule), omitId(localRule)),
-          )
-          if (matchingRemoteRule) {
-            // Update local rule with remote ID while preserving all other properties
-            return { ...localRule, id: matchingRemoteRule.id as string }
-          }
+        // Find matching remote rule by comparing content without IDs
+        const matchingRemoteRule = remoteIPRules.find((remoteRule) =>
+          isDeepEqual(omitId(remoteRule), omitId(localRule)),
+        )
+
+        if (matchingRemoteRule && matchingRemoteRule.id !== localRule.id) {
+          // Update to use newest remote ID, if different
+          return { ...localRule, id: matchingRemoteRule.id as string }
         }
         return localRule
       })

--- a/src/lib/services/FirewallService.ts
+++ b/src/lib/services/FirewallService.ts
@@ -42,7 +42,7 @@ export class FirewallService {
       }
 
       logger.debug('Fetching existing firewall configuration')
-      const activeConfig = await this.client.fetchActiveFirewallConfig()
+      const activeConfig = await this.client.fetchFirewallConfig()
       logger.debug(`Fetched ${activeConfig.rules.length} custom rules and ${activeConfig.ips.length} IP blocking rules`)
 
       // Handle custom rules
@@ -288,7 +288,7 @@ export class FirewallService {
     await new Promise((resolve) => setTimeout(resolve, 1500))
 
     // Fetch latest config with retries
-    const activeConfig = await retry(() => this.client.fetchActiveFirewallConfig(), {
+    const activeConfig = await retry(() => this.client.fetchFirewallConfig(), {
       maxAttempts: 3,
       delayMs: 1000,
       backoff: true,


### PR DESCRIPTION
### Features

- **Add Config Version Support**
  - Enhance the `download` command to accept an optional `configVersion` argument, allowing users to specify a configuration version to download. Update `FirewallService` to use `fetchFirewallConfig` instead of `fetchActiveFirewallConfig` for improved flexibility. (a0b8954)
  - Enhance the `list` command to optionally accept a `configVersion` parameter, allowing users to fetch specific firewall configuration versions. Update `VercelClient` to handle versioned requests, and add `configVersionSchema` for validation. Improve logging for better debugging. (5e07d18)

### Fixes

- **Enhance Sync and Update IP Rules**  (e75c93e)
  - Improve `sync` command by adding debug logging with `LogLevels`. 
  - Refactor `FirewallService` to update local IP rules with the latest remote IDs when they differ. This ensures accurate synchronization of firewall configurations and enhances debugging capabilities.

Resolves #13