### PR TITLE
fix: retry() re-throws the original error instead of a generic wrapper

### DIFF
--- a/src/lib/providers/cloudflare/__tests__/CloudflareRetryLogic.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareRetryLogic.test.ts
@@ -136,9 +136,10 @@ describe('Cloudflare Retry Logic and Backoff Behavior', () => {
         throw new Error('Persistent failure')
       }
 
-      await expect(retry(operation, { maxAttempts: 2, delayMs: 100 })).rejects.toThrow(
-        'Operation failed after 2 attempts',
-      )
+      // retry() re-throws the original error after exhausting attempts (see
+      // #94) rather than wrapping it in a generic Error, so handleCommandError
+      // can still branch on the real error's type/name/code.
+      await expect(retry(operation, { maxAttempts: 2, delayMs: 100 })).rejects.toThrow('Persistent failure')
 
       expect(attemptCount).toBe(2)
     })
@@ -362,9 +363,7 @@ describe('Cloudflare Retry Logic and Backoff Behavior', () => {
         }
       }
 
-      await expect(retry(operation, { maxAttempts: 3, delayMs: 100 })).rejects.toThrow(
-        'Operation failed after 3 attempts',
-      )
+      await expect(retry(operation, { maxAttempts: 3, delayMs: 100 })).rejects.toThrow('Persistent failure')
 
       expect(attemptCount).toBe(3)
       expect(cleanupMock).toHaveBeenCalledTimes(3)
@@ -383,7 +382,38 @@ describe('Cloudflare Retry Logic and Backoff Behavior', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(Error)
         expect((error as Error).message).toContain('Original failure')
+        // The exhausted-retries error must be the original error itself, not
+        // a rewrapped generic Error (see #94) — otherwise callers that branch
+        // on `instanceof ZodError`/`error.name`/`error.code` (handleCommandError)
+        // lose that information for anything routed through retry().
+        expect(error).toBe(originalError)
+        expect((error as Error).stack).toBe('Original stack trace')
       }
+    })
+
+    it('preserves a custom error subclass and its properties through retries (regression test for #94)', async () => {
+      class DoormanError extends Error {
+        code = 'CF_RATE_LIMITED'
+        constructor(message: string) {
+          super(message)
+          this.name = 'DoormanError'
+        }
+      }
+
+      const operation = async () => {
+        throw new DoormanError('rate limited')
+      }
+
+      let caught: unknown
+      try {
+        await retry(operation, { maxAttempts: 2, delayMs: 10 })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(DoormanError)
+      expect((caught as DoormanError).name).toBe('DoormanError')
+      expect((caught as DoormanError).code).toBe('CF_RATE_LIMITED')
     })
 
     it('should handle memory cleanup for long retry sequences', async () => {

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -27,5 +27,10 @@ export async function retry<T>(operation: () => Promise<T>, options: RetryOption
     }
   }
 
-  throw new Error(`Operation failed after ${maxAttempts} attempts. Last error: ${lastError?.message}`)
+  logger.debug(`Operation failed after ${maxAttempts} attempts.`)
+  // Re-throw the original error rather than wrapping it in a generic Error —
+  // handleCommandError branches on `instanceof ZodError` and
+  // `error.name === 'ValidationError'`, which would be unreachable if the
+  // error's type/stack/code were discarded here.
+  throw lastError ?? new Error(`Operation failed after ${maxAttempts} attempts`)
 }


### PR DESCRIPTION
## Summary
- \`retry()\` threw a fresh plain \`Error\` with a formatted message once retries were exhausted, instead of re-throwing (or wrapping while preserving) the original error - discarding its type, stack, and any custom properties.
- \`handleCommandError\` branches on \`instanceof ZodError\` and \`error.name === 'ValidationError'\`, which became unreachable for anything routed through \`retry()\` (used throughout \`FirewallService.ts\` and \`VercelFirewallService.ts\` for create/update/delete calls).
- **Failure scenario:** a \`ZodError\` or \`DoormanError\` with a \`.code\` thrown during a retried call surfaced to the user as a generic Error, losing the structured error code and specific handling/messaging \`handleCommandError\` was designed to provide.

## Fix
\`retry()\` now re-throws \`lastError\` itself after exhausting attempts (logging the attempt count via \`logger.debug\` instead of baking it into the error message).

## Test plan
- [x] Strengthened the existing "should preserve original error context through retries" test to assert the thrown error \`toBe\` the original error instance and preserves its stack, not just a message substring.
- [x] Added a regression test with a custom error subclass (\`name\`/\`code\` properties) confirming both survive through \`retry()\`.
- [x] Updated two other assertions in the same file that expected the old wrapped message (\`'Operation failed after N attempts'\`) to expect the original error's message instead.
- [x] \`pnpm test -- src/lib/providers/cloudflare/__tests__/CloudflareRetryLogic.test.ts\` - 18/18 pass
- [x] \`pnpm test:ci\` - 71 suites / 1218 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #94