### PR TITLE
chore: update audit level to moderate in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
-        run: pnpm audit signatures
+        run: pnpm audit --audit-level=moderate
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
Adjusts the signature verification step to use moderate audit level for better security without slowing down the release process