### PR TITLE
fix: use wirefilter's in operator for CIDR IP-blocking rules

### DIFF
--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -410,10 +410,16 @@ export class RuleTranslator {
       throw new Error(`Invalid IP address or CIDR range: ${ip.ip}`)
     }
 
+    // wirefilter's `eq` only matches a single IP literal — a CIDR range needs
+    // the `in {…}` set-membership operator instead, or Cloudflare's ruleset
+    // API rejects the rule outright.
+    const isCIDR = ip.ip.includes('/')
+    const expression = isCIDR ? `ip.src in {${ip.ip}}` : `ip.src eq ${ip.ip}`
+
     return {
       id: ip.id || crypto.randomUUID(),
       action: ip.action === 'allow' ? 'allow' : 'block',
-      expression: `ip.src eq ${ip.ip}`,
+      expression,
       description: ip.notes || `IP ${ip.action}: ${ip.ip}${ip.hostname ? ` (${ip.hostname})` : ''}`,
       enabled: true,
     }

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -634,10 +634,18 @@ describe('RuleTranslator', () => {
       expect(result.description).not.toContain('(')
     })
 
-    it('accepts a valid CIDR range', () => {
+    it('translates a CIDR range using the `in` set operator, not `eq` (regression test for #86)', () => {
       const ip: UnifiedIPRule = { ip: '203.0.113.0/24', action: 'deny' }
       const result = RuleTranslator.unifiedIPToCloudflare(ip)
-      expect(result.expression).toBe('ip.src eq 203.0.113.0/24')
+      // wirefilter's `eq` only matches a single IP literal — a CIDR range
+      // needs `in {…}` or Cloudflare's ruleset API rejects the rule.
+      expect(result.expression).toBe('ip.src in {203.0.113.0/24}')
+    })
+
+    it('still uses `eq` for a single (non-CIDR) IP', () => {
+      const ip: UnifiedIPRule = { ip: '203.0.113.5', action: 'deny' }
+      const result = RuleTranslator.unifiedIPToCloudflare(ip)
+      expect(result.expression).toBe('ip.src eq 203.0.113.5')
     })
 
     it('rejects an IP value that would inject additional wirefilter syntax', () => {


### PR DESCRIPTION
## Summary
- `unifiedIPToCloudflare` always emitted `ip.src eq {ip}`, but wirefilter's `eq` only matches a single IP literal — a CIDR range needs the `in {…}` set-membership operator instead.
- Both `CloudflareFirewallService`'s own IP validation regex and `add.ts`'s `--ip` flag explicitly document and accept CIDR notation, so a CIDR value passes local/schema validation and only fails once Cloudflare sync falls back to individual IP rules (no `accountId`, or the Lists API failing).
- Fix: detect CIDR notation (presence of `/`) and emit `ip.src in {<cidr>}` instead of `ip.src eq <cidr>`. Plain IPs are unaffected (still `eq`).

## Test plan
- [x] Updated the existing CIDR test to assert the correct `in {…}` output instead of the old invalid `eq` form, and added a new test confirming plain IPs still use `eq`.
- [x] `pnpm test -- src/lib/translators/__tests__/RuleTranslator.test.ts` — 48/48 pass
- [x] `pnpm test:ci` — 70 suites / 1221 tests pass
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — no new warnings/errors

Fixes #86