### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
+      id-token: write # OIDC: npm Trusted Publishing (auth) + provenance attestation
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,9 +24,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm CLI supports OIDC trusted publishing (needs >=11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install pnpm
         run: npm i pnpm@10 -g
@@ -50,6 +54,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: '0'
+        # No NPM_TOKEN: publishes via npm Trusted Publishing (OIDC), using the
+        # id-token permission above. Requires a trusted publisher configured
+        # on npmjs.com for this repo + workflow file per package. See
+        # https://docs.npmjs.com/trusted-publishers
         run: pnpm release


### PR DESCRIPTION
## Summary

Replaces the long-lived `NPM_TOKEN` secret with npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), GA since July 2025 — this is npm's own recommended direction away from static automation tokens. GitHub Actions exchanges a short-lived, workflow-scoped OIDC token for publish auth on each run instead of a stored secret that can leak, sit unrotated, or (as happened here) silently expire and break every release.

## Changes

- `actions/setup-node@v4` → `@v7`, with `registry-url` set (needed for npm to target the right registry during the OIDC exchange)
- Explicit `npm install -g npm@latest` before publish — OIDC trusted publishing needs npm CLI ≥11.5.1, which may be newer than whatever ships bundled with the resolved Node LTS
- Dropped `NPM_TOKEN` from the Release step's env entirely
- `id-token: write` permission was already present (previously only used for provenance) — now also covers publish auth

## ⚠️ One-time manual setup required (not covered by this PR)

npm's trusted-publisher UI needs a package to already exist before you can configure it for that package — it can't bootstrap a brand-new package's first publish. So:

1. Configure a Trusted Publisher on npmjs.com for `vercel-doorman` now (it already exists) — repo `gfargo/doorman`, workflow filename `release.yml`
2. For `@gfargo/doorman` (net-new, part of the rename in #75): a one-time manual `npm publish` from an authenticated local session to create the package, **then** configure its Trusted Publisher the same way
3. Once OIDC is confirmed working end-to-end, remove the (already-invalid) `NPM_TOKEN` secret from the repo

## Test plan
- [x] YAML syntax validated
- [x] `pnpm build` / `pnpm test` — unaffected (workflow-only change)
- [ ] First real CI run against a trusted-publisher-configured package (can't be verified until the npmjs.com setup above is done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)