### PR TITLE
fix: update repository URL to match the renamed GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/gfargo/vercel-doorman.git"
+    "url": "git+ssh://git@github.com/gfargo/doorman.git"
   },
   "scripts": {
     "prebuild": "pnpm clean",


### PR DESCRIPTION
gfargo/vercel-doorman was renamed to gfargo/doorman. \`package.json\`'s \`repository.url\` still pointed at the old name, which \`@semantic-release/github\` checks exactly against the GitHub API's \`clone_url\` — this broke the Release workflow with \`EMISMATCHGITHUBURL\` on the very next run after the rename (right after confirming OIDC trusted publishing itself works — the \`npm\` token exchange succeeded, this was the only remaining blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)