### PR TITLE
chore: address remaining review nitpicks from Cloudflare warnings/injection work

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -201,6 +201,6 @@ async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfi
     throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)
   }
 
-  result.warnings?.forEach((w) => logger.warn(w))
   logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
+  result.warnings?.forEach((w) => logger.warn(w))
 }

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -305,6 +305,7 @@ describe('CloudflareFirewallService', () => {
           hasChanges: true,
         },
         issues: [],
+        warnings: [],
       })
 
       const result = await service.syncRules(mockConfig, { dryRun: true })

--- a/src/lib/translators/__tests__/wirefilterEscape.test.ts
+++ b/src/lib/translators/__tests__/wirefilterEscape.test.ts
@@ -1,0 +1,35 @@
+import { escapeWirefilterString } from '../wirefilterEscape'
+
+describe('escapeWirefilterString', () => {
+  it('returns strings with no special characters unchanged', () => {
+    expect(escapeWirefilterString('Authorization')).toBe('Authorization')
+  })
+
+  it('escapes double quotes', () => {
+    expect(escapeWirefilterString('say "hi"')).toBe('say \\"hi\\"')
+  })
+
+  it('escapes backslashes', () => {
+    expect(escapeWirefilterString('a\\b')).toBe('a\\\\b')
+  })
+
+  it('escapes backslashes before quotes, so a trailing backslash cannot consume a wrapping close-quote', () => {
+    // If a caller wraps the result in `"${escaped}"`, an unescaped trailing
+    // backslash would combine with the wrapping quote to form `\"`, which a
+    // wirefilter parser reads as an escaped quote rather than the string's
+    // actual terminator.
+    const result = escapeWirefilterString('a\\')
+    expect(result).toBe('a\\\\')
+    expect(`"${result}"`).toBe('"a\\\\"')
+  })
+
+  it('escapes an embedded quote so it cannot break out of a field reference', () => {
+    // e.g. building `http.cookie["${escaped}"]` from this key must not let the
+    // key close the bracket early and append trailing wirefilter syntax.
+    const maliciousKey = 'x"] or (true) or http.cookie["x'
+    const result = escapeWirefilterString(maliciousKey)
+    const fieldRef = `http.cookie["${result}"]`
+    expect(fieldRef).toBe('http.cookie["x\\"] or (true) or http.cookie[\\"x"]')
+    expect(fieldRef).not.toMatch(/cookie\["[^"\\]*"\] or/)
+  })
+})

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -395,9 +395,10 @@ export class OperationSafety {
   }
 
   /**
-   * Validate changes for potential issues
+   * Assess changes for risk signals (deletion ratio, changeset size). These are
+   * warnings, not blocking errors — see performDryRunValidation.
    */
-  private static validateChanges(changes: ChangeSet, issues: string[]): void {
+  private static validateChanges(changes: ChangeSet, warnings: string[]): void {
     // Check for excessive deletions
     const totalDeletions = (changes.rulesToDelete?.length || 0) + (changes.ipsToDelete?.length || 0)
     const totalChanges =
@@ -410,23 +411,25 @@ export class OperationSafety {
     if (totalDeletions > 0 && totalChanges > 0) {
       const deletionRatio = totalDeletions / totalChanges
       if (deletionRatio > 0.5) {
-        issues.push(`High deletion ratio detected: ${Math.round(deletionRatio * 100)}% of changes are deletions`)
+        warnings.push(`High deletion ratio detected: ${Math.round(deletionRatio * 100)}% of changes are deletions`)
       }
     }
 
     // Check for large number of changes
     if (totalChanges > 100) {
-      issues.push(`Large number of changes detected: ${totalChanges} total changes`)
+      warnings.push(`Large number of changes detected: ${totalChanges} total changes`)
     }
   }
 
   /**
-   * Check for potential issues in configuration and changes
+   * Check configuration and changes for risk signals (all rules deleted,
+   * potentially traffic-blocking rules, duplicate names, etc). These are
+   * warnings, not blocking errors — see performDryRunValidation.
    */
-  private static checkForPotentialIssues(config: UnifiedConfig, changes: ChangeSet, issues: string[]): void {
+  private static checkForPotentialIssues(config: UnifiedConfig, changes: ChangeSet, warnings: string[]): void {
     // Check if all rules are being deleted
     if (changes.rulesToDelete?.length === config.rules.length && config.rules.length > 0) {
-      issues.push('All existing rules will be deleted - this removes all firewall protection')
+      warnings.push('All existing rules will be deleted - this removes all firewall protection')
     }
 
     // Check for rules that might block all traffic
@@ -439,19 +442,19 @@ export class OperationSafety {
     )
 
     if (potentiallyBlockingRules.length > 0) {
-      issues.push(`Found ${potentiallyBlockingRules.length} rules that may block all traffic`)
+      warnings.push(`Found ${potentiallyBlockingRules.length} rules that may block all traffic`)
     }
 
     // Check for very large IP lists
     if (config.ips && config.ips.length > 1000) {
-      issues.push(`Large IP list detected: ${config.ips.length} IPs may impact performance`)
+      warnings.push(`Large IP list detected: ${config.ips.length} IPs may impact performance`)
     }
 
     // Check for duplicate rule names
     const ruleNames = config.rules.map((rule) => rule.name)
     const duplicateNames = ruleNames.filter((name, index) => ruleNames.indexOf(name) !== index)
     if (duplicateNames.length > 0) {
-      issues.push(`Duplicate rule names found: ${[...new Set(duplicateNames)].join(', ')}`)
+      warnings.push(`Duplicate rule names found: ${[...new Set(duplicateNames)].join(', ')}`)
     }
   }
 }


### PR DESCRIPTION
## Summary

Cleans up the small nitpicks flagged across the reviews of #108, #109, and #110 that weren't worth blocking those PRs on:

- `operationSafety.ts`: renamed the `issues` params on `validateChanges`/`checkForPotentialIssues` to `warnings` — the call sites were updated in #108 to only ever pass the warnings accumulator, but the parameter names were left stale, which reads as if they still populate blocking errors.
- `watch.ts`: log ordering now matches `sync.ts` (success message, then warnings) — the #110 review found the two commands presented the same signal in a different order.
- `CloudflareFirewallService.test.ts`: added the missing `warnings: []` to a dry-run mock override so it matches the real `performDryRunValidation` return shape.
- Added a dedicated unit test for `wirefilterEscape.escapeWirefilterString`, previously only exercised indirectly through `ExpressionBuilder`/`FieldMapper` call sites.

No behavior change beyond the `watch.ts` log ordering.

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm test` — 70/70 suites, 1212 passing (up from 1207)
- [x] `pnpm lint` — clean