### PR TITLE
fix: strip backup metadata before validating restored config

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -174,4 +174,43 @@ describe('backup command', () => {
     expect(restored.rules).toEqual([])
     expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Restored configuration'))
   })
+
+  it('restores from a real backup file that carries the `backup` metadata field (regression test for #113)', async () => {
+    await fs.mkdir(backupDir, { recursive: true })
+    const backupPath = join(backupDir, 'firewall-backup-2024-01-01_00-00-00.json')
+    // Shaped like a file `doorman backup` actually writes — includes the
+    // `backup` metadata wrapper, which isn't part of the live config schema
+    // (additionalProperties: false) and previously failed restore validation.
+    await fs.writeFile(
+      backupPath,
+      JSON.stringify({
+        version: 5,
+        firewallEnabled: true,
+        rules: [],
+        ips: [],
+        backup: {
+          createdAt: '2024-01-01T00:00:00Z',
+          source: 'remote',
+          provider: 'vercel',
+          projectId: 'prj',
+          teamId: 'team',
+          originalVersion: 5,
+        },
+      }),
+    )
+    const outputConfigPath = join(tempDir, 'restored.doorman.json')
+
+    await handler({
+      restore: backupPath,
+      config: outputConfigPath,
+      output: backupDir,
+      debug: false,
+      ci: true,
+    } as any)
+
+    const restored = JSON.parse(await fs.readFile(outputConfigPath, 'utf8'))
+    expect(restored.rules).toEqual([])
+    expect(restored.backup).toBeUndefined()
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Restored configuration'))
+  })
 })

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -146,7 +146,14 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         }
       }
 
-      await saveConfig(backupConfig, outputPath)
+      // Real backups carry a `backup: {createdAt, source, provider, ...}`
+      // metadata field (added when the backup was created — see below) that
+      // isn't part of the live config schema (additionalProperties: false).
+      // Strip it before validating/saving, the same way backup creation keeps
+      // it out of the validated sanitizedConfig.
+      const { backup: _backupMetadata, ...restoredConfig } = backupConfig as FirewallConfig & { backup?: unknown }
+
+      await saveConfig(restoredConfig as FirewallConfig, outputPath)
       logger.success(chalk.green(`✅ Restored configuration from ${restorePath} to ${outputPath}`))
       return
     }


### PR DESCRIPTION
## Summary
- `doorman backup --restore <file>` loaded the backup with `getConfig(restorePath, 'raw')` (skipping validation), but then saved the restored config with `saveConfig()` using default options — validation still on.
- Every real backup written by `doorman backup` carries a `backup: {createdAt, source, provider, ...}` metadata field. That field fails schema validation (`additionalProperties: false`) on save, so restoring any real backup threw and exited 1. Only hand-crafted fixtures without the `backup` field happened to work.
- Fix: strip the `backup` field from the loaded backup before validating/saving, mirroring how `saveConfig` already keeps that field out of the validated config on the backup-creation path (fixed in #112).

## Test plan
- [x] Added a regression test using a realistic backup fixture (includes the `backup` metadata field) and asserted the restore succeeds and the metadata is stripped from the written config.
- [x] `pnpm test -- src/commands/__tests__/backup.test.ts` — 6/6 pass
- [x] `pnpm test:ci` — 70 suites / 1214 tests pass
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — no new warnings/errors

Fixes #113