### PR TITLE
refactor: extract shared credential middleware

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -4,12 +4,11 @@ import { join } from 'path'
 import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { VercelClient } from '../lib/services/VercelClient'
 import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface BackupOptions {
   config?: string
@@ -77,7 +76,7 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
 
     const backupDir = argv.output || './backups'
 
-    // List backups
+    // List backups — no credentials needed
     if (argv.list) {
       if (!existsSync(backupDir)) {
         logger.info(chalk.yellow('No backup directory found.'))
@@ -112,7 +111,7 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
       return
     }
 
-    // Restore from backup
+    // Restore from backup — no credentials needed
     if (argv.restore) {
       const restorePath = argv.restore.startsWith('/') ? argv.restore : join(backupDir, argv.restore)
 
@@ -140,58 +139,63 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
       return
     }
 
-    // Create backup
-    const config = await getConfig(argv.config)
-
-    const { token, projectId, teamId } = await promptForCredentials({
-      token: argv.token,
-      projectId: argv.projectId || config.projectId,
-      teamId: argv.teamId || config.teamId,
-    })
-
-    const client = new VercelClient(projectId, teamId, token)
-
-    logger.start('Fetching current remote configuration...')
-    const remoteConfig = await client.fetchFirewallConfig()
-
-    // Create backup directory if it doesn't exist
-    if (!existsSync(backupDir)) {
-      mkdirSync(backupDir, { recursive: true })
-    }
-
-    // Generate backup filename with timestamp
-    const now = new Date()
-    const datePart = now.toISOString().split('T')[0] ?? 'unknown-date'
-    const timePart = (now.toISOString().split('T')[1] ?? '').split('.')[0]?.replace(/:/g, '-') ?? 'unknown-time'
-    const timestamp = `${datePart}_${timePart}`
-    const backupFilename = `firewall-backup-${timestamp}.json`
-    const backupPath = join(backupDir, backupFilename)
-
-    // Create backup config with metadata
-    const backupConfig: FirewallConfig & {
-      backup: { createdAt: string; source: string; projectId: string; teamId: string; originalVersion: number }
-    } = {
-      ...remoteConfig,
-      backup: {
-        createdAt: new Date().toISOString(),
-        source: 'remote',
-        projectId,
-        teamId,
-        originalVersion: remoteConfig.version,
+    // Create backup — needs credentials
+    await withCredentials(
+      {
+        config: argv.config,
+        projectId: argv.projectId,
+        teamId: argv.teamId,
+        token: argv.token,
+        debug: argv.debug,
+        errorContext: 'creating backup',
       },
-    }
+      async ({ client, projectId, teamId }) => {
+        logger.start('Fetching current remote configuration...')
+        const remoteConfig = await client.fetchFirewallConfig()
 
-    await saveConfig(backupConfig, backupPath)
+        if (!existsSync(backupDir)) {
+          mkdirSync(backupDir, { recursive: true })
+        }
 
-    logger.success(chalk.green(`✅ Backup created: ${backupPath}`))
-    logger.log('')
-    logger.log(chalk.bold('Backup Details:'))
-    logger.log(`${chalk.dim('Version:')} ${remoteConfig.version}`)
-    logger.log(`${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips.length} IP blocking`)
-    logger.log(`${chalk.dim('Created:')} ${new Date().toLocaleString()}`)
-    logger.log('')
-    logger.log(chalk.dim('To restore this backup later, run:'))
-    logger.log(chalk.cyan(`vercel-doorman backup --restore ${backupFilename}`))
+        const now = new Date()
+        const datePart = now.toISOString().split('T')[0] ?? 'unknown-date'
+        const timePart = (now.toISOString().split('T')[1] ?? '').split('.')[0]?.replace(/:/g, '-') ?? 'unknown-time'
+        const timestamp = `${datePart}_${timePart}`
+        const backupFilename = `firewall-backup-${timestamp}.json`
+        const backupPath = join(backupDir, backupFilename)
+
+        const backupConfig: FirewallConfig & {
+          backup: {
+            createdAt: string
+            source: string
+            projectId: string
+            teamId: string
+            originalVersion: number
+          }
+        } = {
+          ...remoteConfig,
+          backup: {
+            createdAt: new Date().toISOString(),
+            source: 'remote',
+            projectId,
+            teamId,
+            originalVersion: remoteConfig.version,
+          },
+        }
+
+        await saveConfig(backupConfig, backupPath)
+
+        logger.success(chalk.green(`✅ Backup created: ${backupPath}`))
+        logger.log('')
+        logger.log(chalk.bold('Backup Details:'))
+        logger.log(`${chalk.dim('Version:')} ${remoteConfig.version}`)
+        logger.log(`${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips.length} IP blocking`)
+        logger.log(`${chalk.dim('Created:')} ${new Date().toLocaleString()}`)
+        logger.log('')
+        logger.log(chalk.dim('To restore this backup later, run:'))
+        logger.log(chalk.cyan(`vercel-doorman backup --restore ${backupFilename}`))
+      },
+    )
   } catch (error) {
     handleCommandError(error, 'managing backup')
   }

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,13 +1,8 @@
 import chalk from 'chalk'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { FirewallService } from '../lib/services/FirewallService'
-import { VercelClient } from '../lib/services/VercelClient'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
-import { getConfig } from '../lib/utils/config'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface DiffOptions {
   config?: string
@@ -56,108 +51,106 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<DiffOptions>) => {
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    // Load and validate config
-    const config = await getConfig(argv.config)
-
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      config: argv.config,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || config.projectId,
-      teamId: argv.teamId || config.teamId,
-    })
+      debug: argv.debug,
+      errorContext: 'calculating diff',
+    },
+    async ({ config, service }) => {
+      logger.start('Calculating differences...')
 
-    const client = new VercelClient(projectId, teamId, token)
-    const service = new FirewallService(client)
+      const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
+        await service.getChanges(config)
 
-    logger.start('Calculating differences...')
+      const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
+      const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
+      const hasVersionChange = config.version !== version
 
-    const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } = await service.getChanges(config)
-
-    const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
-    const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
-    const hasVersionChange = config.version !== version
-
-    if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
-      logger.success(chalk.green('No differences found. Local and remote configurations are in sync.'))
-      return
-    }
-
-    if (argv.format === 'json') {
-      // JSON output for programmatic use
-      const diff = {
-        version: {
-          local: config.version,
-          remote: version,
-          changed: hasVersionChange,
-        },
-        customRules: {
-          toAdd: toAdd.map((rule) => ({ ...rule, status: 'add' })),
-          toUpdate: toUpdate.map((rule) => ({ ...rule, status: 'update' })),
-          toDelete: toDelete.map((rule) => ({ ...rule, status: 'delete' })),
-        },
-        ipRules: {
-          toAdd: ipsToAdd.map((rule) => ({ ...rule, status: 'add' })),
-          toUpdate: ipsToUpdate.map((rule) => ({ ...rule, status: 'update' })),
-          toDelete: ipsToDelete.map((rule) => ({ ...rule, status: 'delete' })),
-        },
-        summary: {
-          hasChanges: hasCustomRuleChanges || hasIPRuleChanges || hasVersionChange,
-          customRuleChanges: toAdd.length + toUpdate.length + toDelete.length,
-          ipRuleChanges: ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length,
-        },
+      if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
+        logger.success(chalk.green('No differences found. Local and remote configurations are in sync.'))
+        return
       }
 
-      logger.log(JSON.stringify(diff, null, 2))
-      return
-    }
+      if (argv.format === 'json') {
+        const diff = {
+          version: {
+            local: config.version,
+            remote: version,
+            changed: hasVersionChange,
+          },
+          customRules: {
+            toAdd: toAdd.map((rule) => ({ ...rule, status: 'add' })),
+            toUpdate: toUpdate.map((rule) => ({ ...rule, status: 'update' })),
+            toDelete: toDelete.map((rule) => ({ ...rule, status: 'delete' })),
+          },
+          ipRules: {
+            toAdd: ipsToAdd.map((rule) => ({ ...rule, status: 'add' })),
+            toUpdate: ipsToUpdate.map((rule) => ({ ...rule, status: 'update' })),
+            toDelete: ipsToDelete.map((rule) => ({ ...rule, status: 'delete' })),
+          },
+          summary: {
+            hasChanges: hasCustomRuleChanges || hasIPRuleChanges || hasVersionChange,
+            customRuleChanges: toAdd.length + toUpdate.length + toDelete.length,
+            ipRuleChanges: ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length,
+          },
+        }
 
-    // Table format (default)
-    logger.log(chalk.bold('\n🔍 Configuration Differences\n'))
+        logger.log(JSON.stringify(diff, null, 2))
+        return
+      }
 
-    if (hasVersionChange) {
-      logger.log(chalk.bold('Version Changes:'))
-      logger.log(`  Local:  ${chalk.red(config.version || 'unknown')}`)
-      logger.log(`  Remote: ${chalk.green(version)}`)
-      logger.log('')
-    }
+      logger.log(chalk.bold('\n🔍 Configuration Differences\n'))
 
-    if (hasCustomRuleChanges) {
-      logger.log(chalk.bold('Custom Rule Changes:\n'))
-      displayRulesTable(
-        [
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ...toAdd.map((rule: any) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id as string })),
-          ...toUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id as string })),
-          ...toDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id as string })),
-        ],
-        { showStatus: true },
-      )
-      logger.log('')
-    }
+      if (hasVersionChange) {
+        logger.log(chalk.bold('Version Changes:'))
+        logger.log(`  Local:  ${chalk.red(config.version || 'unknown')}`)
+        logger.log(`  Remote: ${chalk.green(version)}`)
+        logger.log('')
+      }
 
-    if (hasIPRuleChanges) {
-      logger.log(chalk.bold('IP Blocking Rule Changes:\n'))
-      displayIPBlockingTable(
-        [
-          ...ipsToAdd.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id || undefined })),
-          ...ipsToUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id || undefined })),
-          ...ipsToDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id || undefined })),
-        ],
-        { showStatus: true },
-      )
-      logger.log('')
-    }
+      if (hasCustomRuleChanges) {
+        logger.log(chalk.bold('Custom Rule Changes:\n'))
+        displayRulesTable(
+          [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...toAdd.map((rule: any) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id as string })),
+            ...toUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id as string })),
+            ...toDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id as string })),
+          ],
+          { showStatus: true },
+        )
+        logger.log('')
+      }
 
-    // Summary
-    const totalChanges =
-      toAdd.length + toUpdate.length + toDelete.length + ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length
-    logger.log(chalk.bold(`Summary: ${totalChanges} total changes detected`))
-    logger.log(chalk.dim('Run `sync` to apply these changes to the remote configuration.'))
-  } catch (error) {
-    handleCommandError(error, 'calculating diff')
-  }
+      if (hasIPRuleChanges) {
+        logger.log(chalk.bold('IP Blocking Rule Changes:\n'))
+        displayIPBlockingTable(
+          [
+            ...ipsToAdd.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id || undefined })),
+            ...ipsToUpdate.map((rule) => ({
+              ...rule,
+              changeStatus: RULE_STATUS_MAP.modified,
+              id: rule.id || undefined,
+            })),
+            ...ipsToDelete.map((rule) => ({
+              ...rule,
+              changeStatus: RULE_STATUS_MAP.deleted,
+              id: rule.id || undefined,
+            })),
+          ],
+          { showStatus: true },
+        )
+        logger.log('')
+      }
+
+      const totalChanges =
+        toAdd.length + toUpdate.length + toDelete.length + ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length
+      logger.log(chalk.bold(`Summary: ${totalChanges} total changes detected`))
+      logger.log(chalk.dim('Run `sync` to apply these changes to the remote configuration.'))
+    },
+  )
 }

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,16 +1,14 @@
 import chalk from 'chalk'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { z } from 'zod'
 import { logger } from '../lib/logger'
 import { configVersionSchema } from '../lib/schemas/firewallSchemas'
-import { VercelClient } from '../lib/services/VercelClient'
 import { FirewallConfig, IPBlockingRule } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { displayIPBlockingTable, displayRulesTable } from '../lib/ui/table'
-import { getConfig, saveConfig } from '../lib/utils/config'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { saveConfig } from '../lib/utils/config'
+import { withCredentials } from '../lib/utils/withCredentials'
+
 interface DownloadOptions {
   config?: string
   projectId?: string
@@ -63,114 +61,80 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<DownloadOptions>) => {
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    logger.debug('Starting download command')
-    logger.debug(`Command arguments: ${JSON.stringify(argv)}`)
-
-    // Try to load existing config, but don't fail if it doesn't exist or is invalid
-    let existingConfig: Partial<FirewallConfig> = {}
-    try {
-      existingConfig = await getConfig(argv.config, { validate: false, throwOnError: false })
-      logger.debug(`Existing config: ${JSON.stringify(existingConfig)}`)
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('No config file found')) {
-        const createNewConfig = await prompt('No config file found. Would you like to create a new one?', {
-          type: 'confirm',
-        })
-        if (!createNewConfig) {
-          logger.info(chalk.yellow('Download cancelled. No config file created.'))
-          return
-        }
-        logger.info(`Will create new config file`)
-      } else {
-        logger.error(error)
-        logger.info('Proceeding with empty configuration')
-      }
-    }
-
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      config: argv.config,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || existingConfig.projectId,
-      teamId: argv.teamId || existingConfig.teamId,
-    })
-
-    logger.debug(`Project ID: ${projectId}, Team ID: ${teamId}`)
-
-    // Validate version if provided
-    if (argv.configVersion !== undefined) {
-      try {
-        configVersionSchema.parse(argv.configVersion)
-      } catch (error) {
-        if (error instanceof z.ZodError) {
-          logger.error('Invalid configuration version number. Version must be a positive integer.')
-          process.exit(1)
+      debug: argv.debug,
+      optionalConfig: true,
+      skipValidation: true,
+      errorContext: 'downloading firewall rules',
+    },
+    async ({ config: existingConfig, client, projectId, teamId }) => {
+      // Validate version if provided
+      if (argv.configVersion !== undefined) {
+        try {
+          configVersionSchema.parse(argv.configVersion)
+        } catch (error) {
+          if (error instanceof z.ZodError) {
+            logger.error('Invalid configuration version number. Version must be a positive integer.')
+            process.exit(1)
+          }
+          throw error
         }
-        throw error
       }
-    }
 
-    const client = new VercelClient(projectId, teamId, token)
+      logger.start(
+        `Fetching remote firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`,
+      )
+      const remoteConfig = await client.fetchFirewallConfig(argv.configVersion)
 
-    logger.start(
-      `Fetching remote firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`,
-    )
-    const config = await client.fetchFirewallConfig(argv.configVersion)
-    logger.debug(`Fetched Vercel config: ${JSON.stringify(config)}`)
+      const configRules = remoteConfig.rules
+      const ipBlockingRules = remoteConfig.ips as IPBlockingRule[]
 
-    const configRules = config.rules
-    logger.debug(`Custom rules: ${JSON.stringify(configRules)}`)
+      if (configRules.length > 0) {
+        logger.log(chalk.bold('\nRemote Custom Rules to Download:\n'))
+        displayRulesTable(configRules, { showStatus: false })
+      } else {
+        logger.info('No custom rules to download...')
+      }
 
-    const ipBlockingRules = config.ips as IPBlockingRule[]
-    logger.debug(`IP blocking rules: ${JSON.stringify(ipBlockingRules)}`)
+      if (ipBlockingRules.length > 0) {
+        logger.log(chalk.bold('\nRemote IP Blocking Rules to Download:\n'))
+        displayIPBlockingTable(ipBlockingRules, { showStatus: false })
+      } else {
+        logger.info('No IP blocking rules to download...')
+      }
 
-    if (configRules.length > 0) {
-      logger.log(chalk.bold('\nRemote Custom Rules to Download:\n'))
-      displayRulesTable(configRules, { showStatus: false })
-    } else {
-      logger.info('No custom rules to download...')
-    }
+      if (argv.dryRun) {
+        logger.info(chalk.cyan('Dry run completed. No changes made.'))
+        return
+      }
 
-    if (ipBlockingRules.length > 0) {
-      logger.log(chalk.bold('\nRemote IP Blocking Rules to Download:\n'))
-      displayIPBlockingTable(ipBlockingRules, { showStatus: false })
-    } else {
-      logger.info('No IP blocking rules to download...')
-    }
+      const confirmed = await prompt(
+        `Do you want to download${argv.configVersion ? ` version ${argv.configVersion}` : ' the latest version'} of these rules? This will overwrite your local configuration.`,
+        { type: 'confirm' },
+      )
+      if (!confirmed) {
+        logger.info(chalk.yellow('Download cancelled.'))
+        return
+      }
 
-    // If dry run, stop here
-    if (argv.dryRun) {
-      logger.info(chalk.cyan('Dry run completed. No changes made.'))
-      return
-    }
+      const newConfig: FirewallConfig = {
+        ...existingConfig,
+        projectId,
+        teamId,
+        version: remoteConfig.version,
+        updatedAt: remoteConfig.updatedAt,
+        rules: configRules,
+        ips: ipBlockingRules,
+      }
 
-    const confirmed = await prompt(
-      `Do you want to download${argv.configVersion ? ` version ${argv.configVersion}` : ' the latest version'} of these rules? This will overwrite your local configuration.`,
-      { type: 'confirm' },
-    )
-    if (!confirmed) {
-      logger.info(chalk.yellow('Download cancelled.'))
-      return
-    }
-
-    const newConfig: FirewallConfig = {
-      ...existingConfig,
-      projectId,
-      teamId,
-      version: config.version,
-      updatedAt: config.updatedAt,
-      rules: configRules,
-      ips: ipBlockingRules,
-    }
-    logger.debug(`New config to be written: ${JSON.stringify(newConfig)}`)
-    logger.start(`Saving configuration with version: ${newConfig.version}`)
-
-    await saveConfig(newConfig, argv.config)
-    logger.success(chalk.green('Successfully downloaded and updated configuration'))
-  } catch (error) {
-    handleCommandError(error, 'downloading firewall rules')
-  }
+      logger.start(`Saving configuration with version: ${newConfig.version}`)
+      await saveConfig(newConfig, argv.config)
+      logger.success(chalk.green('Successfully downloaded and updated configuration'))
+    },
+  )
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,13 +1,11 @@
 import chalk from 'chalk'
 import { writeFileSync } from 'fs'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { VercelClient } from '../lib/services/VercelClient'
 import { CustomRule, FirewallConfig, IPBlockingRule } from '../lib/types'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { getConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface ExportOptions {
   config?: string
@@ -77,7 +75,6 @@ const generateMarkdownReport = (config: FirewallConfig): string => {
   markdown += `**Last Updated:** ${updatedAt ? new Date(updatedAt).toLocaleString() : 'Unknown'}\n`
   markdown += `**Generated:** ${new Date().toLocaleString()}\n\n`
 
-  // Custom Rules
   markdown += `## Custom Rules (${rules.length})\n\n`
   if (rules.length > 0) {
     rules.forEach((rule: CustomRule, index: number) => {
@@ -104,7 +101,6 @@ const generateMarkdownReport = (config: FirewallConfig): string => {
     markdown += `No custom rules configured.\n\n`
   }
 
-  // IP Blocking Rules
   markdown += `## IP Blocking Rules (${ips.length})\n\n`
   if (ips.length > 0) {
     markdown += `| IP Address | Hostname | Action |\n`
@@ -124,8 +120,6 @@ const generateTerraformConfig = (config: FirewallConfig): string => {
 
   let terraform = `# Vercel Firewall Configuration\n`
   terraform += `# Generated on ${new Date().toISOString()}\n\n`
-
-  // Note: This is a simplified example - actual Terraform provider would need to be implemented
   terraform += `# Note: This is a conceptual Terraform configuration\n`
   terraform += `# A Vercel Terraform provider would need to be implemented for actual use\n\n`
 
@@ -159,26 +153,25 @@ const generateTerraformConfig = (config: FirewallConfig): string => {
 
 export const handler = async (argv: Arguments<ExportOptions>) => {
   try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
     let config: FirewallConfig
 
     if (argv.source === 'remote') {
-      // Export from remote Vercel
-      const localConfig = await getConfig(argv.config)
-      const { token, projectId, teamId } = await promptForCredentials({
-        token: argv.token,
-        projectId: argv.projectId || localConfig.projectId,
-        teamId: argv.teamId || localConfig.teamId,
-      })
-
-      const client = new VercelClient(projectId, teamId, token)
-      logger.start('Fetching remote configuration...')
-      config = await client.fetchFirewallConfig()
+      // Remote export needs credentials
+      await withCredentials(
+        {
+          config: argv.config,
+          projectId: argv.projectId,
+          teamId: argv.teamId,
+          token: argv.token,
+          debug: argv.debug,
+          errorContext: 'exporting configuration',
+        },
+        async ({ client }) => {
+          logger.start('Fetching remote configuration...')
+          config = await client.fetchFirewallConfig()
+        },
+      )
     } else {
-      // Export from local config
       config = await getConfig(argv.config)
     }
 
@@ -189,17 +182,16 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
 
     switch (argv.format) {
       case 'json':
-        output = JSON.stringify(config, null, 2)
+        output = JSON.stringify(config!, null, 2)
         defaultExtension = 'json'
         break
 
       case 'yaml':
-        // Simple YAML-like output (would need yaml library for proper YAML)
         output = `# Vercel Firewall Configuration\n`
-        output += `version: ${config.version}\n`
-        output += `updatedAt: "${config.updatedAt}"\n`
+        output += `version: ${config!.version}\n`
+        output += `updatedAt: "${config!.updatedAt}"\n`
         output += `rules:\n`
-        config.rules.forEach((rule: CustomRule) => {
+        config!.rules.forEach((rule: CustomRule) => {
           output += `  - name: "${rule.name}"\n`
           output += `    id: "${rule.id}"\n`
           output += `    active: ${rule.active}\n`
@@ -209,12 +201,12 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
         break
 
       case 'terraform':
-        output = generateTerraformConfig(config)
+        output = generateTerraformConfig(config!)
         defaultExtension = 'tf'
         break
 
       case 'markdown':
-        output = generateMarkdownReport(config)
+        output = generateMarkdownReport(config!)
         defaultExtension = 'md'
         break
 
@@ -222,22 +214,19 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
         throw new Error(`Unsupported format: ${argv.format}`)
     }
 
-    // Determine output path
     const outputPath = argv.output || `firewall-export.${defaultExtension}`
 
-    // Write to file or stdout
     if (argv.output === '-' || !argv.output) {
       logger.log(output)
     } else {
       writeFileSync(outputPath, output, 'utf8')
       logger.success(chalk.green(`✅ Exported to ${outputPath}`))
 
-      // Show summary
       logger.log('')
       logger.log(chalk.bold('Export Summary:'))
       logger.log(`${chalk.dim('Format:')} ${argv.format}`)
       logger.log(`${chalk.dim('Source:')} ${argv.source}`)
-      logger.log(`${chalk.dim('Rules:')} ${config.rules.length} custom, ${(config.ips || []).length} IP blocking`)
+      logger.log(`${chalk.dim('Rules:')} ${config!.rules.length} custom, ${(config!.ips || []).length} IP blocking`)
       logger.log(`${chalk.dim('Size:')} ${(output.length / 1024).toFixed(1)} KB`)
     }
   } catch (error) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,16 +1,11 @@
 import chalk from 'chalk'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { z } from 'zod'
 import { logger } from '../lib/logger'
 import { configVersionSchema } from '../lib/schemas/firewallSchemas'
-import { VercelClient } from '../lib/services/VercelClient'
-
-import { FirewallConfig, IPBlockingRule } from '../lib/types'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
+import { IPBlockingRule } from '../lib/types'
 import { displayIPBlockingTable, displayRulesTable } from '../lib/ui/table'
-import { getConfig } from '../lib/utils/config'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface ListOptions {
   projectId: string
@@ -58,94 +53,83 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<ListOptions>) => {
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    // Try to load config for project/team IDs
-    let config = {} as Partial<FirewallConfig>
-    try {
-      config = await getConfig(undefined, { validate: false, throwOnError: false })
-    } catch (error) {
-      logger.debug('No config file found or invalid config, proceeding with CLI arguments only')
-    }
-
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || config?.projectId || undefined,
-      teamId: argv.teamId || config?.teamId || undefined,
-    })
-
-    // Validate version if provided
-    if (argv.configVersion !== undefined) {
-      try {
-        configVersionSchema.parse(argv.configVersion)
-      } catch (error) {
-        if (error instanceof z.ZodError) {
-          logger.error('Invalid configuration version number. Version must be a positive integer.')
-          process.exit(1)
+      debug: argv.debug,
+      optionalConfig: true,
+      skipValidation: true,
+      errorContext: 'listing firewall rules',
+    },
+    async ({ client, token, projectId, teamId }) => {
+      // Validate version if provided
+      if (argv.configVersion !== undefined) {
+        try {
+          configVersionSchema.parse(argv.configVersion)
+        } catch (error) {
+          if (error instanceof z.ZodError) {
+            logger.error('Invalid configuration version number. Version must be a positive integer.')
+            process.exit(1)
+          }
+          throw error
         }
-        throw error
       }
-    }
 
-    const client = new VercelClient(projectId, teamId, token)
+      logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
+      logger.verbose(`Token: ${token}\t projectId: ${projectId}\t teamId: ${teamId}`)
 
-    logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
-    logger.verbose(`Token: ${token}\t projectId: ${projectId}\t teamId: ${teamId}`)
+      const liveConfig = await client.fetchFirewallConfig(argv.configVersion)
 
-    const liveConfig = await client.fetchFirewallConfig(argv.configVersion)
+      const configRules = liveConfig.rules
+      const ipBlockingRules = liveConfig.ips as IPBlockingRule[]
 
-    const configRules = liveConfig.rules
-    const ipBlockingRules = liveConfig.ips as IPBlockingRule[]
+      const lastUpdated = new Date(liveConfig.updatedAt)
+      const formattedDate = new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'medium',
+      }).format(lastUpdated)
 
-    const lastUpdated = new Date(liveConfig.updatedAt)
-    const formattedDate = new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'medium',
-      timeStyle: 'medium',
-    }).format(lastUpdated)
-
-    logger.info(
-      `Found ${chalk.cyan(configRules.length)} custom rules and ${chalk.cyan(ipBlockingRules.length)} IP blocking rules\n` +
-        chalk.dim(`Version: ${chalk.yellow(liveConfig.version)} • Last Updated: ${chalk.yellow(formattedDate)}`),
-    )
-
-    if (argv.format === 'json') {
       logger.info(
-        JSON.stringify(
-          {
-            version: liveConfig.version,
-            updatedAt: liveConfig.updatedAt,
-            lastUpdated: formattedDate,
-            rules: configRules,
-            ips: ipBlockingRules,
-          },
-          null,
-          2,
-        ),
+        `Found ${chalk.cyan(configRules.length)} custom rules and ${chalk.cyan(ipBlockingRules.length)} IP blocking rules\n` +
+          chalk.dim(`Version: ${chalk.yellow(liveConfig.version)} • Last Updated: ${chalk.yellow(formattedDate)}`),
       )
-    } else {
-      if (configRules.length === 0 && ipBlockingRules.length === 0) {
-        logger.info(chalk.yellow('No rules found'))
-        return
-      }
 
-      if (configRules.length > 0) {
-        logger.log(chalk.bold.underline('\nCustom Rules:'), '\n')
-        displayRulesTable(configRules, { showStatus: false })
+      if (argv.format === 'json') {
+        logger.info(
+          JSON.stringify(
+            {
+              version: liveConfig.version,
+              updatedAt: liveConfig.updatedAt,
+              lastUpdated: formattedDate,
+              rules: configRules,
+              ips: ipBlockingRules,
+            },
+            null,
+            2,
+          ),
+        )
       } else {
-        logger.info(chalk.cyan('No custom rules found'))
-      }
+        if (configRules.length === 0 && ipBlockingRules.length === 0) {
+          logger.info(chalk.yellow('No rules found'))
+          return
+        }
 
-      if (ipBlockingRules.length > 0) {
-        logger.log(chalk.bold.underline('\nIP Blocking Rules:'), '\n')
-        displayIPBlockingTable(ipBlockingRules, { showStatus: false })
-      } else {
-        logger.info(chalk.cyan('No IP blocking rules found'))
+        if (configRules.length > 0) {
+          logger.log(chalk.bold.underline('\nCustom Rules:'), '\n')
+          displayRulesTable(configRules, { showStatus: false })
+        } else {
+          logger.info(chalk.cyan('No custom rules found'))
+        }
+
+        if (ipBlockingRules.length > 0) {
+          logger.log(chalk.bold.underline('\nIP Blocking Rules:'), '\n')
+          displayIPBlockingTable(ipBlockingRules, { showStatus: false })
+        } else {
+          logger.info(chalk.cyan('No IP blocking rules found'))
+        }
       }
-    }
-  } catch (error) {
-    handleCommandError(error, 'listing firewall rules')
-  }
+    },
+  )
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,13 +1,8 @@
 import chalk from 'chalk'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { FirewallService } from '../lib/services/FirewallService'
-import { VercelClient } from '../lib/services/VercelClient'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
-import { getConfig } from '../lib/utils/config'
 import { ConfigHealthChecker } from '../lib/utils/configHealth'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface StatusOptions {
   config?: string
@@ -48,82 +43,68 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<StatusOptions>) => {
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    // Load and validate config
-    const config = await getConfig(argv.config)
-
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      config: argv.config,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || config.projectId,
-      teamId: argv.teamId || config.teamId,
-    })
+      debug: argv.debug,
+      errorContext: 'checking status',
+    },
+    async ({ config, service }) => {
+      logger.start('Checking sync status...')
 
-    const client = new VercelClient(projectId, teamId, token)
-    const service = new FirewallService(client)
+      const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
+        await service.getChanges(config)
 
-    logger.start('Checking sync status...')
+      const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
+      const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
+      const hasVersionChange = config.version !== version
 
-    const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } = await service.getChanges(config)
+      logger.log(chalk.bold('\n📊 Sync Status Summary\n'))
 
-    const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
-    const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
-    const hasVersionChange = config.version !== version
-
-    // Display status summary
-    logger.log(chalk.bold('\n📊 Sync Status Summary\n'))
-
-    // Version info
-    logger.log(`${chalk.dim('Local Version:')} ${chalk.yellow(config.version || 'unknown')}`)
-    logger.log(`${chalk.dim('Remote Version:')} ${chalk.yellow(version)}`)
-
-    if (hasVersionChange) {
-      logger.log(`${chalk.dim('Version Status:')} ${chalk.red('Out of sync')}`)
-    } else {
-      logger.log(`${chalk.dim('Version Status:')} ${chalk.green('In sync')}`)
-    }
-
-    logger.log('')
-
-    // Custom rules status
-    logger.log(`${chalk.dim('Custom Rules:')}`)
-    logger.log(`  ${chalk.green('+')} ${toAdd.length} to add`)
-    logger.log(`  ${chalk.cyan('~')} ${toUpdate.length} to update`)
-    logger.log(`  ${chalk.red('-')} ${toDelete.length} to delete`)
-
-    // IP rules status
-    logger.log(`${chalk.dim('IP Blocking Rules:')}`)
-    logger.log(`  ${chalk.green('+')} ${ipsToAdd.length} to add`)
-    logger.log(`  ${chalk.cyan('~')} ${ipsToUpdate.length} to update`)
-    logger.log(`  ${chalk.red('-')} ${ipsToDelete.length} to delete`)
-
-    logger.log('')
-
-    // Overall status
-    if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
-      logger.success(chalk.green('✅ Everything is in sync!'))
-    } else {
-      logger.warn(chalk.yellow('⚠️  Changes detected. Run `sync` to apply changes.'))
+      logger.log(`${chalk.dim('Local Version:')} ${chalk.yellow(config.version || 'unknown')}`)
+      logger.log(`${chalk.dim('Remote Version:')} ${chalk.yellow(version)}`)
 
       if (hasVersionChange) {
-        logger.info(chalk.dim('💡 Version mismatch detected - this will be updated during sync'))
+        logger.log(`${chalk.dim('Version Status:')} ${chalk.red('Out of sync')}`)
+      } else {
+        logger.log(`${chalk.dim('Version Status:')} ${chalk.green('In sync')}`)
       }
-    }
 
-    // Show last updated info if available
-    if (config.updatedAt) {
-      logger.log(`\n${chalk.dim('Last Updated:')} ${new Date(config.updatedAt).toLocaleString()}`)
-    }
+      logger.log('')
 
-    // Add health check
-    logger.log('\n' + chalk.bold('🏥 Configuration Health Check'))
-    const healthResult = ConfigHealthChecker.check(config)
-    const healthReport = ConfigHealthChecker.formatHealthReport(healthResult)
-    logger.log(healthReport)
-  } catch (error) {
-    handleCommandError(error, 'checking status')
-  }
+      logger.log(`${chalk.dim('Custom Rules:')}`)
+      logger.log(`  ${chalk.green('+')} ${toAdd.length} to add`)
+      logger.log(`  ${chalk.cyan('~')} ${toUpdate.length} to update`)
+      logger.log(`  ${chalk.red('-')} ${toDelete.length} to delete`)
+
+      logger.log(`${chalk.dim('IP Blocking Rules:')}`)
+      logger.log(`  ${chalk.green('+')} ${ipsToAdd.length} to add`)
+      logger.log(`  ${chalk.cyan('~')} ${ipsToUpdate.length} to update`)
+      logger.log(`  ${chalk.red('-')} ${ipsToDelete.length} to delete`)
+
+      logger.log('')
+
+      if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
+        logger.success(chalk.green('✅ Everything is in sync!'))
+      } else {
+        logger.warn(chalk.yellow('⚠️  Changes detected. Run `sync` to apply changes.'))
+
+        if (hasVersionChange) {
+          logger.info(chalk.dim('💡 Version mismatch detected - this will be updated during sync'))
+        }
+      }
+
+      if (config.updatedAt) {
+        logger.log(`\n${chalk.dim('Last Updated:')} ${new Date(config.updatedAt).toLocaleString()}`)
+      }
+
+      logger.log('\n' + chalk.bold('🏥 Configuration Health Check'))
+      const healthResult = ConfigHealthChecker.check(config)
+      const healthReport = ConfigHealthChecker.formatHealthReport(healthResult)
+      logger.log(healthReport)
+    },
+  )
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,15 +1,11 @@
 import chalk from 'chalk'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { FirewallService } from '../lib/services/FirewallService'
-import { VercelClient } from '../lib/services/VercelClient'
 import { CustomRule, FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
-import { getConfig, saveConfig } from '../lib/utils/config'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { saveConfig } from '../lib/utils/config'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface SyncOptions {
   config?: string
@@ -50,145 +46,144 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<SyncOptions>) => {
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    // Load and validate config
-    let config = await getConfig(argv.config)
-
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      config: argv.config,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || config.projectId,
-      teamId: argv.teamId || config.teamId,
-    })
-
-    const client = new VercelClient(projectId, teamId, token)
-    const service = new FirewallService(client)
-
-    logger.start(chalk.magenta('Calculating firewall configuration changes...'))
-    const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } = await service.getChanges(config)
-
-    const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
-    const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
-    const hasVersionChange = config.version !== version
-
-    if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
-      logger.success(chalk.green('No changes detected. Firewall rules are in sync.'))
-      return
-    }
-
-    if (hasCustomRuleChanges) {
-      logger.log(chalk.bold('\nProposed Custom Rule Changes:\n'))
-      displayRulesTable(
-        [
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ...toAdd.map((rule: any) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id as string })),
-          ...toUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id as string })),
-          ...toDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id as string })),
-        ],
-        { showStatus: true },
-      )
-    }
-
-    if (hasIPRuleChanges) {
-      logger.log(chalk.bold('\nProposed IP Blocking Rule Changes:\n'))
-      displayIPBlockingTable(
-        [
-          ...ipsToAdd.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id || undefined })),
-          ...ipsToUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id || undefined })),
-          ...ipsToDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id || undefined })),
-        ],
-        { showStatus: true },
-      )
-    }
-
-    if (hasVersionChange) {
-      logger.log(chalk.bold('\nProposed Metadata Changes:\n'))
-      logger.log(`  - Version: ${chalk.red(config.version)} ${chalk.dim('->')} ${chalk.green(version)}`)
-    }
-
-    const confirmed = await prompt('Do you want to apply these changes?', { type: 'confirm' })
-    if (!confirmed) {
-      logger.info(chalk.yellow('Sync cancelled.'))
-      return
-    }
-
-    logger.start('Starting firewall rules sync...')
-
-    // Create backup of original config
-    const backupConfig = JSON.parse(JSON.stringify(config)) as FirewallConfig
-
-    // Perform sync operation
-    const syncResult = await service.syncRules(config, {
       debug: argv.debug,
-    })
-    const { rulesToUpdateLocally } = syncResult
-    logger.success(chalk.green('Firewall rules sync completed successfully'))
+      errorContext: 'syncing firewall rules',
+    },
+    async (ctx) => {
+      let config = ctx.config
+      const service = ctx.service
 
-    // Validate and update config metadata
-    try {
-      const updatedConfig = await service.validateAndUpdateConfig(config, syncResult, { dryRun: false })
-      config = updatedConfig // Update our working copy
-    } catch (error) {
-      logger.error('Failed to validate sync result or update config metadata')
-      logger.error(error instanceof Error ? error.message : String(error))
+      logger.start(chalk.magenta('Calculating firewall configuration changes...'))
+      const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
+        await service.getChanges(config)
 
-      // Write backup to config file
-      await saveConfig(backupConfig, argv.config)
+      const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
+      const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
+      const hasVersionChange = config.version !== version
 
-      logger.info(chalk.yellow('Restored original config due to validation failure'))
-      throw new Error('Sync validation failed - original config restored')
-    }
-
-    // Filter rulesToUpdateLocally to only include entries whose oldId still
-    // exists in the current config. validateAndUpdateConfig may have already
-    // updated some rule IDs to match remote-assigned IDs.
-    const pendingIdUpdates = rulesToUpdateLocally.filter((r) =>
-      config.rules.some((rule) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name)),
-    )
-
-    if (pendingIdUpdates.length > 0) {
-      logger.log('')
-      logger.info(chalk.yellow('Some rules have IDs that do not match their expected snake_case name:'))
-      pendingIdUpdates.forEach((rule) => {
-        logger.log(
-          `  - Rule "${rule.name}": ${chalk.red(rule.oldId || 'empty')} ${chalk.dim('->')} ${chalk.green(rule.newId)}`,
-        )
-      })
-
-      const updateConfirmed = await prompt('Do you want to update the local config with the new IDs?', {
-        type: 'confirm',
-      })
-
-      if (updateConfirmed) {
-        config = {
-          ...config,
-          rules: config.rules.map((rule: CustomRule) => {
-            const ruleToUpdate = pendingIdUpdates.find(
-              (r) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name),
-            )
-            return ruleToUpdate ? { ...rule, id: ruleToUpdate.newId } : rule
-          }),
-          ips: config.ips || [],
-        }
-
-        await saveConfig(config, argv.config)
-        logger.success(chalk.green('Updated local config with new rule IDs'))
-      } else {
-        logger.warn(chalk.yellow('Local config not updated. Remember to update rule IDs manually if needed.'))
+      if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
+        logger.success(chalk.green('No changes detected. Firewall rules are in sync.'))
+        return
       }
-    }
 
-    // Always save config if version or metadata changed
-    if (backupConfig.version !== config.version || backupConfig.updatedAt !== config.updatedAt) {
-      await saveConfig(config, argv.config)
-      logger.success(
-        chalk.green(`Updated version ${chalk.dim(`(v${config.version})`)} and metadata in local config file`),
+      if (hasCustomRuleChanges) {
+        logger.log(chalk.bold('\nProposed Custom Rule Changes:\n'))
+        displayRulesTable(
+          [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...toAdd.map((rule: any) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id as string })),
+            ...toUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id as string })),
+            ...toDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id as string })),
+          ],
+          { showStatus: true },
+        )
+      }
+
+      if (hasIPRuleChanges) {
+        logger.log(chalk.bold('\nProposed IP Blocking Rule Changes:\n'))
+        displayIPBlockingTable(
+          [
+            ...ipsToAdd.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id || undefined })),
+            ...ipsToUpdate.map((rule) => ({
+              ...rule,
+              changeStatus: RULE_STATUS_MAP.modified,
+              id: rule.id || undefined,
+            })),
+            ...ipsToDelete.map((rule) => ({
+              ...rule,
+              changeStatus: RULE_STATUS_MAP.deleted,
+              id: rule.id || undefined,
+            })),
+          ],
+          { showStatus: true },
+        )
+      }
+
+      if (hasVersionChange) {
+        logger.log(chalk.bold('\nProposed Metadata Changes:\n'))
+        logger.log(`  - Version: ${chalk.red(config.version)} ${chalk.dim('->')} ${chalk.green(version)}`)
+      }
+
+      const confirmed = await prompt('Do you want to apply these changes?', { type: 'confirm' })
+      if (!confirmed) {
+        logger.info(chalk.yellow('Sync cancelled.'))
+        return
+      }
+
+      logger.start('Starting firewall rules sync...')
+
+      const backupConfig = JSON.parse(JSON.stringify(config)) as FirewallConfig
+
+      const syncResult = await service.syncRules(config, {
+        debug: argv.debug,
+      })
+      const { rulesToUpdateLocally } = syncResult
+      logger.success(chalk.green('Firewall rules sync completed successfully'))
+
+      try {
+        const updatedConfig = await service.validateAndUpdateConfig(config, syncResult, { dryRun: false })
+        config = updatedConfig
+      } catch (error) {
+        logger.error('Failed to validate sync result or update config metadata')
+        logger.error(error instanceof Error ? error.message : String(error))
+
+        await saveConfig(backupConfig, argv.config)
+
+        logger.info(chalk.yellow('Restored original config due to validation failure'))
+        throw new Error('Sync validation failed - original config restored')
+      }
+
+      // Filter rulesToUpdateLocally to only include entries whose oldId still
+      // exists in the current config. validateAndUpdateConfig may have already
+      // updated some rule IDs to match remote-assigned IDs.
+      const pendingIdUpdates = rulesToUpdateLocally.filter((r) =>
+        config.rules.some((rule) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name)),
       )
-    }
-  } catch (error) {
-    handleCommandError(error, 'syncing firewall rules')
-  }
+
+      if (pendingIdUpdates.length > 0) {
+        logger.log('')
+        logger.info(chalk.yellow('Some rules have IDs that do not match their expected snake_case name:'))
+        pendingIdUpdates.forEach((rule) => {
+          logger.log(
+            `  - Rule "${rule.name}": ${chalk.red(rule.oldId || 'empty')} ${chalk.dim('->')} ${chalk.green(rule.newId)}`,
+          )
+        })
+
+        const updateConfirmed = await prompt('Do you want to update the local config with the new IDs?', {
+          type: 'confirm',
+        })
+
+        if (updateConfirmed) {
+          config = {
+            ...config,
+            rules: config.rules.map((rule: CustomRule) => {
+              const ruleToUpdate = pendingIdUpdates.find(
+                (r) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name),
+              )
+              return ruleToUpdate ? { ...rule, id: ruleToUpdate.newId } : rule
+            }),
+            ips: config.ips || [],
+          }
+
+          await saveConfig(config, argv.config)
+          logger.success(chalk.green('Updated local config with new rule IDs'))
+        } else {
+          logger.warn(chalk.yellow('Local config not updated. Remember to update rule IDs manually if needed.'))
+        }
+      }
+
+      if (backupConfig.version !== config.version || backupConfig.updatedAt !== config.updatedAt) {
+        await saveConfig(config, argv.config)
+        logger.success(
+          chalk.green(`Updated version ${chalk.dim(`(v${config.version})`)} and metadata in local config file`),
+        )
+      }
+    },
+  )
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,13 +1,9 @@
 import chalk from 'chalk'
 import { Stats, watchFile, unwatchFile } from 'fs'
-import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { FirewallService } from '../lib/services/FirewallService'
-import { VercelClient } from '../lib/services/VercelClient'
-import { promptForCredentials } from '../lib/ui/promptForCredentials'
 import { getConfig, saveConfig } from '../lib/utils/config'
-import { handleCommandError } from '../lib/utils/handleCommandError'
+import { withCredentials } from '../lib/utils/withCredentials'
 
 interface WatchOptions {
   config?: string
@@ -55,120 +51,100 @@ export const builder = {
 }
 
 export const handler = async (argv: Arguments<WatchOptions>) => {
-  let isProcessing = false
-  let client: VercelClient
-  let service: FirewallService
-  let lastModified = 0
-
   const configPath = argv.config || 'vercel-firewall.config.json'
 
-  try {
-    if (argv.debug) {
-      logger.level = LogLevels.debug
-    }
-
-    // Initial setup
-    logger.start('Setting up watch mode...')
-
-    const config = await getConfig(configPath)
-    const { token, projectId, teamId } = await promptForCredentials({
+  await withCredentials(
+    {
+      config: configPath,
+      projectId: argv.projectId,
+      teamId: argv.teamId,
       token: argv.token,
-      projectId: argv.projectId || config.projectId,
-      teamId: argv.teamId || config.teamId,
-    })
+      debug: argv.debug,
+      errorContext: 'setting up watch mode',
+    },
+    async ({ service }) => {
+      let isProcessing = false
+      let lastModified = 0
 
-    client = new VercelClient(projectId, teamId, token)
-    service = new FirewallService(client)
+      logger.success(chalk.green(`👀 Watching ${configPath} for changes...`))
+      logger.log(chalk.dim('Press Ctrl+C to stop watching'))
+      logger.log('')
 
-    logger.success(chalk.green(`👀 Watching ${configPath} for changes...`))
-    logger.log(chalk.dim('Press Ctrl+C to stop watching'))
-    logger.log('')
-
-    const handleFileChange = async (curr: Stats, _prev: Stats) => {
-      // Avoid processing if already processing or file hasn't actually changed
-      if (isProcessing || curr.mtime.getTime() === lastModified) {
-        return
-      }
-
-      isProcessing = true
-      lastModified = curr.mtime.getTime()
-
-      try {
-        logger.log(chalk.yellow(`📝 Config file changed at ${new Date().toLocaleTimeString()}`))
-        logger.start('Validating and syncing changes...')
-
-        // Reload config
-        const updatedConfig = await getConfig(configPath)
-
-        // Check for changes
-        const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
-          await service.getChanges(updatedConfig)
-
-        const hasChanges =
-          toAdd.length > 0 ||
-          toUpdate.length > 0 ||
-          toDelete.length > 0 ||
-          ipsToAdd.length > 0 ||
-          ipsToUpdate.length > 0 ||
-          ipsToDelete.length > 0 ||
-          updatedConfig.version !== version
-
-        if (!hasChanges) {
-          logger.info(chalk.blue('No changes detected, skipping sync'))
+      const handleFileChange = async (curr: Stats, _prev: Stats) => {
+        if (isProcessing || curr.mtime.getTime() === lastModified) {
           return
         }
 
-        // Show what will be synced
-        const totalChanges =
-          toAdd.length + toUpdate.length + toDelete.length + ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length
-        logger.log(chalk.cyan(`Syncing ${totalChanges} changes...`))
+        isProcessing = true
+        lastModified = curr.mtime.getTime()
 
-        // Perform sync
-        const syncResult = await service.syncRules(updatedConfig, { debug: argv.debug })
-
-        // Validate and update config with remote-assigned IDs
         try {
-          const validatedConfig = await service.validateAndUpdateConfig(updatedConfig, syncResult, { dryRun: false })
-          await saveConfig(validatedConfig, configPath)
-          logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
-        } catch (validationError) {
-          logger.warn(
-            chalk.yellow(
-              `⚠️ Sync applied but validation failed: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
-            ),
-          )
-          logger.info(chalk.dim('Run `download` to reconcile local config with remote state'))
+          logger.log(chalk.yellow(`📝 Config file changed at ${new Date().toLocaleTimeString()}`))
+          logger.start('Validating and syncing changes...')
+
+          const updatedConfig = await getConfig(configPath)
+
+          const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
+            await service.getChanges(updatedConfig)
+
+          const hasChanges =
+            toAdd.length > 0 ||
+            toUpdate.length > 0 ||
+            toDelete.length > 0 ||
+            ipsToAdd.length > 0 ||
+            ipsToUpdate.length > 0 ||
+            ipsToDelete.length > 0 ||
+            updatedConfig.version !== version
+
+          if (!hasChanges) {
+            logger.info(chalk.blue('No changes detected, skipping sync'))
+            return
+          }
+
+          const totalChanges =
+            toAdd.length + toUpdate.length + toDelete.length + ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length
+          logger.log(chalk.cyan(`Syncing ${totalChanges} changes...`))
+
+          const syncResult = await service.syncRules(updatedConfig, { debug: argv.debug })
+
+          try {
+            const validatedConfig = await service.validateAndUpdateConfig(updatedConfig, syncResult, { dryRun: false })
+            await saveConfig(validatedConfig, configPath)
+            logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
+          } catch (validationError) {
+            logger.warn(
+              chalk.yellow(
+                `⚠️ Sync applied but validation failed: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
+              ),
+            )
+            logger.info(chalk.dim('Run `download` to reconcile local config with remote state'))
+          }
+
+          logger.log(chalk.dim('Watching for more changes...'))
+        } catch (error) {
+          logger.error(chalk.red(`❌ Sync failed: ${error instanceof Error ? error.message : String(error)}`))
+          logger.log(chalk.dim('Continuing to watch for changes...'))
+        } finally {
+          isProcessing = false
         }
-
-        logger.log(chalk.dim('Watching for more changes...'))
-      } catch (error) {
-        logger.error(chalk.red(`❌ Sync failed: ${error instanceof Error ? error.message : String(error)}`))
-        logger.log(chalk.dim('Continuing to watch for changes...'))
-      } finally {
-        isProcessing = false
       }
-    }
 
-    // Start watching
-    watchFile(configPath, { interval: argv.interval }, handleFileChange)
+      watchFile(configPath, { interval: argv.interval }, handleFileChange)
 
-    // Handle graceful shutdown
-    const cleanup = () => {
-      logger.log('\n')
-      logger.info(chalk.yellow('Stopping watch mode...'))
-      unwatchFile(configPath)
-      process.exit(0)
-    }
+      const cleanup = () => {
+        logger.log('\n')
+        logger.info(chalk.yellow('Stopping watch mode...'))
+        unwatchFile(configPath)
+        process.exit(0)
+      }
 
-    process.on('SIGINT', cleanup)
-    process.on('SIGTERM', cleanup)
+      process.on('SIGINT', cleanup)
+      process.on('SIGTERM', cleanup)
 
-    // Keep the process alive
-    const keepAlive = () => {
-      setTimeout(keepAlive, 1000)
-    }
-    keepAlive()
-  } catch (error) {
-    handleCommandError(error, 'setting up watch mode')
-  }
+      const keepAlive = () => {
+        setTimeout(keepAlive, 1000)
+      }
+      keepAlive()
+    },
+  )
 }

--- a/src/lib/utils/withCredentials.ts
+++ b/src/lib/utils/withCredentials.ts
@@ -1,0 +1,100 @@
+import { LogLevels } from 'consola'
+import { logger } from '../logger'
+import { FirewallService } from '../services/FirewallService'
+import { VercelClient } from '../services/VercelClient'
+import { FirewallConfig } from '../types'
+import { promptForCredentials } from '../ui/promptForCredentials'
+import { getConfig } from './config'
+import { handleCommandError } from './handleCommandError'
+
+/**
+ * Context provided to command handlers by `withCredentials`.
+ */
+export interface CommandContext {
+  config: FirewallConfig
+  client: VercelClient
+  service: FirewallService
+  token: string
+  projectId: string
+  teamId: string
+}
+
+/**
+ * Options controlling how `withCredentials` loads config and resolves credentials.
+ */
+export interface WithCredentialsOptions {
+  /** CLI --config path */
+  config?: string
+  /** CLI --projectId override */
+  projectId?: string
+  /** CLI --teamId override */
+  teamId?: string
+  /** CLI --token override */
+  token?: string
+  /** CLI --debug flag */
+  debug?: boolean
+  /**
+   * If true, config file is optional — missing/invalid configs are silently
+   * ignored and an empty partial config is used for credential resolution.
+   * Use for commands like `list` and `download` that can work without a local config.
+   */
+  optionalConfig?: boolean
+  /**
+   * If true, config is loaded without schema validation.
+   * Use for commands like `download` that need to read projectId/teamId
+   * from a potentially incomplete config.
+   */
+  skipValidation?: boolean
+  /** Context string for error messages (e.g., 'syncing firewall rules') */
+  errorContext: string
+}
+
+/**
+ * Shared middleware that handles the common credential resolution pattern:
+ * 1. Enable debug logging if requested
+ * 2. Load config (required or optional)
+ * 3. Resolve credentials from CLI args → config → env vars → interactive prompt
+ * 4. Create VercelClient and FirewallService
+ * 5. Call the handler with the resolved context
+ * 6. Catch and format errors consistently
+ */
+export async function withCredentials(
+  options: WithCredentialsOptions,
+  handler: (ctx: CommandContext) => Promise<void>,
+): Promise<void> {
+  try {
+    if (options.debug) {
+      logger.level = LogLevels.debug
+    }
+
+    let config: FirewallConfig
+
+    if (options.optionalConfig) {
+      try {
+        config = await getConfig(options.config, {
+          validate: !options.skipValidation,
+          throwOnError: false,
+        })
+      } catch {
+        config = {} as FirewallConfig
+      }
+    } else {
+      config = await getConfig(options.config, {
+        validate: !options.skipValidation,
+      })
+    }
+
+    const { token, projectId, teamId } = await promptForCredentials({
+      token: options.token,
+      projectId: options.projectId || config.projectId,
+      teamId: options.teamId || config.teamId,
+    })
+
+    const client = new VercelClient(projectId, teamId, token)
+    const service = new FirewallService(client)
+
+    await handler({ config, client, service, token, projectId, teamId })
+  } catch (error) {
+    handleCommandError(error, options.errorContext)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #58 — Extracts the duplicated credential resolution pattern into a shared `withCredentials()` middleware.

## Problem

The same ~10-line credential setup pattern was repeated across 8 commands:

```typescript
const config = await getConfig(argv.config)
const { token, projectId, teamId } = await promptForCredentials({
  token: argv.token,
  projectId: argv.projectId || config.projectId,
  teamId: argv.teamId || config.teamId,
})
const client = new VercelClient(projectId, teamId, token)
const service = new FirewallService(client)
```

This created maintenance burden and inconsistency risk — some commands used `config.projectId` while others used `argv.projectId || config.projectId`.

## Solution

New `src/lib/utils/withCredentials.ts` provides a `withCredentials()` function that handles:

1. Debug logging setup
2. Config loading (required or optional, with/without validation)
3. Credential resolution (CLI args → config → env vars → interactive prompt)
4. `VercelClient` and `FirewallService` instantiation
5. Error handling via `handleCommandError`

Commands now look like:

```typescript
export const handler = async (argv: Arguments<DiffOptions>) => {
  await withCredentials(
    {
      config: argv.config,
      projectId: argv.projectId,
      teamId: argv.teamId,
      token: argv.token,
      debug: argv.debug,
      errorContext: 'calculating diff',
    },
    async ({ config, service }) => {
      // command-specific logic only
    },
  )
}
```

### Options

| Option | Purpose | Used by |
|--------|---------|---------|
| `optionalConfig` | Config file may not exist | `list`, `download` |
| `skipValidation` | Load config without schema validation | `list`, `download` |
| `errorContext` | Context string for error messages | All commands |

### Commands refactored

`sync`, `download`, `list`, `diff`, `status`, `backup` (create mode), `export` (remote mode), `watch`

Commands with flows that don't need credentials (`backup --list`, `backup --restore`, `export --source local`) keep their own setup.

## Testing

- All 11 test suites pass (141 tests, 3 pre-existing skips)
- Lint clean (0 errors)
- Build succeeds
- Zero TypeScript diagnostics
