### PR TITLE
fix: pin @semantic-release/npm to the OIDC-capable v13 line

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
-    "@semantic-release/npm": "^12.0.1",
+    "@semantic-release/npm": "^13.1.5",
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.12.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^12.0.6
         version: 12.0.6(semantic-release@25.0.3(typescript@5.4.5))
       '@semantic-release/npm':
-        specifier: ^12.0.1
-        version: 12.0.1(semantic-release@25.0.3(typescript@5.4.5))
+        specifier: ^13.1.5
+        version: 13.1.5(semantic-release@25.0.3(typescript@5.4.5))
       '@tsconfig/node20':
         specifier: ^20.1.4
         version: 20.1.4
@@ -1086,12 +1086,6 @@ packages:
     engines: {node: ^22.14.0 || >= 24.10.0}
     peerDependencies:
       semantic-release: '>=24.1.0'
-
-  '@semantic-release/npm@12.0.1':
-    resolution: {integrity: sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=20.1.0'
 
   '@semantic-release/npm@13.1.5':
     resolution: {integrity: sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==}
@@ -3091,10 +3085,6 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-url@8.0.1:
-    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
-    engines: {node: '>=14.16'}
-
   normalize-url@9.0.0:
     resolution: {integrity: sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==}
     engines: {node: '>=20'}
@@ -3106,80 +3096,6 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npm@10.8.0:
-    resolution: {integrity: sha512-wh93uRczgp7HDnPMiLXcCkv2hagdJS0zJ9KT/31d0FoXP02+qgN2AOwpaW85fxRWkinl2rELfPw+CjBXW48/jQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   npm@11.13.0:
     resolution: {integrity: sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==}
@@ -5230,23 +5146,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@12.0.1(semantic-release@25.0.3(typescript@5.4.5))':
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 5.0.0
-      execa: 9.1.0
-      fs-extra: 11.2.0
-      lodash-es: 4.18.1
-      nerf-dart: 1.0.0
-      normalize-url: 8.0.1
-      npm: 10.8.0
-      rc: 1.2.8
-      read-pkg: 9.0.1
-      registry-auth-token: 5.0.2
-      semantic-release: 25.0.3(typescript@5.4.5)
-      semver: 7.6.2
-      tempy: 3.1.0
-
   '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@5.4.5))':
     dependencies:
       '@actions/core': 3.0.1
@@ -5263,7 +5162,7 @@ snapshots:
       read-pkg: 10.1.0
       registry-auth-token: 5.0.2
       semantic-release: 25.0.3(typescript@5.4.5)
-      semver: 7.6.2
+      semver: 7.7.4
       tempy: 3.1.0
 
   '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.3(typescript@5.4.5))':
@@ -7474,8 +7373,6 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  normalize-url@8.0.1: {}
-
   normalize-url@9.0.0: {}
 
   npm-run-path@4.0.1:
@@ -7485,8 +7382,6 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
-
-  npm@10.8.0: {}
 
   npm@11.13.0: {}
 


### PR DESCRIPTION
## Summary
- \`package.json\` explicitly pinned \`@semantic-release/npm@^12.0.1\`, which has no OIDC/trusted-publishing support (added only in v13.1.0).
- CI's release step relies on npm Trusted Publishing (\`release.yml\`'s \`id-token: write\` permission; no \`NPM_TOKEN\`/\`NODE_AUTH_TOKEN\` configured anywhere), and currently only works because \`semantic-release@25\` bundles its own dependency on \`@semantic-release/npm@13.1.5\`, which happens to win plugin resolution ahead of the explicitly pinned 12.0.1 - an accident of pnpm's hoisting layout, not something the declared version range actually guarantees.
- If dependency resolution ever shifts (a different pnpm hoisting config, a lockfile change, switching package managers), the pinned 12.0.1 would be used instead, and publishing would fail with a confusing \"No npm token specified\" error that looks nothing like a version-pin problem.

## Fix
Bumped the explicit pin to \`^13.1.5\` (the version already resolved in the lockfile) so the declared range matches what's actually required, and regenerated the lockfile - this also drops the now-fully-deduplicated \`@semantic-release/npm@12.0.1\` entry and its bundled \`npm@10.8.0\` transitive tree.

## Test plan
- [x] \`pnpm install\` - lockfile regenerated, single deduplicated \`@semantic-release/npm@13.1.5\`
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm test:ci\` - 70 suites / 1214 tests pass
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #88