### PR TITLE
fix: stop prompting for Vercel credentials twice on first run

### DIFF
--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -55,7 +55,7 @@ describe('providerHelper', () => {
       process.env.VERCEL_PROJECT_ID = 'proj'
       process.env.VERCEL_TEAM_ID = 'team'
 
-      const provider = await getProviderInstance({
+      const { provider } = await getProviderInstance({
         provider: 'vercel',
         interactive: false,
       })
@@ -67,7 +67,7 @@ describe('providerHelper', () => {
       process.env.CLOUDFLARE_API_TOKEN = 'token'
       process.env.CLOUDFLARE_ZONE_ID = 'zone'
 
-      const provider = await getProviderInstance({
+      const { provider } = await getProviderInstance({
         provider: 'cloudflare',
         interactive: false,
       })
@@ -85,7 +85,7 @@ describe('providerHelper', () => {
       process.env.VERCEL_PROJECT_ID = 'proj'
       process.env.VERCEL_TEAM_ID = 'team'
 
-      const provider = await getProviderInstance({ interactive: false })
+      const { provider } = await getProviderInstance({ interactive: false })
       expect(provider.name).toBe('vercel')
     })
 
@@ -99,8 +99,34 @@ describe('providerHelper', () => {
       process.env.VERCEL_PROJECT_ID = 'proj'
       process.env.VERCEL_TEAM_ID = 'team'
 
-      const provider = await getProviderInstance({ interactive: false })
+      const { provider } = await getProviderInstance({ interactive: false })
       expect(provider.name).toBe('vercel')
+    })
+
+    it('returns the resolved Vercel credentials so callers do not have to re-prompt (regression test for #93)', async () => {
+      const { provider, vercelCredentials } = await getProviderInstance({
+        provider: 'vercel',
+        token: 'my-token',
+        projectId: 'my-project',
+        teamId: 'my-team',
+        interactive: false,
+      })
+      expect(provider.name).toBe('vercel')
+      expect(vercelCredentials).toEqual({
+        token: 'my-token',
+        projectId: 'my-project',
+        teamId: 'my-team',
+      })
+    })
+
+    it('does not populate vercelCredentials for the Cloudflare provider', async () => {
+      const { vercelCredentials } = await getProviderInstance({
+        provider: 'cloudflare',
+        apiToken: 'cf-token',
+        zoneId: 'cf-zone',
+        interactive: false,
+      })
+      expect(vercelCredentials).toBeUndefined()
     })
 
     it('passes explicit credentials to Vercel provider', async () => {

--- a/src/lib/utils/__tests__/withCredentials.test.ts
+++ b/src/lib/utils/__tests__/withCredentials.test.ts
@@ -1,0 +1,57 @@
+jest.mock('../../logger', () => ({ logger: require('../../../tests/testHelpers/loggerMock').createLoggerMock() }))
+
+const promptMock = jest.fn()
+jest.mock('../../ui/prompt', () => ({ prompt: (...args: unknown[]) => promptMock(...args) }))
+
+import { withCredentials } from '../withCredentials'
+
+describe('withCredentials', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.VERCEL_TOKEN
+    delete process.env.VERCEL_PROJECT_ID
+    delete process.env.VERCEL_TEAM_ID
+    promptMock.mockImplementation((message: string) => {
+      if (message.includes('Auth Token')) return Promise.resolve('prompted-token')
+      if (message.includes('Team ID')) return Promise.resolve('prompted-team')
+      if (message.includes('Project ID')) return Promise.resolve('prompted-project')
+      throw new Error(`Unexpected prompt: ${message}`)
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('prompts for missing Vercel credentials only once, not twice (regression test for #93)', async () => {
+    let receivedToken = ''
+    let receivedProjectId = ''
+    let receivedTeamId = ''
+
+    await withCredentials(
+      {
+        provider: 'vercel',
+        // No config path and no on-disk config — 'optional' mode returns an
+        // empty config without touching ConfigFinder's filesystem walk.
+        config: '/nonexistent/.doorman.json',
+        optionalConfig: true,
+        ci: false,
+        errorContext: 'test',
+      },
+      async (ctx) => {
+        receivedToken = ctx.token
+        receivedProjectId = ctx.projectId
+        receivedTeamId = ctx.teamId
+      },
+    )
+
+    // One prompt each for token, team ID, and project ID — three total, not six.
+    expect(promptMock).toHaveBeenCalledTimes(3)
+    expect(receivedToken).toBe('prompted-token')
+    expect(receivedProjectId).toBe('prompted-project')
+    expect(receivedTeamId).toBe('prompted-team')
+  })
+})

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -25,12 +25,25 @@ export interface ProviderOptions {
   accountId?: string
 }
 
+export interface ProviderInstanceResult {
+  provider: IFirewallProvider
+  /**
+   * Resolved Vercel credentials, populated only when `provider.name` is
+   * `'vercel'`. Callers that need the raw token/projectId/teamId (e.g. for
+   * legacy `VercelClient` construction) should use these rather than
+   * re-resolving credentials themselves — resolution here may already have
+   * prompted the user interactively, and prompting again would ask for the
+   * same values a second time.
+   */
+  vercelCredentials?: { token: string; projectId: string; teamId: string }
+}
+
 /**
  * Get provider instance with automatic detection and credential prompting
  * @param options - Provider options including credentials and config
- * @returns IFirewallProvider instance
+ * @returns The resolved provider, plus Vercel credentials when applicable
  */
-export async function getProviderInstance(options: ProviderOptions): Promise<IFirewallProvider> {
+export async function getProviderInstance(options: ProviderOptions): Promise<ProviderInstanceResult> {
   // 1. Determine which provider to use
   let providerType: ProviderType
 
@@ -63,7 +76,8 @@ export async function getProviderInstance(options: ProviderOptions): Promise<IFi
     if (providerType === 'vercel') {
       return await getVercelProvider(options)
     } else if (providerType === 'cloudflare') {
-      return await getCloudflareProvider(options)
+      const provider = await getCloudflareProvider(options)
+      return { provider }
     } else {
       throw new Error(`Unknown provider: ${providerType}`)
     }
@@ -76,7 +90,7 @@ export async function getProviderInstance(options: ProviderOptions): Promise<IFi
 /**
  * Get Vercel provider instance
  */
-async function getVercelProvider(options: ProviderOptions): Promise<IFirewallProvider> {
+async function getVercelProvider(options: ProviderOptions): Promise<ProviderInstanceResult> {
   const token = options.token || process.env.VERCEL_TOKEN
 
   // Type guard for accessing Vercel-specific properties
@@ -104,18 +118,20 @@ async function getVercelProvider(options: ProviderOptions): Promise<IFirewallPro
       teamId,
     })
 
-    return VercelProvider.fromConfig({
+    const provider = VercelProvider.fromConfig({
       token: credentials.token,
       projectId: credentials.projectId,
       teamId: credentials.teamId,
     })
+    return { provider, vercelCredentials: credentials }
   }
 
-  return VercelProvider.fromConfig({
+  const provider = VercelProvider.fromConfig({
     token,
     projectId,
     teamId,
   })
+  return { provider, vercelCredentials: { token, projectId, teamId } }
 }
 
 /**

--- a/src/lib/utils/withCredentials.ts
+++ b/src/lib/utils/withCredentials.ts
@@ -4,7 +4,6 @@ import type { IFirewallProvider, ProviderType } from '../providers/IFirewallProv
 import { FirewallService } from '../services/FirewallService'
 import { VercelClient } from '../services/VercelClient'
 import { FirewallConfig } from '../types'
-import { promptForCredentials } from '../ui/promptForCredentials'
 import { getConfig } from './config'
 import { handleCommandError } from './handleCommandError'
 import { getProviderInstance } from './providerHelper'
@@ -100,7 +99,7 @@ export async function withCredentials(
     }
 
     // 2. Get provider instance (handles credential resolution for both providers)
-    const provider = await getProviderInstance({
+    const { provider, vercelCredentials } = await getProviderInstance({
       provider: options.provider,
       config,
       interactive: !options.ci,
@@ -122,16 +121,13 @@ export async function withCredentials(
     let projectId = ''
     let teamId = ''
 
-    if (provider.name === 'vercel') {
-      // Resolve Vercel credentials for the legacy context fields
-      const resolved = await promptForCredentials({
-        token: options.token,
-        projectId: options.projectId || config.projectId,
-        teamId: options.teamId || config.teamId,
-      })
-      token = resolved.token
-      projectId = resolved.projectId
-      teamId = resolved.teamId
+    if (provider.name === 'vercel' && vercelCredentials) {
+      // Reuse the credentials getProviderInstance already resolved above —
+      // re-resolving here via promptForCredentials would ask an interactive
+      // user for the same token/projectId/teamId a second time.
+      token = vercelCredentials.token
+      projectId = vercelCredentials.projectId
+      teamId = vercelCredentials.teamId
       client = new VercelClient(projectId, teamId, token)
       service = new FirewallService(client)
     } else {


### PR DESCRIPTION
## Summary
- \`getProviderInstance\`'s \`getVercelProvider\` already resolves missing token/projectId/teamId, prompting interactively when needed.
- \`withCredentials\` then unconditionally called \`promptForCredentials\` a second time for \`provider.name === 'vercel'\`, passing only \`options\`/\`config\` values - not the values that were just entered - so a brand-new interactive user running \`doorman sync\` with no env vars/config/flags got asked for the Vercel token, team ID, and project ID twice in a row in the same command invocation.
- Fix: \`getProviderInstance\` now returns the resolved Vercel credentials alongside the provider (\`vercelCredentials\`), and \`withCredentials\` reuses them directly instead of re-resolving from scratch.

## Test plan
- [x] Added a regression test at the \`providerHelper\` level confirming \`vercelCredentials\` is returned and matches the resolved values.
- [x] Added a new \`withCredentials.test.ts\` that mocks the interactive \`prompt\` function and asserts it's called exactly 3 times (token, team ID, project ID), not 6, when running with no credentials provided.
- [x] \`pnpm test -- src/lib/utils/__tests__/providerHelper.test.ts src/lib/utils/__tests__/withCredentials.test.ts\` - 16/16 pass
- [x] \`pnpm test:ci\` - 71 suites / 1217 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #93