### PR TITLE
fix: stop logging the raw Vercel API token in debug output

### DIFF
--- a/src/commands/__tests__/list.test.ts
+++ b/src/commands/__tests__/list.test.ts
@@ -48,6 +48,29 @@ describe('list command', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Found'))
   })
 
+  it('never logs the raw Vercel API token, even in debug mode (regression test for #100)', async () => {
+    const secretToken = 'vercel_super_secret_token_12345'
+
+    await handler({
+      provider: 'vercel',
+      token: secretToken,
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'table',
+      debug: true,
+      ci: true,
+    } as any)
+
+    const loggedText = Object.values(logger)
+      .filter((fn): fn is jest.Mock => jest.isMockFunction(fn))
+      .flatMap((fn) => fn.mock.calls)
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join('\n')
+
+    expect(loggedText).not.toContain(secretToken)
+  })
+
   it('outputs JSON for the Vercel provider when format is json', async () => {
     await handler({
       provider: 'vercel',

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -79,7 +79,7 @@ export const handler = async (argv: Arguments<ListOptions>) => {
       skipValidation: true,
       errorContext: 'listing firewall rules',
     },
-    async ({ client, provider, token, projectId, teamId }) => {
+    async ({ client, provider, projectId, teamId }) => {
       // Validate version if provided
       if (argv.configVersion !== undefined) {
         try {
@@ -99,7 +99,7 @@ export const handler = async (argv: Arguments<ListOptions>) => {
       }
 
       logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
-      logger.verbose(`Token: ${token}\t projectId: ${projectId}\t teamId: ${teamId}`)
+      logger.verbose(`projectId: ${projectId}\t teamId: ${teamId}`)
 
       const liveConfig = await client.fetchFirewallConfig(argv.configVersion)
 


### PR DESCRIPTION
## Summary
- `list.ts`'s verbose debug log (`logger.verbose(\`Token: ${token}...\`)`) printed the complete plaintext Vercel API token.
- Any `doorman list --debug` run, or a CI pipeline capturing verbose output, leaked the full credential into terminal output or retained CI logs (e.g. GitHub Actions logs, terminal recordings).
- Fix: drop the token from the log line entirely — `projectId`/`teamId` aren't secrets and are sufficient for debugging context. No other command logs the raw token this way (verified via grep across `src/`).

## Test plan
- [x] Added a regression test that runs `list` in `--debug` mode with a distinctive fake token and asserts it never appears in any logger call's output.
- [x] `pnpm test -- src/commands/__tests__/list.test.ts` — 4/4 pass
- [x] `pnpm test:ci` — 70 suites / 1215 tests pass
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — no new warnings/errors

Fixes #100