### PR TITLE
fix: recognize CIDR and IPv6 IP-blocking rules on Cloudflare fetchConfig

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -665,18 +665,32 @@ export class CloudflareFirewallService extends BaseFirewallService {
   }
 
   /**
-   * Check if a Cloudflare rule is a simple IP blocking rule
+   * Check if a Cloudflare rule is a simple IP blocking rule. Covers both
+   * forms `unifiedIPToCloudflare` emits: `ip.src eq <ip>` for a single
+   * IPv4/IPv6 address, and `ip.src in {<cidr>}` for a CIDR range (wirefilter's
+   * `eq` only matches a single literal, so CIDR ranges use the `in` set
+   * operator instead). The address pattern allows IPv4 dotted-decimal and
+   * IPv6 hex/colon forms.
    */
   private isIPBlockingRule(rule: CloudflareRule): boolean {
-    // Check if expression is simple IP equality
-    return /^ip\.src eq [\d.]+$/.test(rule.expression.trim())
+    const expression = rule.expression.trim()
+    return (
+      CloudflareFirewallService.IP_EQ_PATTERN.test(expression) ||
+      CloudflareFirewallService.IP_IN_SET_PATTERN.test(expression)
+    )
   }
+
+  private static readonly IP_EQ_PATTERN = /^ip\.src eq ([0-9a-fA-F:.]+)$/
+  private static readonly IP_IN_SET_PATTERN = /^ip\.src in \{([0-9a-fA-F:./]+)\}$/
 
   /**
    * Convert Cloudflare rule to IP rule
    */
   private cloudflareRuleToIPRule(rule: CloudflareRule): UnifiedIPRule {
-    const match = rule.expression.match(/ip\.src eq ([\d.]+)/)
+    const expression = rule.expression.trim()
+    const match =
+      expression.match(CloudflareFirewallService.IP_EQ_PATTERN) ||
+      expression.match(CloudflareFirewallService.IP_IN_SET_PATTERN)
     const ip = match?.[1] || ''
 
     // Extract hostname from description if present

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -221,6 +221,166 @@ describe('CloudflareFirewallService', () => {
       expect(config.ips?.[0]?.hostname).toBe('example.com')
     })
 
+    it('should recognize a CIDR IP-blocking rule using the `in {...}` set form (regression test)', async () => {
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'ip.src in {192.168.1.0/24}',
+            description: 'Block IP range (example.com)',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 0,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+      const config = await service.fetchConfig()
+
+      // Must round-trip as an IP rule, not a generic custom rule
+      expect(config.rules).toHaveLength(0)
+      expect(config.ips).toHaveLength(1)
+      expect(config.ips?.[0]?.ip).toBe('192.168.1.0/24')
+      expect(config.ips?.[0]?.hostname).toBe('example.com')
+    })
+
+    it('should recognize a plain IPv6 IP-blocking rule (regression test)', async () => {
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'ip.src eq 2001:db8::1',
+            description: 'Block specific IP (example.com)',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 0,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+      const config = await service.fetchConfig()
+
+      expect(config.rules).toHaveLength(0)
+      expect(config.ips).toHaveLength(1)
+      expect(config.ips?.[0]?.ip).toBe('2001:db8::1')
+      expect(config.ips?.[0]?.hostname).toBe('example.com')
+    })
+
+    it('should recognize an IPv6 CIDR IP-blocking rule using the `in {...}` set form (regression test)', async () => {
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'ip.src in {2001:db8::/32}',
+            description: 'Block IP range',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 0,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+      const config = await service.fetchConfig()
+
+      expect(config.rules).toHaveLength(0)
+      expect(config.ips).toHaveLength(1)
+      expect(config.ips?.[0]?.ip).toBe('2001:db8::/32')
+    })
+
+    it('should not misclassify a List-based IP rule as a CIDR set-literal rule', async () => {
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'ip.src in $doorman_ip_blocklist',
+            description: 'Block IPs in Doorman IP Blocklist',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 0,
+        num_referencing_filters: 1,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+      const config = await service.fetchConfig()
+
+      // List-based rules are skipped from both `rules` and inline `ips`
+      // (their IPs are fetched separately from the Cloudflare List)
+      expect(config.rules).toHaveLength(0)
+      expect(config.ips).toHaveLength(0)
+    })
+
     it('should continue if Lists API fails', async () => {
       const mockRuleset: CloudflareRuleset = {
         id: 'ruleset-1',


### PR DESCRIPTION
## Summary
- `isListBasedIPRule`/`isIPBlockingRule`/`cloudflareRuleToIPRule` in `CloudflareFirewallService` only recognized the plain `ip.src eq <ipv4>` form when parsing rules fetched back from Cloudflare.
- They did not match:
  1. CIDR ranges emitted as `ip.src in {<cidr>}` (the format `RuleTranslator.unifiedIPToCloudflare` emits for CIDR values, since wirefilter's `eq` only matches a single literal — see #86 / #120).
  2. Any IPv6 address, CIDR or not (`[\d.]+` doesn't match `:` or hex digits).
- Net effect: a CIDR or IPv6 IP-blocking rule created via `doorman sync` reached Cloudflare fine, but on the next `download`/`status`/`diff`/`sync` it wasn't recognized as an IP rule at all — misclassified as a generic custom rule or silently dropped from the reconstructed `ips` array, breaking round-tripping and potentially causing `sync` to think the rule needs to be re-created every run.
- Fix: broadened the recognition/parsing patterns to cover IPv4 and IPv6 addresses in both the `eq` and `in {...}` (set-literal) forms, while keeping the existing `in $list_name` List-based detection unambiguous (no overlap since it requires a literal `$` where the set-literal form has `{`).

## Test plan
- [x] Added regression tests to `CloudflareFirewallService.test.ts` covering `fetchConfig` round-tripping: a CIDR IP rule (`ip.src in {192.168.1.0/24}`), a plain IPv6 rule (`ip.src eq 2001:db8::1`), an IPv6 CIDR rule (`ip.src in {2001:db8::/32}`), and a check that List-based rules (`ip.src in $doorman_ip_blocklist`) still aren't misclassified.
- [x] `pnpm test:ci` — 70 suites / 1218 passed (3 pre-existing skips)
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — no new warnings/errors