### PR TITLE
fix: emit valid wirefilter syntax for negated Cloudflare operators

### DIFF
--- a/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
@@ -247,7 +247,11 @@ describe('Rule Translation Accuracy', () => {
       const result = RuleTranslator.unifiedToCloudflare(rule)
       expect(result.result.action).toBe('managed_challenge')
       expect(result.result.expression).toContain('ip.geoip.country')
-      expect(result.result.expression).toContain('not in')
+      // wirefilter has no single-token `not in` operator — `not_in` must
+      // translate to a positive `in` comparison wrapped in `not (...)`
+      // (see #85), not the invalid `not in` token.
+      expect(result.result.expression).toContain('not (ip.geoip.country in')
+      expect(result.result.expression).not.toContain('not in')
     })
 
     it('should translate a rate limit rule with all parameters', () => {

--- a/src/lib/translators/ExpressionBuilder.ts
+++ b/src/lib/translators/ExpressionBuilder.ts
@@ -34,10 +34,10 @@ export class ExpressionBuilder {
    */
   public static fromVercelCondition(condition: VercelRuleCondition): string {
     const field = FieldMapper.toCloudflare(condition.type, condition.key)
-    const operator = this.mapVercelOperator(condition.op)
-    const value = this.formatValue(condition.value, condition.op)
-
-    let expression = `${field} ${operator} ${value}`
+    let expression = this.buildExistsOrComparisonExpression(field, condition.op, () => {
+      const operator = this.mapVercelOperator(condition.op)
+      return `${operator} ${this.formatValue(condition.value, condition.op)}`
+    })
 
     // Handle negation
     if (condition.neg) {
@@ -75,10 +75,7 @@ export class ExpressionBuilder {
         ? `${baseField}["${escapeWirefilterString(condition.key)}"]`
         : baseField
 
-    const operator = this.mapUnifiedOperator(condition.operator)
-    const value = this.formatValue(condition.value, operator)
-
-    let expression = `${field} ${operator} ${value}`
+    let expression = this.buildUnifiedExpression(field, condition.operator, condition.value)
 
     if (condition.negated) {
       expression = `not (${expression})`
@@ -88,7 +85,45 @@ export class ExpressionBuilder {
   }
 
   /**
-   * Map Vercel operators to Cloudflare operators
+   * `exists`/`not_exists` (Vercel: `ex`/`nex`) conditions carry no value and
+   * wirefilter has no `not exists` binary operator — negation must wrap the
+   * whole unary `exists` check in `not (...)` instead. Every other operator
+   * falls through to the caller's ordinary `<op> <value>` comparison.
+   */
+  private static buildExistsOrComparisonExpression(field: string, op: string, buildComparison: () => string): string {
+    if (op === 'ex' || op === 'exists') {
+      return `${field} exists`
+    }
+    if (op === 'nex' || op === 'not_exists') {
+      return `not (${field} exists)`
+    }
+    return `${field} ${buildComparison()}`
+  }
+
+  /**
+   * wirefilter also has no `not contains`/`not in` binary operators — like
+   * `not_exists` above, these negated unified operators translate to the
+   * positive comparison (`contains`/`in`) wrapped in `not (...)`.
+   */
+  private static buildUnifiedExpression(field: string, op: UnifiedCondition['operator'], value: unknown): string {
+    if (op === 'not_contains') {
+      return `not (${field} contains ${this.formatValue(value, 'contains')})`
+    }
+    if (op === 'not_in') {
+      return `not (${field} in ${this.formatValue(value, 'in')})`
+    }
+    return this.buildExistsOrComparisonExpression(field, op, () => {
+      const operator = this.mapUnifiedOperator(op)
+      return `${operator} ${this.formatValue(value, operator)}`
+    })
+  }
+
+  /**
+   * Map Vercel operators to Cloudflare operators.
+   * `ex` (and unified `exists`/`not_exists` below) are handled entirely by
+   * `buildExistsOrComparisonExpression` before this is ever called — wirefilter
+   * has no `not exists` binary operator, so `nex` is deliberately omitted here
+   * rather than mapped to that invalid token.
    */
   private static mapVercelOperator(op: string): string {
     const mapping: Record<string, string> = {
@@ -99,32 +134,33 @@ export class ExpressionBuilder {
       sub: 'contains',
       re: 'matches',
       ex: 'exists',
-      nex: 'not exists',
     }
 
     return mapping[op] || op
   }
 
   /**
-   * Map unified operators to Cloudflare operators
+   * Map unified operators to Cloudflare operators.
+   * `exists`/`not_exists`/`not_contains`/`not_in` are handled entirely by
+   * `buildUnifiedExpression` before this is ever called — wirefilter has no
+   * single-token `not exists`/`not contains`/`not in` operator, only
+   * `not (<expr>)` wrapping a positive comparison — so those four are
+   * deliberately omitted here rather than mapped to invalid tokens.
    */
   private static mapUnifiedOperator(op: string): string {
     const mapping: Record<string, string> = {
       eq: 'eq',
       ne: 'ne',
       contains: 'contains',
-      not_contains: 'not contains',
       starts_with: 'starts_with',
       ends_with: 'ends_with',
       matches: 'matches',
       in: 'in',
-      not_in: 'not in',
       gt: 'gt',
       ge: 'ge',
       lt: 'lt',
       le: 'le',
       exists: 'exists',
-      not_exists: 'not exists',
     }
 
     return mapping[op] || op

--- a/src/lib/translators/__tests__/ExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/ExpressionBuilder.test.ts
@@ -151,6 +151,20 @@ describe('ExpressionBuilder', () => {
       const condition: VercelRuleCondition = { type: 'geo_as_number', op: 'eq', value: 13335 }
       expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('ip.geoip.asnum eq 13335')
     })
+
+    it('builds a valueless exists (ex) expression (regression test for #85)', () => {
+      const condition: VercelRuleCondition = { type: 'header', op: 'ex', key: 'x-api-version' }
+      expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('http.request.headers["x-api-version"] exists')
+    })
+
+    it('builds a valueless not-exists (nex) expression wrapped in not(...) (regression test for #85)', () => {
+      const condition: VercelRuleCondition = { type: 'header', op: 'nex', key: 'x-api-version' }
+      expect(ExpressionBuilder.fromVercelCondition(condition)).toBe(
+        'not (http.request.headers["x-api-version"] exists)',
+      )
+      expect(ExpressionBuilder.fromVercelCondition(condition)).not.toContain('undefined')
+      expect(ExpressionBuilder.fromVercelCondition(condition)).not.toContain('not exists')
+    })
   })
 
   describe('fromUnifiedConditions', () => {
@@ -293,6 +307,48 @@ describe('ExpressionBuilder', () => {
       })
       expect(result).toBe('http.request.uri.query eq "abc"')
       expect(result).not.toContain('headers')
+    })
+
+    it('builds a valueless exists expression (regression test for #85)', () => {
+      // `value` is omitted here the same way RuleTranslator's Vercel->unified
+      // conversion leaves it undefined for exists/not_exists conditions.
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'header',
+        operator: 'exists',
+        key: 'x-api-version',
+      } as UnifiedCondition)
+      expect(result).toBe('http.request.headers["x-api-version"] exists')
+    })
+
+    it('builds a valueless not_exists expression wrapped in not(...) (regression test for #85)', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'header',
+        operator: 'not_exists',
+        key: 'x-api-version',
+      } as UnifiedCondition)
+      expect(result).toBe('not (http.request.headers["x-api-version"] exists)')
+      expect(result).not.toContain('undefined')
+      expect(result).not.toContain('not exists')
+    })
+
+    it('builds a not_contains expression as a positive comparison wrapped in not(...) (regression test for #85)', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'path',
+        operator: 'not_contains',
+        value: 'admin',
+      })
+      expect(result).toBe('not (http.request.uri.path contains "admin")')
+      expect(result).not.toContain('not contains')
+    })
+
+    it('builds a not_in expression as a positive comparison wrapped in not(...) (regression test for #85)', () => {
+      const result = ExpressionBuilder.fromUnifiedCondition({
+        field: 'country',
+        operator: 'not_in',
+        value: ['US', 'CA'],
+      })
+      expect(result).toBe('not (ip.geoip.country in {"US" "CA"})')
+      expect(result).not.toContain('not in')
     })
   })
 


### PR DESCRIPTION
## Summary
wirefilter (Cloudflare's rule expression language) has no single-token `not exists`/`not contains`/`not in` binary operators — negation is only expressed by wrapping a positive comparison in `not (<expr>)`. `ExpressionBuilder` emitted all three as literal (invalid) tokens:
- `ex`/`nex` (Vercel) and unified `exists`/`not_exists` conditions carry no `value` by design, but the builder always appended `formatValue(undefined)` → the literal string `"undefined"`.
- `nex`/`not_exists` mapped to the invalid token `not exists` instead of `not (field exists)`.
- Unified `not_contains`/`not_in` had the same bug class, mapping to the invalid tokens `not contains`/`not in`.

**Failure scenario:** the repo's own example config (`examples/header-based-rules.json`) uses `{"op":"nex","type":"header","key":"x-api-version"}`, which translated to `http.request.headers["x-api-version"][0] not exists undefined` — Cloudflare's ruleset API rejects this, failing the *entire* rule sync, not just that one rule.

## Fix
- `ex`/`exists` → bare `<field> exists`
- `nex`/`not_exists` → `not (<field> exists)`
- `not_contains` → `not (<field> contains <value>)`
- `not_in` → `not (<field> in <value>)`

Removed the now-dead/invalid map entries (`nex: 'not exists'`, `not_contains: 'not contains'`, `not_in: 'not in'`, `not_exists: 'not exists'`) so they can't be silently reintroduced.

Also fixed one existing test in `CloudflareWorkflowIntegration.test.ts` that was asserting the old, invalid `not in` output.

## Test plan
- [x] Added regression tests for `ex`/`nex` (Vercel) and `exists`/`not_exists`/`not_contains`/`not_in` (unified) covering both the correct output and absence of `undefined`/invalid tokens.
- [x] `pnpm test -- src/lib/translators/__tests__/ExpressionBuilder.test.ts` — 48/48 pass
- [x] `pnpm test:ci` — 70 suites / 1220 tests pass
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — no new warnings/errors

Fixes #85