### PR TITLE
fix(deps): override handlebars to >=4.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
       "brace-expansion@>=2.0.0": "^2.0.2",
       "tmp": ">=0.2.4",
       "esbuild": ">=0.25.0",
-      "@babel/helpers": ">=7.26.10"
+      "@babel/helpers": ">=7.26.10",
+      "handlebars": ">=4.7.9"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   tmp: '>=0.2.4'
   esbuild: '>=0.25.0'
   '@babel/helpers': '>=7.26.10'
+  handlebars: '>=4.7.9'
 
 importers:
 
@@ -2084,8 +2085,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -5422,7 +5423,7 @@ snapshots:
     dependencies:
       '@types/semver': 7.5.8
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
       semver: 7.6.2
 
@@ -6167,7 +6168,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
Resolves 7 Dependabot alerts (1 Critical, 3 High, 2 Medium, 1 Low) via pnpm.overrides. handlebars is a transitive dep of semantic-release.

---

Hi @gfargo!

I'd like to open some PRs to resolve open security warnings while I am in the process of adopting `vercel-doorman`. I noticed you have already resolved a few this same way with overrides. Let me know if you'd prefer I go about this a different way... I was planning on opening atomic PRs for each dependency.