### PR TITLE
chore: replace lingering "Vercel Doorman" branding with "Doorman"

### DIFF
--- a/schema/firewall-config.schema.json
+++ b/schema/firewall-config.schema.json
@@ -40,7 +40,7 @@
       },
       "required": ["rules"],
       "additionalProperties": false,
-      "description": "The main configuration type for Vercel Doorman"
+      "description": "The main configuration type for Doorman"
     },
     "CustomRule": {
       "type": "object",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -142,7 +142,7 @@ interface InitOptions {
 }
 
 export const command = 'init [template]'
-export const desc = 'Initialize a new Vercel Doorman configuration'
+export const desc = 'Initialize a new Doorman configuration'
 
 export const builder = {
   template: {
@@ -183,7 +183,7 @@ export const builder = {
 
 const showWelcomeMessage = () => {
   logger.log('')
-  logger.log(chalk.bold.cyan('🚪 Welcome to Vercel Doorman!'))
+  logger.log(chalk.bold.cyan('🚪 Welcome to Doorman!'))
   logger.log(chalk.dim("Let's set up your firewall configuration.\n"))
 }
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,13 +5,13 @@ import { logger } from '../lib/logger'
 type SetupOptions = Record<string, never>
 
 export const command = 'setup'
-export const desc = 'Show setup instructions and helpful links for Vercel Doorman'
+export const desc = 'Show setup instructions and helpful links for Doorman'
 
 export const builder = {}
 
 export const handler = async (_argv: Arguments<SetupOptions>) => {
   logger.log('')
-  logger.log(chalk.bold.cyan('🚪 Vercel Doorman Setup Guide'))
+  logger.log(chalk.bold.cyan('🚪 Doorman Setup Guide'))
   logger.log(chalk.dim('Everything you need to get started with firewall management\n'))
 
   // Step 1: Prerequisites

--- a/src/constants/schema.ts
+++ b/src/constants/schema.ts
@@ -50,7 +50,7 @@ export const schema = {
       },
       required: ['rules'],
       additionalProperties: false,
-      description: 'The main configuration type for Vercel Doorman',
+      description: 'The main configuration type for Doorman',
     },
     CustomRule: {
       type: 'object',

--- a/src/lib/errors/DoormanError.ts
+++ b/src/lib/errors/DoormanError.ts
@@ -21,7 +21,7 @@ export interface DoormanErrorOptions {
 }
 
 /**
- * Custom error class for Vercel Doorman with structured error codes,
+ * Custom error class for Doorman with structured error codes,
  * suggestions, and formatting capabilities
  */
 export class DoormanError extends Error {

--- a/src/lib/errors/ErrorCodes.ts
+++ b/src/lib/errors/ErrorCodes.ts
@@ -1,5 +1,5 @@
 /**
- * Error codes for Vercel Doorman
+ * Error codes for Doorman
  * Organized by category for better error tracking and debugging
  */
 

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized error handling system for Vercel Doorman
+ * Centralized error handling system for Doorman
  *
  * This module provides:
  * - Structured error codes organized by category

--- a/src/lib/providers/cloudflare/CloudflareClient.ts
+++ b/src/lib/providers/cloudflare/CloudflareClient.ts
@@ -413,7 +413,7 @@ export class CloudflareClient extends BaseFirewallClient {
       name: 'Doorman Custom Firewall Rules',
       kind: 'custom',
       phase: 'http_request_firewall_custom',
-      description: 'Custom firewall rules managed by Vercel Doorman',
+      description: 'Custom firewall rules managed by Doorman',
       rules: [],
     })
   }
@@ -767,7 +767,7 @@ export class CloudflareClient extends BaseFirewallClient {
       logger.info('No existing IP blocklist found, creating new one')
       return this.createList({
         name: 'Doorman IP Blocklist',
-        description: 'IP addresses blocked by Vercel Doorman',
+        description: 'IP addresses blocked by Doorman',
         kind: 'ip',
       })
     } catch (error) {

--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -357,7 +357,7 @@ describe('CloudflareClient', () => {
       const newRuleset: CloudflareRuleset = {
         id: 'new-ruleset',
         name: 'Doorman Custom Firewall Rules',
-        description: 'Custom firewall rules managed by Vercel Doorman',
+        description: 'Custom firewall rules managed by Doorman',
         kind: 'custom',
         phase: 'http_request_firewall_custom',
         version: '1',
@@ -691,7 +691,7 @@ describe('CloudflareClient', () => {
       const newList: CloudflareList = {
         id: 'new-list',
         name: 'Doorman IP Blocklist',
-        description: 'IP addresses blocked by Vercel Doorman',
+        description: 'IP addresses blocked by Doorman',
         kind: 'ip',
         num_items: 0,
         num_referencing_filters: 0,

--- a/src/lib/providers/cloudflare/__tests__/CloudflareEdgeCases.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareEdgeCases.test.ts
@@ -271,7 +271,7 @@ describe('CloudflareClient - Edge Cases', () => {
       const newRuleset: CloudflareRuleset = {
         id: 'new-id',
         name: 'Doorman Custom Firewall Rules',
-        description: 'Custom firewall rules managed by Vercel Doorman',
+        description: 'Custom firewall rules managed by Doorman',
         kind: 'custom',
         phase: 'http_request_firewall_custom',
         version: '1',
@@ -326,7 +326,7 @@ describe('CloudflareClient - Edge Cases', () => {
       const newRuleset: CloudflareRuleset = {
         id: 'new-id',
         name: 'Doorman Custom Firewall Rules',
-        description: 'Custom firewall rules managed by Vercel Doorman',
+        description: 'Custom firewall rules managed by Doorman',
         kind: 'custom',
         phase: 'http_request_firewall_custom',
         version: '1',
@@ -390,7 +390,7 @@ describe('CloudflareClient - Edge Cases', () => {
       const newList = {
         id: 'new-list-id',
         name: 'Doorman IP Blocklist',
-        description: 'IP addresses blocked by Vercel Doorman',
+        description: 'IP addresses blocked by Doorman',
         kind: 'ip' as const,
         num_items: 0,
         num_referencing_filters: 0,
@@ -449,7 +449,7 @@ describe('CloudflareClient - Edge Cases', () => {
       const newList = {
         id: 'new-list-id',
         name: 'Doorman IP Blocklist',
-        description: 'IP addresses blocked by Vercel Doorman',
+        description: 'IP addresses blocked by Doorman',
         kind: 'ip' as const,
         num_items: 0,
         num_referencing_filters: 0,

--- a/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
@@ -29,7 +29,7 @@ const ACCOUNT_ID = 'test-account-id'
 const createMockRuleset = (rules: CloudflareRule[] = [], version = '1'): CloudflareRuleset => ({
   id: 'ruleset-1',
   name: 'Doorman Custom Firewall Rules',
-  description: 'Custom firewall rules managed by Vercel Doorman',
+  description: 'Custom firewall rules managed by Doorman',
   kind: 'custom',
   phase: 'http_request_firewall_custom',
   version,
@@ -40,7 +40,7 @@ const createMockRuleset = (rules: CloudflareRule[] = [], version = '1'): Cloudfl
 const createMockIPBlocklist = (numItems = 0) => ({
   id: 'list-1',
   name: 'Doorman IP Blocklist',
-  description: 'IP addresses blocked by Vercel Doorman',
+  description: 'IP addresses blocked by Doorman',
   kind: 'ip' as const,
   num_items: numItems,
   num_referencing_filters: numItems > 0 ? 1 : 0,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -104,7 +104,7 @@ export interface ProjectConfig {
 }
 
 /**
- * The main configuration type for Vercel Doorman
+ * The main configuration type for Doorman
  * @property $schema - The URI of the JSON Schema to validate against
  * @property version - Configuration version number
  * @property rules - List of firewall rules


### PR DESCRIPTION
## Summary
- Found while regenerating the marketing site's `schema.json`: the CLI's JSON schema description, `init`/`setup` welcome banners, `--help` text, and the descriptions written into Cloudflare rulesets/IP lists during `sync` (i.e. text that lands in a customer's live WAF config) all still said "Vercel Doorman" after the rename to `@gfargo/doorman`.
- Updated the source of truth (`src/lib/types.ts` JSDoc) and regenerated `schema/firewall-config.schema.json` / `src/constants/schema.ts` via `pnpm build:schema` rather than hand-editing the generated files.
- Updated matching Cloudflare test fixtures so assertions stay in sync with the new description strings.

## Test plan
- [x] `pnpm test` — 118 suites, 2324 passed / 6 skipped
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm format` — passes
- [x] `pnpm build:schema` — regenerated cleanly, no leftover "Vercel Doorman" strings anywhere in `src/`, `schema/`
