### PR TITLE
fix: resolve prettier formatting error in FirewallService.ts

### DIFF
--- a/src/lib/services/FirewallService.ts
+++ b/src/lib/services/FirewallService.ts
@@ -406,9 +406,7 @@ export class FirewallService {
     if (updatedConfig.ips) {
       updatedConfig.ips = updatedConfig.ips.map((localRule): IPBlockingRule => {
         const matchingRemoteRule = remoteIPRules.find(
-          (remoteRule) =>
-            !matchedRemoteIPIds.has(remoteRule.id!) &&
-            isDeepEqual(omitId(remoteRule), omitId(localRule)),
+          (remoteRule) => !matchedRemoteIPIds.has(remoteRule.id!) && isDeepEqual(omitId(remoteRule), omitId(localRule)),
         )
         if (matchingRemoteRule && matchingRemoteRule.id !== localRule.id) {
           matchedRemoteIPIds.add(matchingRemoteRule.id!)


### PR DESCRIPTION
Fixes the CI lint failure — a multi-line arrow function in the IP rule matching block exceeded prettier's width rules. One-line auto-fix via `pnpm lint:fix`.

The pre-commit hook already runs `lint:fix`, but this slipped through because prior commits used `--no-verify`.