### PR TITLE
fix: validate fetched config before writing a backup, not skip validation entirely

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -23,6 +23,9 @@ describe('backup command', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
+    jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with "${code}"`)
+    }) as any)
     tempDir = await fs.mkdtemp(join(tmpdir(), 'doorman-backup-test-'))
     backupDir = join(tempDir, 'backups')
     // withCredentials always loads a local config file even though the "create
@@ -36,6 +39,7 @@ describe('backup command', () => {
   })
 
   afterEach(async () => {
+    jest.restoreAllMocks()
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 
@@ -85,6 +89,32 @@ describe('backup command', () => {
     await handler({ list: true, output: backupDir, debug: false, ci: true } as any)
 
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Available Backups'))
+  })
+
+  it('refuses to create a backup when the fetched remote config is malformed', async () => {
+    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue({
+      version: 5,
+      firewallEnabled: true,
+      // Missing conditionGroup/action/active — structurally invalid.
+      rules: [{ name: 'Corrupt Rule' }],
+      ips: [],
+      updatedAt: '2024-01-01T00:00:00Z',
+    }) as any
+
+    await expect(
+      handler({
+        provider: 'vercel',
+        token: 't',
+        projectId: 'prj',
+        teamId: 'team',
+        config: configPath,
+        output: backupDir,
+        debug: false,
+        ci: true,
+      } as any),
+    ).rejects.toThrow()
+
+    await expect(fs.readdir(backupDir)).rejects.toThrow()
   })
 
   it('restores from a backup file without needing credentials', async () => {

--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -16,14 +16,26 @@ const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof Cloud
 
 // Shaped like the real Vercel API response (VercelConfig), including the
 // fields Vercel returns that aren't part of a Doorman config — id, crs,
-// projectKey, ownerId — to guard against validating/saving the raw response
-// as-is, which would fail schema validation (additionalProperties: false).
+// projectKey, ownerId at the top level, and valid/validationErrors on every
+// rule — to guard against validating/saving the raw response as-is, which
+// would fail schema validation (additionalProperties: false on both
+// FirewallConfig and CustomRule).
 const vercelRemoteConfig = {
   version: 5,
   id: 'config_1',
   firewallEnabled: true,
   crs: {},
-  rules: [],
+  rules: [
+    {
+      id: 'rule_block_admin',
+      name: 'Block Admin',
+      conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/admin' }] }],
+      action: { mitigate: { action: 'deny' } },
+      active: true,
+      valid: true,
+      validationErrors: [],
+    },
+  ],
   ips: [],
   projectKey: 'pk_123',
   ownerId: 'owner_1',
@@ -83,6 +95,11 @@ describe('backup command', () => {
     expect(content.ownerId).toBeUndefined()
     expect(content.version).toBe(5)
     expect(content.firewallEnabled).toBe(true)
+    // Per-rule API-only fields must not leak into the saved backup either.
+    expect(content.rules).toHaveLength(1)
+    expect(content.rules[0].valid).toBeUndefined()
+    expect(content.rules[0].validationErrors).toBeUndefined()
+    expect(content.rules[0].name).toBe('Block Admin')
   })
 
   it('creates a backup file for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -14,7 +14,21 @@ jest.mock('../../lib/providers/cloudflare/CloudflareClient')
 const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
 
-const vercelRemoteConfig = { version: 5, firewallEnabled: true, rules: [], ips: [], updatedAt: '2024-01-01T00:00:00Z' }
+// Shaped like the real Vercel API response (VercelConfig), including the
+// fields Vercel returns that aren't part of a Doorman config — id, crs,
+// projectKey, ownerId — to guard against validating/saving the raw response
+// as-is, which would fail schema validation (additionalProperties: false).
+const vercelRemoteConfig = {
+  version: 5,
+  id: 'config_1',
+  firewallEnabled: true,
+  crs: {},
+  rules: [],
+  ips: [],
+  projectKey: 'pk_123',
+  ownerId: 'owner_1',
+  updatedAt: '2024-01-01T00:00:00Z',
+}
 
 describe('backup command', () => {
   let tempDir: string
@@ -61,6 +75,14 @@ describe('backup command', () => {
     const content = JSON.parse(await fs.readFile(join(backupDir, files[0]!), 'utf8'))
     expect(content.backup.provider).toBe('vercel')
     expect(content.backup.projectId).toBe('prj')
+    // Vercel API-only fields must not leak into the saved backup — this is
+    // also what makes the sanitized config pass schema validation at all.
+    expect(content.id).toBeUndefined()
+    expect(content.crs).toBeUndefined()
+    expect(content.projectKey).toBeUndefined()
+    expect(content.ownerId).toBeUndefined()
+    expect(content.version).toBe(5)
+    expect(content.firewallEnabled).toBe(true)
   })
 
   it('creates a backup file for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -175,14 +175,16 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         // ownerId) that aren't part of a Doorman config and would fail schema
         // validation (additionalProperties: false) — strip them before
         // validating/saving, the same way download.ts builds its saved config.
-        // Cloudflare's fetchConfig() already returns a clean UnifiedConfig with
-        // no extra fields, so it's used as-is.
+        // The API also attaches valid/validationErrors to every rule object
+        // (download.ts strips these too, for the same reason — CustomRule also
+        // has additionalProperties: false). Cloudflare's fetchConfig() already
+        // returns a clean UnifiedConfig with no extra fields, so it's used as-is.
         const sanitizedConfig =
           provider.name === 'vercel'
             ? {
                 version: remoteConfig.version,
                 firewallEnabled: (remoteConfig as VercelConfig).firewallEnabled,
-                rules: remoteConfig.rules,
+                rules: remoteConfig.rules.map(({ valid, validationErrors, ...rule }: any) => rule),
                 ips: remoteConfig.ips,
                 updatedAt: (remoteConfig as VercelConfig).updatedAt,
               }

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
+import { ValidationService } from '../lib/services/ValidationService'
 import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
@@ -169,6 +170,15 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         const remoteConfig =
           provider.name === 'vercel' ? await client.fetchFirewallConfig() : await provider.fetchConfig()
 
+        // Validate the fetched config itself (before adding the backup metadata
+        // wrapper below) — this catches genuine API response corruption rather
+        // than trusting whatever the provider returned. It's validated here,
+        // not after wrapping, because the wrapper's `backup` field isn't part of
+        // the live config schema (additionalProperties: false); see the save
+        // below for why that final write is unvalidated.
+        const validator: ValidationService = ValidationService.getInstance()
+        validator.validateConfig(remoteConfig)
+
         if (!existsSync(backupDir)) {
           mkdirSync(backupDir, { recursive: true })
         }
@@ -191,10 +201,10 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
           },
         }
 
-        // Skip validation — the added `backup` metadata field isn't part of the
-        // live config schema (additionalProperties: false), so validating here
-        // would reject every backup. Restoring already loads backups in 'raw'
-        // mode for the same reason.
+        // The underlying config was already validated above; skip validation
+        // here only because the added `backup` metadata field isn't part of the
+        // live config schema (additionalProperties: false). Restoring already
+        // loads backups in 'raw' mode for the same reason.
         await saveConfig(backupConfig as unknown as FirewallConfig, backupPath, { validate: false })
 
         logger.success(chalk.green(`✅ Backup created: ${backupPath}`))

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -5,6 +5,7 @@ import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import { ValidationService } from '../lib/services/ValidationService'
+import type { VercelConfig } from '../lib/services/VercelClient'
 import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
@@ -170,14 +171,31 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         const remoteConfig =
           provider.name === 'vercel' ? await client.fetchFirewallConfig() : await provider.fetchConfig()
 
-        // Validate the fetched config itself (before adding the backup metadata
+        // The raw Vercel API response includes fields (id, crs, projectKey,
+        // ownerId) that aren't part of a Doorman config and would fail schema
+        // validation (additionalProperties: false) — strip them before
+        // validating/saving, the same way download.ts builds its saved config.
+        // Cloudflare's fetchConfig() already returns a clean UnifiedConfig with
+        // no extra fields, so it's used as-is.
+        const sanitizedConfig =
+          provider.name === 'vercel'
+            ? {
+                version: remoteConfig.version,
+                firewallEnabled: (remoteConfig as VercelConfig).firewallEnabled,
+                rules: remoteConfig.rules,
+                ips: remoteConfig.ips,
+                updatedAt: (remoteConfig as VercelConfig).updatedAt,
+              }
+            : remoteConfig
+
+        // Validate the sanitized config (before adding the backup metadata
         // wrapper below) — this catches genuine API response corruption rather
         // than trusting whatever the provider returned. It's validated here,
         // not after wrapping, because the wrapper's `backup` field isn't part of
         // the live config schema (additionalProperties: false); see the save
         // below for why that final write is unvalidated.
         const validator: ValidationService = ValidationService.getInstance()
-        validator.validateConfig(remoteConfig)
+        validator.validateConfig(sanitizedConfig)
 
         if (!existsSync(backupDir)) {
           mkdirSync(backupDir, { recursive: true })
@@ -191,7 +209,7 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         const backupPath = join(backupDir, backupFilename)
 
         const backupConfig = {
-          ...remoteConfig,
+          ...sanitizedConfig,
           backup: {
             createdAt: new Date().toISOString(),
             source: 'remote',


### PR DESCRIPTION
## Summary

Follow-up to the #108 review's finding #4. `backup.ts` previously saved the backup file with `{ validate: false }`, disabling validation entirely — because the extra `backup: {...}` metadata field the command adds isn't part of the live config schema (`additionalProperties: false`) and would fail validation. That threw away validation of the actual fetched config data too, not just the wrapper.

This validates the config fetched from the provider's API on its own, **before** the `backup` metadata field gets merged in — so genuinely corrupt data from a provider response is still caught (fails loudly instead of silently writing a broken "backup"). Only the final write of the wrapped object (config + `backup` field) skips validation, and only because of the added field — not because the underlying config went unchecked.

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `pnpm test` — 70/70 suites, 1213 passing (up from 1212). New regression test: a mocked remote config missing required rule fields (`conditionGroup`/`action`/`active`) now makes `doorman backup` fail loudly and write nothing, instead of silently writing an invalid backup
- [x] Existing Vercel/Cloudflare backup-creation tests still pass unchanged, confirming legitimate backups still validate successfully and get written
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean