### PR TITLE
fix: surface sync warnings in watch mode

### DIFF
--- a/src/commands/__tests__/watch.test.ts
+++ b/src/commands/__tests__/watch.test.ts
@@ -101,6 +101,44 @@ describe('watch command', () => {
     expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Sync completed'))
   })
 
+  it('surfaces sync warnings from the Cloudflare provider instead of silently dropping them', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [
+        {
+          name: 'Duplicate Rule',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'block' },
+        },
+        {
+          name: 'Duplicate Rule',
+          enabled: true,
+          conditions: [{ field: 'path', operator: 'eq', value: '/admin' }],
+          action: { type: 'block' },
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      config: '.doorman.json',
+      provider: 'cloudflare',
+      apiToken: 'cf-token',
+      zoneId: '0123456789abcdef0123456789abcdef',
+      interval: 50,
+      debug: false,
+      ci: true,
+    } as any)
+
+    await capturedWatchListener!(fakeStats(2000), fakeStats(1000))
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Duplicate rule names found'))
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Sync completed'))
+  })
+
   it('skips syncing when the file change reports no config differences', async () => {
     mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -201,5 +201,6 @@ async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfi
     throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)
   }
 
+  result.warnings?.forEach((w) => logger.warn(w))
   logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
 }


### PR DESCRIPTION
## Summary

`sync.ts` logs `result.warnings` after a Cloudflare sync (e.g. duplicate rule names, high deletion ratio — surfaced instead of blocking, per #83), but `watch.ts`'s equivalent Cloudflare branch never read them, so the same warnings were silently dropped during auto-sync. Flagged during review of #108. Now logs them the same way `sync.ts` does.

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm test` — new regression test: a config with duplicate rule names produces a logged "Duplicate rule names found" warning during a watch-triggered Cloudflare sync, alongside the existing success message
- [x] `pnpm lint` — clean