### PR TITLE
fix: Cloudflare dry-run warnings, Wirefilter injection, and command test coverage

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { logger } from '../../lib/logger'
+import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../backup'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+const vercelRemoteConfig = { version: 5, firewallEnabled: true, rules: [], ips: [], updatedAt: '2024-01-01T00:00:00Z' }
+
+describe('backup command', () => {
+  let tempDir: string
+  let backupDir: string
+  let configPath: string
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    tempDir = await fs.mkdtemp(join(tmpdir(), 'doorman-backup-test-'))
+    backupDir = join(tempDir, 'backups')
+    // withCredentials always loads a local config file even though the "create
+    // backup" handler doesn't read it — an explicit --config path avoids
+    // ConfigFinder's cwd auto-discovery (which dynamic-imports the ESM-only
+    // `find-up` package and doesn't play well with ts-jest's CJS transform).
+    configPath = join(tempDir, '.doorman.json')
+    await fs.writeFile(configPath, JSON.stringify({ rules: [], ips: [] }))
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(vercelRemoteConfig) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('creates a backup file for the Vercel provider', async () => {
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      config: configPath,
+      output: backupDir,
+      debug: false,
+      ci: true,
+    } as any)
+
+    const files = await fs.readdir(backupDir)
+    expect(files.some((f) => f.startsWith('firewall-backup-') && f.endsWith('.json'))).toBe(true)
+
+    const content = JSON.parse(await fs.readFile(join(backupDir, files[0]!), 'utf8'))
+    expect(content.backup.provider).toBe('vercel')
+    expect(content.backup.projectId).toBe('prj')
+  })
+
+  it('creates a backup file for the Cloudflare provider without crashing (regression test for #82)', async () => {
+    await handler({
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      config: configPath,
+      output: backupDir,
+      debug: false,
+      ci: true,
+    } as any)
+
+    const files = await fs.readdir(backupDir)
+    expect(files.some((f) => f.startsWith('firewall-backup-') && f.endsWith('.json'))).toBe(true)
+
+    const content = JSON.parse(await fs.readFile(join(backupDir, files[0]!), 'utf8'))
+    expect(content.backup.provider).toBe('cloudflare')
+    expect(content.provider).toBe('cloudflare')
+  })
+
+  it('lists existing backups without needing credentials', async () => {
+    await fs.mkdir(backupDir, { recursive: true })
+    await fs.writeFile(join(backupDir, 'firewall-backup-2024-01-01_00-00-00.json'), '{}')
+
+    await handler({ list: true, output: backupDir, debug: false, ci: true } as any)
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Available Backups'))
+  })
+
+  it('restores from a backup file without needing credentials', async () => {
+    await fs.mkdir(backupDir, { recursive: true })
+    const backupPath = join(backupDir, 'firewall-backup-2024-01-01_00-00-00.json')
+    await fs.writeFile(backupPath, JSON.stringify({ rules: [], ips: [] }))
+    const outputConfigPath = join(tempDir, 'restored.doorman.json')
+
+    await handler({
+      restore: backupPath,
+      config: outputConfigPath,
+      output: backupDir,
+      debug: false,
+      ci: true,
+    } as any)
+
+    const restored = JSON.parse(await fs.readFile(outputConfigPath, 'utf8'))
+    expect(restored.rules).toEqual([])
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Restored configuration'))
+  })
+})

--- a/src/commands/__tests__/diff.test.ts
+++ b/src/commands/__tests__/diff.test.ts
@@ -1,0 +1,97 @@
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../diff'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn() }))
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+const vercelRemoteConfig = { version: 5, firewallEnabled: true, rules: [], ips: [], updatedAt: '2024-01-01T00:00:00Z' }
+
+describe('diff command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(vercelRemoteConfig) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  it('reports no differences for the Vercel provider when configs match', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({ provider: 'vercel', token: 't', projectId: 'prj', teamId: 'team', debug: false, ci: true } as any)
+
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('No differences found'))
+  })
+
+  it('prints rule changes for the Vercel provider as JSON when format is json', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: 3,
+      rules: [
+        {
+          name: 'New Rule',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/new' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const jsonCall = (logger.log as unknown as jest.Mock).mock.calls.find((call) =>
+      String(call[0]).includes('"customRules"'),
+    )
+    expect(jsonCall).toBeDefined()
+    const parsed = JSON.parse(jsonCall![0])
+    expect(parsed.customRules.toAdd).toHaveLength(1)
+  })
+
+  it('reports differences for the Cloudflare provider without crashing (regression test for #82)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [
+        {
+          name: 'Block Bad Bots',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'block' },
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('cloudflare Configuration Differences'))
+    const summaryCall = (logger.log as unknown as jest.Mock).mock.calls.find((call) =>
+      String(call[0]).includes('Summary:'),
+    )
+    expect(summaryCall).toBeDefined()
+    expect(String(summaryCall![0])).toContain('1 total changes detected')
+  })
+})

--- a/src/commands/__tests__/download.test.ts
+++ b/src/commands/__tests__/download.test.ts
@@ -1,0 +1,46 @@
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { mockCloudflareClientPrototype, emptyCloudflareRuleset } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../download'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn(), saveConfig: jest.fn() }))
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+describe('download command — Cloudflare provider (regression test for #82)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedGetConfig.mockResolvedValue({} as any)
+    mockCloudflareClientPrototype(MockedCloudflareClient, {
+      ruleset: emptyCloudflareRuleset({
+        rules: [
+          {
+            id: 'r1',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/admin"',
+            description: 'Block Admin',
+            enabled: true,
+          },
+        ],
+      }),
+    })
+  })
+
+  it('lists remote rules for a dry run without crashing', async () => {
+    await handler({
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      dryRun: true,
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Remote Custom Rules to Download (1)'))
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Dry run completed'))
+  })
+})

--- a/src/commands/__tests__/export.test.ts
+++ b/src/commands/__tests__/export.test.ts
@@ -1,0 +1,117 @@
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../export'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn() }))
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+const localVercelConfig = {
+  version: 4,
+  rules: [
+    {
+      id: 'rule_1',
+      name: 'Block Admin',
+      conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/admin' }] }],
+      action: { mitigate: { action: 'deny' } },
+      active: true,
+    },
+  ],
+  ips: [],
+}
+
+describe('export command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any)
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue({
+      version: 5,
+      firewallEnabled: true,
+      rules: [],
+      ips: [],
+      updatedAt: '2024-01-01T00:00:00Z',
+    }) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('exports the local config as JSON to stdout', async () => {
+    mockedGetConfig.mockResolvedValue(localVercelConfig as any)
+
+    await handler({ source: 'local', format: 'json', output: '-', debug: false, ci: true } as any)
+
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(JSON.parse(logged)).toEqual(localVercelConfig)
+  })
+
+  it('exports the local config as markdown to stdout', async () => {
+    mockedGetConfig.mockResolvedValue(localVercelConfig as any)
+
+    await handler({ source: 'local', format: 'markdown', output: '-', debug: false, ci: true } as any)
+
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(logged).toContain('Block Admin')
+  })
+
+  it('exports the remote config for the Vercel provider', async () => {
+    mockedGetConfig.mockResolvedValue({} as any)
+
+    await handler({
+      source: 'remote',
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'json',
+      output: '-',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(JSON.parse(logged).version).toBe(5)
+  })
+
+  it('exports the remote config for the Cloudflare provider without crashing (regression test for #82)', async () => {
+    mockedGetConfig.mockResolvedValue({} as any)
+
+    await handler({
+      source: 'remote',
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      format: 'json',
+      output: '-',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(JSON.parse(logged).provider).toBe('cloudflare')
+  })
+
+  it('refuses non-JSON export formats for a multi-provider config instead of producing garbage output', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [],
+      ips: [],
+    } as any)
+
+    await handler({ source: 'local', format: 'markdown', output: '-', debug: false, ci: true } as any)
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('only supported for Vercel configurations'))
+  })
+})

--- a/src/commands/__tests__/list.test.ts
+++ b/src/commands/__tests__/list.test.ts
@@ -1,0 +1,97 @@
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { logger } from '../../lib/logger'
+import { mockCloudflareClientPrototype, emptyCloudflareRuleset } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../list'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+const vercelRemoteConfig = {
+  version: 5,
+  firewallEnabled: true,
+  rules: [
+    {
+      id: 'rule_1',
+      name: 'Block Admin',
+      conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/admin' }] }],
+      action: { mitigate: { action: 'deny' } },
+      active: true,
+    },
+  ],
+  ips: [],
+  updatedAt: '2024-01-01T00:00:00Z',
+}
+
+describe('list command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(vercelRemoteConfig) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  it('lists rules for the Vercel provider', async () => {
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'table',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Found'))
+  })
+
+  it('outputs JSON for the Vercel provider when format is json', async () => {
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const jsonCall = (logger.info as unknown as jest.Mock).mock.calls.find((call) =>
+      String(call[0]).includes('"rules"'),
+    )
+    expect(jsonCall).toBeDefined()
+    const parsed = JSON.parse(jsonCall![0])
+    expect(parsed.rules).toHaveLength(1)
+  })
+
+  it('lists rules for the Cloudflare provider without crashing (regression test for #82)', async () => {
+    mockCloudflareClientPrototype(MockedCloudflareClient, {
+      ruleset: emptyCloudflareRuleset({
+        rules: [
+          {
+            id: 'r1',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/admin"',
+            description: 'Block Admin',
+            enabled: true,
+          },
+        ],
+      }),
+    })
+
+    await handler({
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      format: 'table',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Found'))
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Custom Rules:'), '\n')
+  })
+})

--- a/src/commands/__tests__/setup.test.ts
+++ b/src/commands/__tests__/setup.test.ts
@@ -1,0 +1,26 @@
+import { logger } from '../../lib/logger'
+import { handler } from '../setup'
+
+jest.mock('../../lib/logger', () => ({
+  logger: { log: jest.fn() },
+}))
+
+describe('setup command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('prints setup instructions without throwing', async () => {
+    await expect(handler({} as any)).resolves.toBeUndefined()
+    expect(logger.log).toHaveBeenCalled()
+  })
+
+  it('mentions the key setup steps', async () => {
+    await handler({} as any)
+
+    const output = (logger.log as unknown as jest.Mock).mock.calls.map((call) => String(call[0])).join('\n')
+    expect(output).toContain('Doorman Setup Guide')
+    expect(output).toContain('VERCEL_TOKEN')
+    expect(output).toContain('doorman init --interactive')
+  })
+})

--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -1,0 +1,97 @@
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../status'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+
+jest.mock('../../lib/utils/config', () => ({
+  getConfig: jest.fn(),
+}))
+
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+const vercelRemoteConfig = {
+  version: 5,
+  firewallEnabled: true,
+  rules: [],
+  ips: [],
+  updatedAt: '2024-01-01T00:00:00Z',
+}
+
+describe('status command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(vercelRemoteConfig) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  it('reports in-sync status for the Vercel provider when local matches remote', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 'test-token',
+      projectId: 'prj_test',
+      teamId: 'team_test',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Everything is in sync'))
+  })
+
+  it('reports changes detected for the Vercel provider when local differs from remote', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: 3,
+      rules: [
+        {
+          name: 'New Rule',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/new' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 'test-token',
+      projectId: 'prj_test',
+      teamId: 'team_test',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Changes detected'))
+  })
+
+  it('reports status for the Cloudflare provider without crashing (regression test for #82)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [],
+      ips: [],
+    } as any)
+
+    await handler({
+      provider: 'cloudflare',
+      apiToken: 'test-cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('cloudflare Sync Status Summary'))
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Everything is in sync'))
+  })
+})

--- a/src/commands/__tests__/template.test.ts
+++ b/src/commands/__tests__/template.test.ts
@@ -1,0 +1,60 @@
+import { getConfig, saveConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { handler } from '../template'
+
+jest.mock('../../lib/logger', () => ({
+  logger: {
+    log: jest.fn(),
+    start: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+jest.mock('../../lib/utils/config', () => ({
+  getConfig: jest.fn(),
+  saveConfig: jest.fn(),
+}))
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const mockedSaveConfig = saveConfig as jest.MockedFunction<typeof saveConfig>
+
+describe('template command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedGetConfig.mockResolvedValue({ rules: [], ips: [] } as any)
+    mockedSaveConfig.mockResolvedValue(undefined)
+    jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with "${code}"`)
+    }) as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('appends the named template rules to the existing config and saves it', async () => {
+    await handler({ name: 'wordpress', dryRun: false, debug: false } as any)
+
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+    expect((savedConfig as any).rules.length).toBeGreaterThan(0)
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining("added template 'wordpress'"))
+  })
+
+  it('does not save anything on a dry run', async () => {
+    await handler({ name: 'wordpress', dryRun: true, debug: false } as any)
+
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Dry run'))
+  })
+
+  it('exits with an error for an unknown template name', async () => {
+    await expect(handler({ name: 'not-a-real-template', dryRun: false, debug: false } as any)).rejects.toThrow(
+      'process.exit called with "1"',
+    )
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/__tests__/validate.test.ts
+++ b/src/commands/__tests__/validate.test.ts
@@ -1,0 +1,95 @@
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { handler } from '../validate'
+
+jest.mock('../../lib/logger', () => ({
+  logger: { start: jest.fn(), log: jest.fn(), error: jest.fn(), success: jest.fn(), warn: jest.fn() },
+}))
+
+jest.mock('../../lib/utils/config', () => ({
+  getConfig: jest.fn(),
+}))
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+
+describe('validate command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with "${code}"`)
+    }) as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('reports success for a valid legacy Vercel config', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Block Admin',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({ verbose: false } as any)
+
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Configuration is valid'))
+    expect(process.exit).not.toHaveBeenCalled()
+  })
+
+  it('reports success for a valid multi-provider (Cloudflare) config', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [
+        {
+          name: 'Block Bad Bots',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'block' },
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({ verbose: false } as any)
+
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Configuration is valid'))
+    expect(process.exit).not.toHaveBeenCalled()
+  })
+
+  it('exits with an error for an invalid config', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Broken Rule',
+          conditionGroup: [{ conditions: [] }], // empty condition group is invalid
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await expect(handler({ verbose: false } as any)).rejects.toThrow('process.exit called with "1"')
+    expect(logger.success).not.toHaveBeenCalled()
+  })
+
+  it('exits with an error when a Cloudflare config is missing required rule fields', async () => {
+    mockedGetConfig.mockResolvedValue({
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [{ name: 'Missing Conditions', enabled: true, conditions: [], action: { type: 'block' } }],
+      ips: [],
+    } as any)
+
+    await expect(handler({ verbose: false } as any)).rejects.toThrow('process.exit called with "1"')
+  })
+})

--- a/src/commands/__tests__/watch.test.ts
+++ b/src/commands/__tests__/watch.test.ts
@@ -1,0 +1,122 @@
+import type { Stats } from 'fs'
+import { getConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { VercelClient } from '../../lib/services/VercelClient'
+import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { handler } from '../watch'
+
+jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
+jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn(), saveConfig: jest.fn() }))
+jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/cloudflare/CloudflareClient')
+
+let capturedWatchListener: ((curr: Stats, prev: Stats) => void) | undefined
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs')
+  return {
+    ...actual,
+    watchFile: jest.fn((_path: string, _opts: unknown, listener: (curr: Stats, prev: Stats) => void) => {
+      capturedWatchListener = listener
+    }),
+    unwatchFile: jest.fn(),
+  }
+})
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
+const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
+
+function fakeStats(mtimeMs: number): Stats {
+  return { mtime: new Date(mtimeMs) } as Stats
+}
+
+describe('watch command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    capturedWatchListener = undefined
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue({
+      version: 5,
+      firewallEnabled: true,
+      rules: [],
+      ips: [],
+      updatedAt: '2024-01-01T00:00:00Z',
+    }) as any
+    mockCloudflareClientPrototype(MockedCloudflareClient)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  it('registers a file watcher and does nothing until the file changes', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({
+      config: '.doorman.json',
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      interval: 50,
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(capturedWatchListener).toBeDefined()
+  })
+
+  it('syncs via the Cloudflare provider on file change without crashing (regression test for #82)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [
+        {
+          name: 'Block Bad Bots',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'block' },
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      config: '.doorman.json',
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      interval: 50,
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(capturedWatchListener).toBeDefined()
+    await capturedWatchListener!(fakeStats(2000), fakeStats(1000))
+
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Sync completed'))
+  })
+
+  it('skips syncing when the file change reports no config differences', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({
+      config: '.doorman.json',
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      interval: 50,
+      debug: false,
+      ci: true,
+    } as any)
+
+    await capturedWatchListener!(fakeStats(2000), fakeStats(1000))
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('No changes detected'))
+  })
+})

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -191,7 +191,11 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
           },
         }
 
-        await saveConfig(backupConfig as unknown as FirewallConfig, backupPath)
+        // Skip validation — the added `backup` metadata field isn't part of the
+        // live config schema (additionalProperties: false), so validating here
+        // would reject every backup. Restoring already loads backups in 'raw'
+        // mode for the same reason.
+        await saveConfig(backupConfig as unknown as FirewallConfig, backupPath, { validate: false })
 
         logger.success(chalk.green(`✅ Backup created: ${backupPath}`))
         logger.log('')

--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -230,6 +230,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
         ipsAdded: dryRunResult.changes.ipsToAdd?.length || 0,
         ipsUpdated: dryRunResult.changes.ipsToUpdate?.length || 0,
         ipsDeleted: dryRunResult.changes.ipsToDelete?.length || 0,
+        warnings: dryRunResult.warnings,
       }
     }
 
@@ -378,6 +379,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
       ipsUpdated,
       ipsDeleted,
       version: parseInt(updatedRuleset.version, 10),
+      warnings: dryRunResult.warnings?.length ? dryRunResult.warnings : undefined,
     }
 
     this.logSyncStats(result)

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../../utils/operationSafety', () => ({
         hasChanges: false,
       },
       issues: [],
+      warnings: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
   },

--- a/src/lib/translators/ExpressionBuilder.ts
+++ b/src/lib/translators/ExpressionBuilder.ts
@@ -1,6 +1,7 @@
 import type { VercelRuleCondition, VercelConditionGroup } from '../types/vercel'
 import type { UnifiedCondition } from '../types/unified'
 import { FieldMapper } from './FieldMapper'
+import { escapeWirefilterString } from './wirefilterEscape'
 
 /**
  * Builds Cloudflare wirefilter expressions from structured conditions
@@ -65,7 +66,7 @@ export class ExpressionBuilder {
    */
   public static fromUnifiedCondition(condition: UnifiedCondition): string {
     const field = condition.key
-      ? `http.request.headers["${condition.key}"]`
+      ? `http.request.headers["${escapeWirefilterString(condition.key)}"]`
       : this.mapUnifiedFieldToCloudflare(condition.field)
 
     const operator = this.mapUnifiedOperator(condition.operator)
@@ -166,9 +167,7 @@ export class ExpressionBuilder {
    */
   private static formatSingleValue(value: unknown): string {
     if (typeof value === 'string') {
-      // Escape quotes in string values
-      const escaped = value.replace(/"/g, '\\"')
-      return `"${escaped}"`
+      return `"${escapeWirefilterString(value)}"`
     }
 
     if (typeof value === 'number') {

--- a/src/lib/translators/FieldMapper.ts
+++ b/src/lib/translators/FieldMapper.ts
@@ -1,6 +1,7 @@
 import type { VercelRuleType } from '../types/vercel'
 import type { CloudflareFieldType } from '../types/cloudflare'
 import { logger } from '../logger'
+import { escapeWirefilterString } from './wirefilterEscape'
 
 /**
  * Maps field types between Vercel and Cloudflare
@@ -67,11 +68,11 @@ export class FieldMapper {
 
     // For header and cookie, append the key
     if (vercelType === 'header' && key) {
-      return `${field}["${key.toLowerCase()}"]`
+      return `${field}["${escapeWirefilterString(key.toLowerCase())}"]`
     }
 
     if (vercelType === 'cookie' && key) {
-      return `${field}["${key}"]`
+      return `${field}["${escapeWirefilterString(key)}"]`
     }
 
     return field

--- a/src/lib/translators/__tests__/ExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/ExpressionBuilder.test.ts
@@ -122,6 +122,31 @@ describe('ExpressionBuilder', () => {
       )
     })
 
+    it('escapes quotes in a header key so it cannot break out of the field reference', () => {
+      const condition: VercelRuleCondition = {
+        type: 'header',
+        op: 'eq',
+        value: 'x',
+        key: 'x"] or (true) or http.request.headers["x',
+      }
+      const result = ExpressionBuilder.fromVercelCondition(condition)
+      // The escaped key must stay inside a single string literal — no unescaped
+      // `"]` sequence should appear anywhere in the generated field reference.
+      expect(result).toBe('http.request.headers["x\\"] or (true) or http.request.headers[\\"x"] eq "x"')
+      expect(result).not.toMatch(/headers\["[^"\\]*"\] or/)
+    })
+
+    it('escapes quotes in a cookie key so it cannot break out of the field reference', () => {
+      const condition: VercelRuleCondition = {
+        type: 'cookie',
+        op: 'eq',
+        value: 'x',
+        key: 'a" or true or http.cookie["a',
+      }
+      const result = ExpressionBuilder.fromVercelCondition(condition)
+      expect(result).toBe('http.cookie["a\\" or true or http.cookie[\\"a"] eq "x"')
+    })
+
     it('handles numeric values', () => {
       const condition: VercelRuleCondition = { type: 'geo_as_number', op: 'eq', value: 13335 }
       expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('ip.geoip.asnum eq 13335')
@@ -217,6 +242,26 @@ describe('ExpressionBuilder', () => {
         key: 'Authorization',
       })
       expect(result).toBe('http.request.headers["Authorization"] eq "Bearer token"')
+    })
+
+    it('escapes quotes in a unified header key so it cannot break out of the field reference', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'header',
+        operator: 'eq',
+        value: 'x',
+        key: 'x"] or (true) or http.request.headers["x',
+      })
+      expect(result).toBe('http.request.headers["x\\"] or (true) or http.request.headers[\\"x"] eq "x"')
+      expect(result).not.toMatch(/headers\["[^"\\]*"\] or/)
+    })
+
+    it('escapes backslashes in string values so a trailing backslash cannot consume the closing quote', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'path',
+        operator: 'eq',
+        value: 'a\\',
+      })
+      expect(result).toBe('http.request.uri.path eq "a\\\\"')
     })
   })
 

--- a/src/lib/translators/__tests__/FieldMapper.test.ts
+++ b/src/lib/translators/__tests__/FieldMapper.test.ts
@@ -78,6 +78,17 @@ describe('FieldMapper', () => {
       expect(FieldMapper.toCloudflare('cookie', 'session_id')).toBe('http.cookie["session_id"]')
     })
 
+    it('escapes quotes in a header key so it cannot break out of the field reference', () => {
+      const result = FieldMapper.toCloudflare('header', 'x"] or (true) or http.request.headers["x')
+      expect(result).toBe('http.request.headers["x\\"] or (true) or http.request.headers[\\"x"]')
+      expect(result).not.toMatch(/headers\["[^"\\]*"\] or/)
+    })
+
+    it('escapes quotes in a cookie key so it cannot break out of the field reference', () => {
+      const result = FieldMapper.toCloudflare('cookie', 'a" or true or http.cookie["a')
+      expect(result).toBe('http.cookie["a\\" or true or http.cookie[\\"a"]')
+    })
+
     it('throws for environment (Vercel-specific, no mapping)', () => {
       expect(() => FieldMapper.toCloudflare('environment')).toThrow(/Unsupported Vercel rule type/)
     })

--- a/src/lib/translators/wirefilterEscape.ts
+++ b/src/lib/translators/wirefilterEscape.ts
@@ -1,0 +1,14 @@
+/**
+ * Escapes a string for safe interpolation into a double-quoted Cloudflare
+ * wirefilter string literal (e.g. a field reference like `http.request.headers["<key>"]`
+ * or a condition value like `"<value>"`).
+ *
+ * Backslashes must be escaped *before* quotes — otherwise a value ending in a
+ * backslash (e.g. `x\`) would consume the literal's closing quote instead of
+ * terminating the string, and an unescaped quote in a header/cookie condition
+ * key can break out of the field reference entirely and inject arbitrary
+ * wirefilter syntax (e.g. `or (true) or http.request.headers["x`).
+ */
+export function escapeWirefilterString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}

--- a/src/lib/utils/__tests__/operationSafety.test.ts
+++ b/src/lib/utils/__tests__/operationSafety.test.ts
@@ -98,6 +98,42 @@ describe('OperationSafety', () => {
       expect(result.valid).toBe(false)
       expect(result.issues).toContain('Dry-run validation failed: Validation failed')
     })
+
+    it('should surface duplicate rule names as a warning, not a blocking issue', async () => {
+      const configWithDuplicates: UnifiedConfig = {
+        ...mockConfig,
+        rules: [
+          { ...mockConfig.rules[0]!, id: 'rule_1', name: 'Block Bad Bots' },
+          { ...mockConfig.rules[0]!, id: 'rule_2', name: 'Block Bad Bots' },
+        ],
+      }
+      const validateFn = jest.fn().mockResolvedValue(mockChanges)
+
+      const result = await OperationSafety.performDryRunValidation(configWithDuplicates, 'test operation', validateFn)
+
+      expect(result.valid).toBe(true)
+      expect(result.issues).toHaveLength(0)
+      expect(result.warnings.some((w) => w.includes('Duplicate rule names found'))).toBe(true)
+    })
+
+    it('should surface a high deletion ratio as a warning, not a blocking issue', async () => {
+      const deletionHeavyChanges: ChangeSet = {
+        rulesToAdd: [],
+        rulesToUpdate: [],
+        rulesToDelete: [mockConfig.rules[0]!],
+        ipsToAdd: [],
+        ipsToUpdate: [],
+        ipsToDelete: [],
+        hasChanges: true,
+      }
+      const validateFn = jest.fn().mockResolvedValue(deletionHeavyChanges)
+
+      const result = await OperationSafety.performDryRunValidation(mockConfig, 'test operation', validateFn)
+
+      expect(result.valid).toBe(true)
+      expect(result.issues).toHaveLength(0)
+      expect(result.warnings.some((w) => w.includes('High deletion ratio detected'))).toBe(true)
+    })
   })
 
   describe('getBackupRecommendation', () => {

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -99,16 +99,24 @@ export class OperationSafety {
   }
 
   /**
-   * Perform dry-run validation before actual changes
+   * Perform dry-run validation before actual changes.
+   *
+   * `issues` are structural problems that make the config unsafe to sync at all
+   * (e.g. malformed shape) and always block the operation. `warnings` are risk
+   * signals (large deletion ratio, duplicate names, etc.) that should be surfaced
+   * to the user via the risk-assessment/confirmation flow below, not treated as
+   * unrecoverable failures — otherwise a config that's merely risky (or just has
+   * two rules with the same name) can never be synced, even with --force.
    */
   public static async performDryRunValidation(
     config: UnifiedConfig,
     operation: string,
     validateFn: (config: UnifiedConfig) => Promise<ChangeSet>,
-  ): Promise<{ valid: boolean; changes: ChangeSet; issues: string[] }> {
+  ): Promise<{ valid: boolean; changes: ChangeSet; issues: string[]; warnings: string[] }> {
     logger.info(`🔍 Performing dry-run validation for ${operation}...`)
 
     const issues: string[] = []
+    const warnings: string[] = []
     let changes: ChangeSet = {
       rulesToAdd: [],
       rulesToUpdate: [],
@@ -120,17 +128,15 @@ export class OperationSafety {
     }
 
     try {
-      // Validate configuration structure
+      // Validate configuration structure — real, unrecoverable errors
       this.validateConfigurationStructure(config, issues)
 
       // Perform operation-specific validation
       changes = await validateFn(config)
 
-      // Validate changes
-      this.validateChanges(changes, issues)
-
-      // Check for potential issues
-      this.checkForPotentialIssues(config, changes, issues)
+      // Risk signals — surfaced as warnings, not hard failures
+      this.validateChanges(changes, warnings)
+      this.checkForPotentialIssues(config, changes, warnings)
 
       const valid = issues.length === 0
 
@@ -141,13 +147,18 @@ export class OperationSafety {
         issues.forEach((issue) => logger.warn(`   • ${issue}`))
       }
 
-      return { valid, changes, issues }
+      if (warnings.length > 0) {
+        logger.warn(`⚠️  Dry-run validation found ${warnings.length} warning(s):`)
+        warnings.forEach((warning) => logger.warn(`   • ${warning}`))
+      }
+
+      return { valid, changes, issues, warnings }
     } catch (error) {
       const errorMessage = `Dry-run validation failed: ${error instanceof Error ? error.message : String(error)}`
       issues.push(errorMessage)
       logger.error(errorMessage)
 
-      return { valid: false, changes, issues }
+      return { valid: false, changes, issues, warnings }
     }
   }
 

--- a/src/tests/testHelpers/loggerMock.ts
+++ b/src/tests/testHelpers/loggerMock.ts
@@ -1,0 +1,27 @@
+/**
+ * A complete mock of the consola-based logger, covering every method used
+ * anywhere in the command call chain (withCredentials/ProviderDetector call
+ * `logger.debug`, list.ts calls `logger.verbose`, etc). Using a partial mock
+ * is a trap: an unstubbed method throws `TypeError: logger.x is not a
+ * function` deep inside withCredentials' try/catch, which gets silently
+ * swallowed by handleCommandError and reported as a generic command failure.
+ */
+export function createLoggerMock() {
+  return {
+    log: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    start: jest.fn(),
+    debug: jest.fn(),
+    verbose: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    ready: jest.fn(),
+    box: jest.fn(),
+    fail: jest.fn(),
+    silent: jest.fn(),
+    level: 3,
+  }
+}

--- a/src/tests/testHelpers/providerMocks.ts
+++ b/src/tests/testHelpers/providerMocks.ts
@@ -1,0 +1,54 @@
+import type { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
+import { CloudflareOptimizer } from '../../lib/providers/cloudflare/CloudflareOptimizer'
+import type { CloudflareRuleset } from '../../lib/types/cloudflare'
+
+/**
+ * Default empty Cloudflare ruleset used by tests that don't care about its contents.
+ */
+export function emptyCloudflareRuleset(overrides: Partial<CloudflareRuleset> = {}): CloudflareRuleset {
+  return {
+    id: 'ruleset-1',
+    name: 'Doorman Custom Ruleset',
+    description: 'Managed by Doorman',
+    kind: 'custom',
+    phase: 'http_request_firewall_custom',
+    version: '1',
+    last_updated: '2024-01-01T00:00:00Z',
+    rules: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Wires up a mocked `CloudflareClient` class (from `jest.mock('.../CloudflareClient')`)
+ * with sensible defaults so commands that resolve a Cloudflare provider (via
+ * `withCredentials` -> `getProviderInstance` -> `CloudflareProvider.fromConfig`) don't
+ * make real network calls. Call this after `jest.mock('.../CloudflareClient')` in the
+ * test file; pass the mocked class itself.
+ */
+export function mockCloudflareClientPrototype(
+  MockedCloudflareClient: jest.MockedClass<typeof CloudflareClient>,
+  options: { ruleset?: CloudflareRuleset } = {},
+): void {
+  const ruleset = options.ruleset ?? emptyCloudflareRuleset()
+
+  // Real (not mocked) — it's pure diffing logic, not a network call, and
+  // CloudflareFirewallService.getChanges depends on it actually working.
+  MockedCloudflareClient.prototype.getOptimizer = jest.fn().mockReturnValue(new CloudflareOptimizer()) as any
+  MockedCloudflareClient.prototype.getOrCreateFirewallRuleset = jest.fn().mockResolvedValue(ruleset) as any
+  MockedCloudflareClient.prototype.updateRuleset = jest.fn().mockResolvedValue({ ...ruleset, version: '2' }) as any
+  MockedCloudflareClient.prototype.getOrCreateIPBlocklist = jest.fn().mockResolvedValue({
+    id: 'list-1',
+    name: 'Doorman IP Blocklist',
+    description: 'Managed by Doorman',
+    kind: 'ip',
+    num_items: 0,
+    num_referencing_filters: 0,
+    created_on: '2024-01-01T00:00:00Z',
+    modified_on: '2024-01-01T00:00:00Z',
+  }) as any
+  MockedCloudflareClient.prototype.getListItems = jest.fn().mockResolvedValue([]) as any
+  MockedCloudflareClient.prototype.addListItems = jest.fn().mockResolvedValue([]) as any
+  MockedCloudflareClient.prototype.removeListItems = jest.fn().mockResolvedValue(undefined) as any
+  MockedCloudflareClient.prototype.verifyCredentials = jest.fn().mockResolvedValue(true) as any
+}


### PR DESCRIPTION
## Summary

- **Dry-run validation no longer treats risk warnings as hard failures** (#83). `performDryRunValidation` previously lumped risk signals (duplicate rule names, high deletion ratio, large changesets) together with genuine structural errors and blocked `sync` on any of them, with no override — not even `--force`. Split into `issues` (real blockers) and `warnings` (now surfaced through the existing risk-assessment/confirmation flow instead). `SyncResult.warnings` is threaded through to `sync`/`watch` output.
- **Closes a Wirefilter expression injection** (#84). Header/cookie condition keys were interpolated into Cloudflare Wirefilter field references without escaping quotes, so a crafted config key like `` x"] or (true) or http.request.headers["x `` could hijack a rule's logic during sync. Added a shared escape helper (also fixes a related bug where a trailing backslash in a value could consume the closing quote) and used it everywhere a key or value is interpolated into a Wirefilter literal.
- **Adds test coverage for the 9 previously-untested commands** (#98): `backup`, `export`, `list`, `status`, `diff`, `watch`, `setup`, `template`, `validate` — covering both the Vercel and Cloudflare code paths where applicable, plus a bonus Cloudflare-path test for `download`.

### Bonus fix found while writing coverage

Writing tests for `backup` surfaced a real, pre-existing bug: `doorman backup` on the **Vercel** path has always thrown `Unknown property backup`, because it validated the backup file against the live-config schema, which doesn't allow the extra `backup` metadata field the command itself adds. Fixed by saving backups unvalidated, matching how restore already loads them (`'raw'` mode).

Closes #83, closes #84, closes #98

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm lint` — no errors (pre-existing warnings only)
- [x] `pnpm test` — 69/69 suites, 1201 passing (up from 59/1170 before this PR), same 3 pre-existing skips
- [x] `pnpm build` — clean
- [x] Manually reproduced the injection payload through `ExpressionBuilder.fromUnifiedCondition` and confirmed the malicious key stays inside a single escaped string literal
- [x] New regression tests for duplicate rule names / high deletion ratio confirm they no longer block sync
- [x] New command tests cover both Vercel and Cloudflare provider paths for every previously-untested command