### PR TITLE
Add JSON Schema Support for Enhanced Configuration Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ pnpm add vercel-doorman
 
 ## Configuration
 
-Create a `vercel-firewall.config.json` file in your project root:
+Create a `vercel-firewall.config.json` file in your project root. The configuration file supports JSON Schema for enhanced IDE features like autocompletion and validation:
 
 ```json
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "projectId": "your-project-id",
   "teamId": "your-team-id",
   "rules": [],

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,7 @@ Each firewall rule in Vercel Doorman follows this structure:
 
 ```json
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "name": "Example Rule",
   "description": "Optional description of the rule",
   "conditionGroup": [

--- a/examples/challenge-rules.json
+++ b/examples/challenge-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Search Protection",

--- a/examples/conditional-rules.json
+++ b/examples/conditional-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Complex Bot Detection",

--- a/examples/environment-rules.json
+++ b/examples/environment-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Preview Environment Protection",

--- a/examples/geo-blocking.json
+++ b/examples/geo-blocking.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Block Country",

--- a/examples/header-based-rules.json
+++ b/examples/header-based-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "API Version Control",

--- a/examples/header-rate-limits.json
+++ b/examples/header-rate-limits.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "API Key Rate Limit",

--- a/examples/ip-block.json
+++ b/examples/ip-block.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Block Single IP",

--- a/examples/method-restriction.json
+++ b/examples/method-restriction.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "POST Only Endpoints",

--- a/examples/mixed-rules.json
+++ b/examples/mixed-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Complete API Protection",

--- a/examples/path-protection.json
+++ b/examples/path-protection.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Protect Sensitive Paths",

--- a/examples/protocol-rules.json
+++ b/examples/protocol-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Force HTTPS",

--- a/examples/rate-limiting.json
+++ b/examples/rate-limiting.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "API Rate Limit",

--- a/examples/redirect-rules.json
+++ b/examples/redirect-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Legacy Path Redirect",

--- a/examples/simple-config.json
+++ b/examples/simple-config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "projectId": "prj_...",
   "teamId": "team_...",
   "rules": [

--- a/examples/user-agent-filtering.json
+++ b/examples/user-agent-filtering.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://doorman.griffen.codes/schema.json",
   "rules": [
     {
       "name": "Block Bad Bots",

--- a/schema/firewall-config.schema.json
+++ b/schema/firewall-config.schema.json
@@ -13,6 +13,9 @@
         "teamId": {
           "type": "string"
         },
+        "$schema": {
+          "type": "string"
+        },
         "version": {
           "type": "number"
         },
@@ -33,7 +36,8 @@
         }
       },
       "required": ["rules"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "The main configuration type for Vercel Doorman"
     },
     "CustomRule": {
       "type": "object",

--- a/src/constants/schema.ts
+++ b/src/constants/schema.ts
@@ -21,6 +21,9 @@ export const schema = {
         teamId: {
           type: 'string',
         },
+        $schema: {
+          type: 'string',
+        },
         version: {
           type: 'number',
         },
@@ -42,6 +45,7 @@ export const schema = {
       },
       required: ['rules'],
       additionalProperties: false,
+      description: 'The main configuration type for Vercel Doorman',
     },
     CustomRule: {
       type: 'object',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,7 +103,16 @@ export interface ProjectConfig {
   teamId?: string
 }
 
+/**
+ * The main configuration type for Vercel Doorman
+ * @property $schema - The URI of the JSON Schema to validate against
+ * @property version - Configuration version number
+ * @property rules - List of firewall rules
+ * @property ips - Optional list of IP blocking rules
+ * @property updatedAt - Last update timestamp
+ */
 export interface FirewallConfig extends ProjectConfig {
+  $schema?: string
   version?: number
   rules: CustomRule[]
   ips?: IPBlockingRule[]

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -11,7 +11,10 @@ interface ConfigOptions {
   throwOnError?: boolean // Whether to throw on validation errors (if validate is true)
 }
 
+const SCHEMA_URL = 'https://doorman.griffen.codes/schema.json'
+
 const createEmptyConfig = (): FirewallConfig => ({
+  $schema: SCHEMA_URL,
   rules: [],
 })
 


### PR DESCRIPTION
### Configuration Updates

- **Add JSON Schema to Example Configs**
  - Annotate all example JSON configurations with `$schema` to ensure adherence to the defined schema. This change improves validation and consistency across rule examples. (Commit: 05d7f96)

- **Enhance FirewallConfig with JSON Schema Support**
  - Introduce `$schema` property for JSON Schema validation in `FirewallConfig`.
  - Update comments and README to guide users on leveraging JSON Schema for better IDE features.
  - Add `SCHEMA_URL` constant for consistent schema referencing. (Commit: 06c2a47)
  
  
Resolves #36 