### PR TITLE
fix: accept IPv6 addresses and CIDR ranges in Cloudflare IP validation

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -1,3 +1,4 @@
+import { isIPv4, isIPv6 } from 'net'
 import { BaseFirewallService } from '../BaseFirewallService'
 import { CloudflareClient } from './CloudflareClient'
 import { CloudflareOptimizer } from './CloudflareOptimizer'
@@ -562,10 +563,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
       if (config.ips) {
         config.ips.forEach((ip, index) => {
           try {
-            // Enhanced IP/CIDR validation
-            const ipPattern =
-              /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\/(?:[0-9]|[1-2][0-9]|3[0-2]))?$/
-            if (!ipPattern.test(ip.ip)) {
+            if (!CloudflareFirewallService.isValidIPOrCIDR(ip.ip)) {
               const error = cloudflareErrors.invalidIP(ip.ip)
               errors.push({
                 path: `ips[${index}].ip`,
@@ -654,6 +652,36 @@ export class CloudflareFirewallService extends BaseFirewallService {
   public clearCache(): void {
     this.client.clearCache()
     this.optimizer.clearCaches()
+  }
+
+  /**
+   * Validate an IP address or CIDR range, IPv4 or IPv6. Cloudflare's IP
+   * blocking/Lists API supports both address families, so validation here
+   * must too — a plain IPv4-only regex rejects legitimate IPv6 configs
+   * outright.
+   */
+  private static isValidIPOrCIDR(value: string): boolean {
+    const [address, prefix, ...rest] = value.split('/')
+    if (rest.length > 0 || !address) {
+      return false
+    }
+
+    if (prefix === undefined) {
+      return isIPv4(address) || isIPv6(address)
+    }
+
+    if (!/^\d+$/.test(prefix)) {
+      return false
+    }
+    const prefixLength = Number(prefix)
+
+    if (isIPv4(address)) {
+      return prefixLength <= 32
+    }
+    if (isIPv6(address)) {
+      return prefixLength <= 128
+    }
+    return false
   }
 
   /**

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -940,6 +940,37 @@ describe('CloudflareFirewallService', () => {
       expect(result.errors.some((e) => e.code === 'CF_6013')).toBe(true)
     })
 
+    it('accepts IPv6 addresses and CIDR ranges (regression test for #87)', () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [
+          { id: 'ip-1', ip: '2001:db8::1', action: 'deny' },
+          { id: 'ip-2', ip: '2001:db8::/32', action: 'deny' },
+          { id: 'ip-3', ip: '::1', action: 'deny' },
+        ],
+      }
+
+      const result = service.validateConfig(config)
+
+      expect(result.errors.some((e) => e.code === 'CF_6013')).toBe(false)
+    })
+
+    it('rejects an IPv6 CIDR with an out-of-range prefix length', () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [{ id: 'ip-1', ip: '2001:db8::/129', action: 'deny' }],
+      }
+
+      const result = service.validateConfig(config)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.code === 'CF_6013')).toBe(true)
+    })
+
     it('should warn about large IP lists without account ID', () => {
       const serviceWithoutAccount = new CloudflareFirewallService(API_TOKEN, ZONE_ID)
 


### PR DESCRIPTION
## Summary
- The `ipPattern` regex used to validate `config.ips` entries in `CloudflareFirewallService.validateConfig` had no IPv6 branch at all, even though Cloudflare's IP blocking/Lists API supports IPv6.
- Any IPv6 address (e.g. `2001:db8::1`) failed validation outright, blocking sync for otherwise legitimate configs.
- Fix: replaced the IPv4-only regex with a private `isValidIPOrCIDR` helper built on Node's built-in `net.isIPv4`/`net.isIPv6`, which also validates the CIDR prefix length against the correct range per address family (0-32 for IPv4, 0-128 for IPv6).

## Test plan
- [x] Added regression tests: plain IPv6 addresses, IPv6 CIDR ranges, and `::1` all pass validation; an out-of-range IPv6 prefix (`/129`) is correctly rejected.
- [x] `pnpm test -- src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts` - 43/43 pass
- [x] `pnpm test:ci` - 70 suites / 1217 tests pass
- [x] `pnpm build` - succeeds
- [x] `pnpm lint` - no new warnings/errors

Fixes #87