### PR TITLE
fix: make Cloudflare provider actually work for sync/status/diff/watch/backup/download/export/list

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -164,9 +164,10 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         ci: argv.ci,
         errorContext: 'creating backup',
       },
-      async ({ client, projectId, teamId }) => {
+      async ({ client, provider, projectId, teamId }) => {
         logger.start('Fetching current remote configuration...')
-        const remoteConfig = await client.fetchFirewallConfig()
+        const remoteConfig =
+          provider.name === 'vercel' ? await client.fetchFirewallConfig() : await provider.fetchConfig()
 
         if (!existsSync(backupDir)) {
           mkdirSync(backupDir, { recursive: true })
@@ -179,32 +180,26 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         const backupFilename = `firewall-backup-${timestamp}.json`
         const backupPath = join(backupDir, backupFilename)
 
-        const backupConfig: FirewallConfig & {
-          backup: {
-            createdAt: string
-            source: string
-            projectId: string
-            teamId: string
-            originalVersion: number
-          }
-        } = {
+        const backupConfig = {
           ...remoteConfig,
           backup: {
             createdAt: new Date().toISOString(),
             source: 'remote',
-            projectId,
-            teamId,
+            provider: provider.name,
+            ...(provider.name === 'vercel' ? { projectId, teamId } : {}),
             originalVersion: remoteConfig.version,
           },
         }
 
-        await saveConfig(backupConfig, backupPath)
+        await saveConfig(backupConfig as unknown as FirewallConfig, backupPath)
 
         logger.success(chalk.green(`✅ Backup created: ${backupPath}`))
         logger.log('')
         logger.log(chalk.bold('Backup Details:'))
         logger.log(`${chalk.dim('Version:')} ${remoteConfig.version}`)
-        logger.log(`${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips.length} IP blocking`)
+        logger.log(
+          `${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips?.length ?? 0} IP blocking`,
+        )
         logger.log(`${chalk.dim('Created:')} ${new Date().toLocaleString()}`)
         logger.log('')
         logger.log(chalk.dim('To restore this backup later, run:'))

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
+import type { UnifiedConfig } from '../lib/types/unified'
 import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
 import { withCredentials } from '../lib/utils/withCredentials'
 
@@ -50,7 +52,12 @@ export const handler = async (argv: Arguments<DiffOptions>) => {
       ci: argv.ci,
       errorContext: 'calculating diff',
     },
-    async ({ config, service }) => {
+    async ({ config, service, provider }) => {
+      if (provider.name !== 'vercel') {
+        await diffWithProvider(provider, config as unknown as UnifiedConfig, argv)
+        return
+      }
+
       logger.start('Calculating differences...')
 
       const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
@@ -137,4 +144,74 @@ export const handler = async (argv: Arguments<DiffOptions>) => {
       logger.log(chalk.dim('Run `sync` to apply these changes to the remote configuration.'))
     },
   )
+}
+
+async function diffWithProvider(
+  provider: IFirewallProvider,
+  config: UnifiedConfig,
+  argv: Arguments<DiffOptions>,
+): Promise<void> {
+  logger.start('Calculating differences...')
+  const changes = await provider.getChanges(config)
+
+  if (!changes.hasChanges) {
+    logger.success(chalk.green('No differences found. Local and remote configurations are in sync.'))
+    return
+  }
+
+  const ipsToAdd = changes.ipsToAdd ?? []
+  const ipsToUpdate = changes.ipsToUpdate ?? []
+  const ipsToDelete = changes.ipsToDelete ?? []
+
+  if (argv.format === 'json') {
+    logger.log(
+      JSON.stringify(
+        {
+          rules: {
+            toAdd: changes.rulesToAdd,
+            toUpdate: changes.rulesToUpdate,
+            toDelete: changes.rulesToDelete,
+          },
+          ips: { toAdd: ipsToAdd, toUpdate: ipsToUpdate, toDelete: ipsToDelete },
+          summary: {
+            hasChanges: changes.hasChanges,
+            ruleChanges: changes.rulesToAdd.length + changes.rulesToUpdate.length + changes.rulesToDelete.length,
+            ipChanges: ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    return
+  }
+
+  logger.log(chalk.bold(`\n🔍 ${provider.name} Configuration Differences\n`))
+
+  logger.log(chalk.bold('Rule Changes:'))
+  logger.log(`  ${chalk.green('+')} ${changes.rulesToAdd.length} to add`)
+  changes.rulesToAdd.forEach((r) => logger.log(`    ${chalk.green('+')} ${r.name}`))
+  logger.log(`  ${chalk.cyan('~')} ${changes.rulesToUpdate.length} to update`)
+  changes.rulesToUpdate.forEach((r) => logger.log(`    ${chalk.cyan('~')} ${r.name}`))
+  logger.log(`  ${chalk.red('-')} ${changes.rulesToDelete.length} to delete`)
+  changes.rulesToDelete.forEach((r) => logger.log(`    ${chalk.red('-')} ${r.name}`))
+
+  if (ipsToAdd.length || ipsToUpdate.length || ipsToDelete.length) {
+    logger.log('')
+    logger.log(chalk.bold('IP Rule Changes:'))
+    logger.log(`  ${chalk.green('+')} ${ipsToAdd.length} to add`)
+    logger.log(`  ${chalk.cyan('~')} ${ipsToUpdate.length} to update`)
+    logger.log(`  ${chalk.red('-')} ${ipsToDelete.length} to delete`)
+  }
+
+  const totalChanges =
+    changes.rulesToAdd.length +
+    changes.rulesToUpdate.length +
+    changes.rulesToDelete.length +
+    ipsToAdd.length +
+    ipsToUpdate.length +
+    ipsToDelete.length
+  logger.log('')
+  logger.log(chalk.bold(`Summary: ${totalChanges} total changes detected`))
+  logger.log(chalk.dim('Run `sync` to apply these changes to the remote configuration.'))
 }

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { z } from 'zod'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import { configVersionSchema } from '../lib/schemas/firewallSchemas'
 import { FirewallConfig, IPBlockingRule } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
@@ -87,7 +88,7 @@ export const handler = async (argv: Arguments<DownloadOptions>) => {
       skipValidation: true,
       errorContext: 'downloading firewall rules',
     },
-    async ({ config: existingConfig, client, projectId, teamId }) => {
+    async ({ config: existingConfig, client, provider, projectId, teamId }) => {
       // Validate version if provided
       if (argv.configVersion !== undefined) {
         try {
@@ -99,6 +100,11 @@ export const handler = async (argv: Arguments<DownloadOptions>) => {
           }
           throw error
         }
+      }
+
+      if (provider.name !== 'vercel') {
+        await downloadWithProvider(provider, existingConfig, argv)
+        return
       }
 
       logger.start(
@@ -152,4 +158,56 @@ export const handler = async (argv: Arguments<DownloadOptions>) => {
       logger.success(chalk.green('Successfully downloaded and updated configuration'))
     },
   )
+}
+
+/**
+ * Download via the generic IFirewallProvider interface. Rules/IPs are listed as
+ * plain text rather than through the shared table renderers, which assume the
+ * Vercel-specific rule shape (conditionGroup/action.mitigate).
+ */
+async function downloadWithProvider(
+  provider: IFirewallProvider,
+  existingConfig: FirewallConfig,
+  argv: Arguments<DownloadOptions>,
+): Promise<void> {
+  logger.start(
+    `Fetching remote firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`,
+  )
+  const remoteConfig = await provider.fetchConfig(argv.configVersion)
+  const rules = remoteConfig.rules
+  const ips = remoteConfig.ips ?? []
+
+  if (rules.length > 0) {
+    logger.log(chalk.bold(`\nRemote Custom Rules to Download (${rules.length}):\n`))
+    rules.forEach((rule) => logger.log(`  - ${rule.name}${rule.enabled ? '' : chalk.dim(' (disabled)')}`))
+  } else {
+    logger.info('No custom rules to download...')
+  }
+
+  if (ips.length > 0) {
+    logger.log(chalk.bold(`\nRemote IP Blocking Rules to Download (${ips.length}):\n`))
+    ips.forEach((ip) => logger.log(`  - ${ip.ip} (${ip.action})`))
+  } else {
+    logger.info('No IP blocking rules to download...')
+  }
+
+  if (argv.dryRun) {
+    logger.info(chalk.cyan('Dry run completed. No changes made.'))
+    return
+  }
+
+  const confirmed = await prompt(
+    `Do you want to download${argv.configVersion ? ` version ${argv.configVersion}` : ' the latest version'} of these rules? This will overwrite your local configuration.`,
+    { type: 'confirm' },
+  )
+  if (!confirmed) {
+    logger.info(chalk.yellow('Download cancelled.'))
+    return
+  }
+
+  const newConfig = { ...existingConfig, ...remoteConfig }
+
+  logger.start('Saving configuration...')
+  await saveConfig(newConfig as unknown as FirewallConfig, argv.config)
+  logger.success(chalk.green('Successfully downloaded and updated configuration'))
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { writeFileSync } from 'fs'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { CustomRule, FirewallConfig, IPBlockingRule } from '../lib/types'
+import { CustomRule, FirewallConfig, IPBlockingRule, hasProviderMetadata } from '../lib/types'
 import { getConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
 import { withCredentials } from '../lib/utils/withCredentials'
@@ -181,9 +181,12 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
           ci: argv.ci,
           errorContext: 'exporting configuration',
         },
-        async ({ client }) => {
+        async ({ client, provider }) => {
           logger.start('Fetching remote configuration...')
-          config = await client.fetchFirewallConfig()
+          config =
+            provider.name === 'vercel'
+              ? await client.fetchFirewallConfig()
+              : ((await provider.fetchConfig()) as unknown as FirewallConfig)
         },
       )
     } else {
@@ -191,6 +194,17 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
     }
 
     logger.start(`Exporting configuration in ${argv.format} format...`)
+
+    // The yaml/terraform/markdown generators below assume the legacy Vercel rule
+    // shape (conditionGroup/action.mitigate). A multi-provider (Cloudflare) config
+    // uses a different rule shape and would otherwise silently produce garbage
+    // output, so only json export is supported for those until dedicated generators
+    // exist.
+    if (argv.format !== 'json' && hasProviderMetadata(config!)) {
+      throw new Error(
+        `The '${argv.format}' export format is currently only supported for Vercel configurations. Use --format json instead.`,
+      )
+    }
 
     let output: string
     let defaultExtension: string

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { z } from 'zod'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import { configVersionSchema } from '../lib/schemas/firewallSchemas'
 import { IPBlockingRule } from '../lib/types'
 import { displayIPBlockingTable, displayRulesTable } from '../lib/ui/table'
@@ -78,7 +79,7 @@ export const handler = async (argv: Arguments<ListOptions>) => {
       skipValidation: true,
       errorContext: 'listing firewall rules',
     },
-    async ({ client, token, projectId, teamId }) => {
+    async ({ client, provider, token, projectId, teamId }) => {
       // Validate version if provided
       if (argv.configVersion !== undefined) {
         try {
@@ -90,6 +91,11 @@ export const handler = async (argv: Arguments<ListOptions>) => {
           }
           throw error
         }
+      }
+
+      if (provider.name !== 'vercel') {
+        await listWithProvider(provider, argv)
+        return
       }
 
       logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
@@ -147,4 +153,50 @@ export const handler = async (argv: Arguments<ListOptions>) => {
       }
     },
   )
+}
+
+/**
+ * List via the generic IFirewallProvider interface. Rules/IPs are listed as plain
+ * text for the table format rather than through the shared table renderers, which
+ * assume the Vercel-specific rule shape (conditionGroup/action.mitigate).
+ */
+async function listWithProvider(provider: IFirewallProvider, argv: Arguments<ListOptions>): Promise<void> {
+  logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
+
+  const liveConfig = await provider.fetchConfig(argv.configVersion)
+  const rules = liveConfig.rules
+  const ips = liveConfig.ips ?? []
+  const version = liveConfig.metadata?.version ?? liveConfig.version
+  const updatedAt = liveConfig.metadata?.updatedAt
+
+  logger.info(
+    `Found ${chalk.cyan(rules.length)} custom rules and ${chalk.cyan(ips.length)} IP blocking rules\n` +
+      chalk.dim(
+        `Version: ${chalk.yellow(version ?? 'unknown')}${updatedAt ? ` • Last Updated: ${chalk.yellow(updatedAt)}` : ''}`,
+      ),
+  )
+
+  if (argv.format === 'json') {
+    logger.info(JSON.stringify({ version, updatedAt, rules, ips }, null, 2))
+    return
+  }
+
+  if (rules.length === 0 && ips.length === 0) {
+    logger.info(chalk.yellow('No rules found'))
+    return
+  }
+
+  if (rules.length > 0) {
+    logger.log(chalk.bold.underline('\nCustom Rules:'), '\n')
+    rules.forEach((rule) => logger.log(`  - ${rule.name}${rule.enabled ? '' : chalk.dim(' (disabled)')}`))
+  } else {
+    logger.info(chalk.cyan('No custom rules found'))
+  }
+
+  if (ips.length > 0) {
+    logger.log(chalk.bold.underline('\nIP Blocking Rules:'), '\n')
+    ips.forEach((ip) => logger.log(`  - ${ip.ip} (${ip.action})`))
+  } else {
+    logger.info(chalk.cyan('No IP blocking rules found'))
+  }
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
+import type { UnifiedConfig } from '../lib/types/unified'
 import { ConfigHealthChecker } from '../lib/utils/configHealth'
 import { withCredentials } from '../lib/utils/withCredentials'
 
@@ -67,7 +69,12 @@ export const handler = async (argv: Arguments<StatusOptions>) => {
       ci: argv.ci,
       errorContext: 'checking status',
     },
-    async ({ config, service }) => {
+    async ({ config, service, provider }) => {
+      if (provider.name !== 'vercel') {
+        await statusWithProvider(provider, config as unknown as UnifiedConfig)
+        return
+      }
+
       logger.start('Checking sync status...')
 
       const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
@@ -122,4 +129,42 @@ export const handler = async (argv: Arguments<StatusOptions>) => {
       logger.log(healthReport)
     },
   )
+}
+
+async function statusWithProvider(provider: IFirewallProvider, config: UnifiedConfig): Promise<void> {
+  logger.start('Checking sync status...')
+  const changes = await provider.getChanges(config)
+
+  logger.log(chalk.bold(`\n📊 ${provider.name} Sync Status Summary\n`))
+  logger.log(`${chalk.dim('Rules:')}`)
+  logger.log(`  ${chalk.green('+')} ${changes.rulesToAdd.length} to add`)
+  logger.log(`  ${chalk.cyan('~')} ${changes.rulesToUpdate.length} to update`)
+  logger.log(`  ${chalk.red('-')} ${changes.rulesToDelete.length} to delete`)
+  logger.log(`${chalk.dim('IPs:')}`)
+  logger.log(`  ${chalk.green('+')} ${changes.ipsToAdd?.length ?? 0} to add`)
+  logger.log(`  ${chalk.cyan('~')} ${changes.ipsToUpdate?.length ?? 0} to update`)
+  logger.log(`  ${chalk.red('-')} ${changes.ipsToDelete?.length ?? 0} to delete`)
+  logger.log('')
+
+  if (!changes.hasChanges) {
+    logger.success(chalk.green('✅ Everything is in sync!'))
+  } else {
+    logger.warn(chalk.yellow('⚠️  Changes detected. Run `sync` to apply changes.'))
+  }
+
+  logger.log('\n' + chalk.bold('🏥 Configuration Health Check'))
+  const health = provider.getHealthScore(config)
+  logger.log(`${chalk.dim('Score:')} ${health.score}/100 (${health.grade})`)
+  health.issues.forEach((issue) => {
+    const marker =
+      issue.severity === 'error' ? chalk.red('✗') : issue.severity === 'warning' ? chalk.yellow('⚠') : chalk.dim('ℹ')
+    logger.log(`  ${marker} [${issue.category}] ${issue.message}`)
+    if (issue.suggestion) {
+      logger.log(`    ${chalk.dim(issue.suggestion)}`)
+    }
+  })
+  if (health.recommendations.length > 0) {
+    logger.log(chalk.dim('\nRecommendations:'))
+    health.recommendations.forEach((rec) => logger.log(`  - ${rec}`))
+  }
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,7 +1,9 @@
 import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import { CustomRule, FirewallConfig } from '../lib/types'
+import type { UnifiedConfig } from '../lib/types/unified'
 import { prompt } from '../lib/ui/prompt'
 import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
 import { saveConfig } from '../lib/utils/config'
@@ -71,6 +73,11 @@ export const handler = async (argv: Arguments<SyncOptions>) => {
       errorContext: 'syncing firewall rules',
     },
     async (ctx) => {
+      if (ctx.provider.name !== 'vercel') {
+        await syncWithProvider(ctx.provider, ctx.config, argv)
+        return
+      }
+
       let config = ctx.config
       const service = ctx.service
 
@@ -200,4 +207,58 @@ export const handler = async (argv: Arguments<SyncOptions>) => {
       }
     },
   )
+}
+
+/**
+ * Sync using the generic IFirewallProvider interface (Cloudflare and any future
+ * non-Vercel provider). Simpler than the Vercel flow above: providers implementing
+ * this interface handle their own diff/risk-assessment/confirmation internally, and
+ * the interface has no equivalent of Vercel's remote-assigned-ID reconciliation, so
+ * there's nothing to write back to the local config file after a successful sync.
+ */
+async function syncWithProvider(
+  provider: IFirewallProvider,
+  config: FirewallConfig,
+  argv: Arguments<SyncOptions>,
+): Promise<void> {
+  const unifiedConfig = config as unknown as UnifiedConfig
+
+  logger.start(chalk.magenta(`Calculating ${provider.name} firewall configuration changes...`))
+  const changes = await provider.getChanges(unifiedConfig)
+
+  if (!changes.hasChanges) {
+    logger.success(chalk.green('No changes detected. Firewall rules are in sync.'))
+    return
+  }
+
+  logger.log(chalk.bold('\nProposed Changes:\n'))
+  logger.log(`  ${chalk.green('+')} ${changes.rulesToAdd.length} rules to add`)
+  logger.log(`  ${chalk.cyan('~')} ${changes.rulesToUpdate.length} rules to update`)
+  logger.log(`  ${chalk.red('-')} ${changes.rulesToDelete.length} rules to delete`)
+  const ipsToAdd = changes.ipsToAdd ?? []
+  const ipsToUpdate = changes.ipsToUpdate ?? []
+  const ipsToDelete = changes.ipsToDelete ?? []
+  if (ipsToAdd.length || ipsToUpdate.length || ipsToDelete.length) {
+    logger.log(`  ${chalk.green('+')} ${ipsToAdd.length} IPs to add`)
+    logger.log(`  ${chalk.cyan('~')} ${ipsToUpdate.length} IPs to update`)
+    logger.log(`  ${chalk.red('-')} ${ipsToDelete.length} IPs to delete`)
+  }
+
+  logger.start('Starting firewall rules sync...')
+  // Non-vercel providers prompt for confirmation internally (unless --ci); no need
+  // to prompt again here.
+  const result = await provider.syncRules(unifiedConfig, { force: argv.ci })
+
+  if (!result.success) {
+    throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)
+  }
+
+  logger.success(chalk.green('Firewall rules sync completed successfully'))
+  logger.log(`  Rules: ${result.rulesAdded} added, ${result.rulesUpdated} updated, ${result.rulesDeleted} deleted`)
+  if (result.ipsAdded || result.ipsUpdated || result.ipsDeleted) {
+    logger.log(
+      `  IPs: ${result.ipsAdded ?? 0} added, ${result.ipsUpdated ?? 0} updated, ${result.ipsDeleted ?? 0} deleted`,
+    )
+  }
+  result.warnings?.forEach((w) => logger.warn(w))
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -3,7 +3,9 @@ import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import { firewallConfigSchema } from '../lib/schemas/firewallSchemas'
+import { unifiedConfigSchema } from '../lib/schemas/unifiedSchemas'
 import { ValidationError, ValidationService } from '../lib/services/ValidationService'
+import { hasProviderMetadata } from '../lib/types'
 import { getConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
 
@@ -34,13 +36,19 @@ export const handler = async (argv: Arguments<ValidateOptions>) => {
     // Load config without validation since we'll do that ourselves
     const configJson = await getConfig(argv.config, 'raw')
     const validator: ValidationService = ValidationService.getInstance()
+    // Multi-provider (Unified) configs — e.g. Cloudflare — use a different rule
+    // shape than the legacy Vercel-only schema, so validate against the matching
+    // schema (mirrors the routing in ValidationService.validateConfig).
+    const isMultiProviderConfig = hasProviderMetadata(configJson)
 
     if (argv.verbose) {
       logger.start('Validating configuration file...\n')
     }
 
     // Run Zod validation first
-    const zodResult = firewallConfigSchema.safeParse(configJson)
+    const zodResult = isMultiProviderConfig
+      ? unifiedConfigSchema.safeParse(configJson)
+      : firewallConfigSchema.safeParse(configJson)
     if (argv.verbose) {
       logger.log(chalk.bold.underline('Zod Schema Validation:'))
       if (zodResult.success) {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk'
 import { Stats, watchFile, unwatchFile } from 'fs'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
+import type { UnifiedConfig } from '../lib/types/unified'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { withCredentials } from '../lib/utils/withCredentials'
 
@@ -77,7 +79,7 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
       ci: argv.ci,
       errorContext: 'setting up watch mode',
     },
-    async ({ service }) => {
+    async ({ service, provider }) => {
       let isProcessing = false
       let lastModified = 0
 
@@ -98,6 +100,12 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
           logger.start('Validating and syncing changes...')
 
           const updatedConfig = await getConfig(configPath)
+
+          if (provider.name !== 'vercel') {
+            await syncChangesWithProvider(provider, updatedConfig as unknown as UnifiedConfig)
+            logger.log(chalk.dim('Watching for more changes...'))
+            return
+          }
 
           const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
             await service.getChanges(updatedConfig)
@@ -162,4 +170,36 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
       keepAlive()
     },
   )
+}
+
+/**
+ * Mirrors the Vercel branch above but via the generic IFirewallProvider interface.
+ * Always applies changes without prompting (force: true) — same as the Vercel path,
+ * which goes straight from diff to sync without a confirmation prompt, since watch
+ * mode is opt-in unattended auto-sync.
+ */
+async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfig: UnifiedConfig): Promise<void> {
+  const changes = await provider.getChanges(updatedConfig)
+
+  if (!changes.hasChanges) {
+    logger.info(chalk.blue('No changes detected, skipping sync'))
+    return
+  }
+
+  const totalChanges =
+    changes.rulesToAdd.length +
+    changes.rulesToUpdate.length +
+    changes.rulesToDelete.length +
+    (changes.ipsToAdd?.length ?? 0) +
+    (changes.ipsToUpdate?.length ?? 0) +
+    (changes.ipsToDelete?.length ?? 0)
+  logger.log(chalk.cyan(`Syncing ${totalChanges} changes...`))
+
+  const result = await provider.syncRules(updatedConfig, { force: true })
+
+  if (!result.success) {
+    throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)
+  }
+
+  logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
 }

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -3,7 +3,8 @@ import Ajv, { Ajv as AjvType } from 'ajv'
 import { z } from 'zod'
 import { schema } from '../../constants/schema'
 import { conditionGroupSchema, firewallConfigSchema, rateLimitSchema } from '../schemas/firewallSchemas'
-import { FirewallConfig } from '../types'
+import { validateUnifiedConfig } from '../schemas/unifiedSchemas'
+import { FirewallConfig, hasProviderMetadata } from '../types'
 import { ErrorFormatter } from '../utils/errorFormatter'
 
 export class ValidationError extends Error {
@@ -72,6 +73,23 @@ export class ValidationService {
   }
 
   validateConfig(config: unknown): asserts config is FirewallConfig {
+    // Multi-provider (Unified) configs — e.g. Cloudflare — declare a top-level
+    // `provider`/`providers` field and use a different rule shape (`conditions` +
+    // `action.type` instead of `conditionGroup` + `action.mitigate`). The AJV/Zod
+    // schemas below only understand the legacy Vercel-only shape, so route those
+    // configs to the unified schema instead of rejecting them as invalid.
+    if (hasProviderMetadata(config)) {
+      try {
+        validateUnifiedConfig(config)
+        return
+      } catch (error) {
+        throw new ValidationError(
+          'Invalid firewall configuration:\n' + (error instanceof Error ? error.message : String(error)),
+          null,
+        )
+      }
+    }
+
     // AJV Validation
     const validate = this.ajv.compile(this.schema)
     const ajvValid = validate(config)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,4 +122,4 @@ export interface FirewallConfig extends ProjectConfig {
 
 // Re-export unified types for multi-provider support
 export type { UnifiedConfig, UnifiedRule, UnifiedIPRule } from './types/unified'
-export { isUnifiedConfig, isUnifiedRule, isUnifiedIPRule } from './types/unified'
+export { isUnifiedConfig, isUnifiedRule, isUnifiedIPRule, hasProviderMetadata } from './types/unified'

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -77,6 +77,7 @@ export {
   isUnifiedConfig,
   isUnifiedRule,
   isUnifiedIPRule,
+  hasProviderMetadata,
   createUnifiedCondition,
   createUnifiedAction,
   createUnifiedRule,

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -100,6 +100,18 @@ export function isUnifiedConfig(obj: unknown): obj is UnifiedConfig {
   )
 }
 
+/**
+ * Distinguishes a multi-provider (Unified) config from a legacy Vercel-only config.
+ * Both shapes have a top-level `rules` array, so `isUnifiedConfig` alone can't tell
+ * them apart — this checks for the `provider`/`providers` fields that only appear on
+ * multi-provider configs (matching the signal `ProviderDetector` already relies on).
+ */
+export function hasProviderMetadata(obj: unknown): boolean {
+  if (!obj || typeof obj !== 'object') return false
+  const rec = obj as Record<string, unknown>
+  return typeof rec.provider === 'string' || (typeof rec.providers === 'object' && rec.providers !== null)
+}
+
 export function isUnifiedRule(obj: unknown): obj is UnifiedRule {
   const rec = obj as Record<string, unknown>
   return !!obj && typeof obj === 'object' && 'name' in rec && 'enabled' in rec && 'conditions' in rec && 'action' in rec


### PR DESCRIPTION
## Summary

- `sync`, `status`, `diff`, `watch`, `backup`, `download`, `export`, and `list` all called the legacy `client`/`service` objects directly, which `withCredentials.ts` stubs to `{}` for any non-Vercel provider — crashing with `TypeError: service.getChanges is not a function` under `--provider cloudflare`. Each command now branches onto the generic `IFirewallProvider` interface (`ctx.provider`) when the provider isn't Vercel; the Vercel code paths are unchanged.
- Fixes a second, deeper bug found while verifying the first: even after that fix, `sync`/`validate` still rejected every real Cloudflare config before reaching the network layer, because `ValidationService` (and a duplicate check in `validate.ts`) validated all configs against a Vercel-only AJV/Zod schema with `additionalProperties: false`, which rejects the `provider`/`providers` fields a real Cloudflare config requires. Configs that declare `provider`/`providers` metadata now route to the existing (previously unused) unified config schema instead.

Closes #82

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm lint` — no errors (pre-existing warnings only)
- [x] `pnpm test` — 59/59 suites, 1162 passing, same 3 pre-existing skips
- [x] `pnpm build` + manually ran `sync`/`status`/`diff`/`download`/`list`/`export`/`backup` with `--provider cloudflare` against a real Cloudflare-shaped config — all now reach the Cloudflare API (failing there with a normal network/auth error against fake credentials) instead of throwing `TypeError`
- [x] `doorman validate` against both a Cloudflare config with real rules and a legacy Vercel config — both pass
- [x] Regression check: Vercel `validate`/`status` against a legacy config still behave exactly as before