### PR TITLE
fix: harden remaining Wirefilter injection sites in rule translation

### DIFF
--- a/src/lib/translators/ExpressionBuilder.ts
+++ b/src/lib/translators/ExpressionBuilder.ts
@@ -65,9 +65,15 @@ export class ExpressionBuilder {
    * Build expression from a single unified condition
    */
   public static fromUnifiedCondition(condition: UnifiedCondition): string {
-    const field = condition.key
-      ? `http.request.headers["${escapeWirefilterString(condition.key)}"]`
-      : this.mapUnifiedFieldToCloudflare(condition.field)
+    const baseField = this.mapUnifiedFieldToCloudflare(condition.field)
+    // `key` only makes sense as a bracket index for header/cookie fields
+    // (matching FieldMapper's Vercel-side behavior) — a header or cookie
+    // condition's key must not fall through to the headers field regardless
+    // of which of the two it actually is.
+    const field =
+      condition.key && (condition.field === 'header' || condition.field === 'cookie')
+        ? `${baseField}["${escapeWirefilterString(condition.key)}"]`
+        : baseField
 
     const operator = this.mapUnifiedOperator(condition.operator)
     const value = this.formatValue(condition.value, operator)

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -2,6 +2,7 @@ import type { VercelCustomRule, VercelIPBlockingRule, VercelConditionGroup } fro
 import type { CloudflareRule } from '../types/cloudflare'
 import type { UnifiedRule, UnifiedIPRule, UnifiedCondition, UnifiedAction } from '../types/unified'
 import { ExpressionBuilder } from './ExpressionBuilder'
+import { ipAddressSchema } from '../schemas/commonSchemas'
 import { logger } from '../logger'
 
 /**
@@ -399,6 +400,16 @@ export class RuleTranslator {
    * Translate Unified IP rule to Cloudflare rule
    */
   public static unifiedIPToCloudflare(ip: UnifiedIPRule): CloudflareRule {
+    // `ip.ip` is interpolated unquoted into the wirefilter expression below (IP
+    // literals aren't string literals in wirefilter, so there are no quotes to
+    // escape). Config-level schema validation already constrains this value in
+    // normal usage, but this function shouldn't trust its input blindly — an
+    // unvalidated value here has no delimiter at all to contain it, making this
+    // a more direct injection primitive than a quoted string field.
+    if (!ipAddressSchema.safeParse(ip.ip).success) {
+      throw new Error(`Invalid IP address or CIDR range: ${ip.ip}`)
+    }
+
     return {
       id: ip.id || crypto.randomUUID(),
       action: ip.action === 'allow' ? 'allow' : 'block',

--- a/src/lib/translators/__tests__/ExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/ExpressionBuilder.test.ts
@@ -263,6 +263,37 @@ describe('ExpressionBuilder', () => {
       })
       expect(result).toBe('http.request.uri.path eq "a\\\\"')
     })
+
+    it('handles cookie conditions with key as http.cookie, not http.request.headers', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'cookie',
+        operator: 'eq',
+        value: 'abc123',
+        key: 'session_id',
+      })
+      expect(result).toBe('http.cookie["session_id"] eq "abc123"')
+    })
+
+    it('escapes quotes in a unified cookie key so it cannot break out of the field reference', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'cookie',
+        operator: 'eq',
+        value: 'x',
+        key: 'a" or true or http.cookie["a',
+      })
+      expect(result).toBe('http.cookie["a\\" or true or http.cookie[\\"a"] eq "x"')
+    })
+
+    it('ignores an unsupported key on a query condition instead of mislabeling it as a header', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'query',
+        operator: 'eq',
+        value: 'abc',
+        key: 'utm_source',
+      })
+      expect(result).toBe('http.request.uri.query eq "abc"')
+      expect(result).not.toContain('headers')
+    })
   })
 
   describe('validate', () => {

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -633,6 +633,17 @@ describe('RuleTranslator', () => {
       expect(result.description).toContain('IP deny: 10.0.0.1')
       expect(result.description).not.toContain('(')
     })
+
+    it('accepts a valid CIDR range', () => {
+      const ip: UnifiedIPRule = { ip: '203.0.113.0/24', action: 'deny' }
+      const result = RuleTranslator.unifiedIPToCloudflare(ip)
+      expect(result.expression).toBe('ip.src eq 203.0.113.0/24')
+    })
+
+    it('rejects an IP value that would inject additional wirefilter syntax', () => {
+      const ip: UnifiedIPRule = { ip: '1.2.3.4 or (true) or ip.src eq 1.2.3.4', action: 'deny' }
+      expect(() => RuleTranslator.unifiedIPToCloudflare(ip)).toThrow('Invalid IP address or CIDR range')
+    })
   })
 
   describe('window parsing (via vercelToCloudflare rate_limit)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #108's review, which flagged two more spots in the Cloudflare rule-translation layer that interpolate data into generated wirefilter expressions without the same validation/escaping #84 added elsewhere:

- **`RuleTranslator.unifiedIPToCloudflare`** built `` `ip.src eq ${ip.ip}` `` via raw string concatenation with no validation at all. IP literals aren't quoted in wirefilter, so there was no delimiter to contain a malicious value — actually a more direct injection primitive than a quoted string field, since there's nothing to "escape out of" in the first place. Now validates `ip.ip` against the existing `ipAddressSchema` before interpolating, and throws rather than silently building an injectable expression.
- **`ExpressionBuilder.fromUnifiedCondition`** hardcoded `http.request.headers[...]` for *any* condition with a `key`, regardless of `condition.field` — so a cookie condition with a key got mistranslated as a header expression instead of `http.cookie[...]`. Now only bracket-indexes for `header`/`cookie` fields specifically, using the matching base field. A `query` condition with a key now falls through to the plain field instead of being mislabeled as a header (matching how the existing Vercel-path `FieldMapper` already treats keyed query conditions).

Both are defense-in-depth: normal config loading already validates IPs and rule shape before reaching this code, but the translator shouldn't trust its input blindly — especially a function whose whole job is generating an expression string from user-controlled config.

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm test` — new regression tests cover: CIDR still accepted, an injection-shaped IP string is rejected, a cookie condition with a key now produces `http.cookie[...]` (not headers), a query condition with a key doesn't get mislabeled as a header, and quote-escaping still holds for the cookie case
- [x] `pnpm lint` — clean