### PR TITLE
fix: accept standard compressed IPv6 notation in Vercel validation

### DIFF
--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -1,3 +1,4 @@
+import { isIPv6 } from 'net'
 import type { ErrorObject } from 'ajv'
 import Ajv, { Ajv as AjvType } from 'ajv'
 import { z } from 'zod'
@@ -292,12 +293,7 @@ export class ValidationService {
       })
     }
 
-    const isValidIPv6 = (ip: string): boolean => {
-      // Simple IPv6 validation for 8 groups; extended forms are out of scope here
-      const hextets = ip.split(':')
-      if (hextets.length !== 8) return false
-      return hextets.every((h) => /^[0-9a-fA-F]{1,4}$/.test(h))
-    }
+    const isValidIPv6 = (ip: string): boolean => isIPv6(ip)
 
     const isV4 = isValidIPv4(ipPart)
     const isV6 = isValidIPv6(ipPart)

--- a/src/lib/services/__tests__/ValidationService.test.ts
+++ b/src/lib/services/__tests__/ValidationService.test.ts
@@ -236,4 +236,50 @@ describe('ValidationService', () => {
       expect(() => validator.validateConfig(config)).not.toThrow()
     })
   })
+
+  describe('IP address condition validation (regression tests for #95)', () => {
+    const configWithIP = (value: string): FirewallConfig => ({
+      rules: [
+        {
+          name: 'test-rule',
+          conditionGroup: [
+            {
+              conditions: [
+                {
+                  type: 'ip_address',
+                  op: 'eq',
+                  value,
+                },
+              ],
+            },
+          ],
+          action: {
+            mitigate: {
+              action: 'deny',
+            },
+          },
+          active: true,
+        },
+      ],
+    })
+
+    it.each(['::1', '2001:db8::1', 'fe80::1ff:fe23:4567:890a', '::', '2001:db8::/32'])(
+      'accepts the compressed IPv6 form %s',
+      (value) => {
+        expect(() => validator.validateConfig(configWithIP(value))).not.toThrow()
+      },
+    )
+
+    it('still accepts a plain IPv4 address', () => {
+      expect(() => validator.validateConfig(configWithIP('192.168.1.1'))).not.toThrow()
+    })
+
+    it('still accepts an IPv4 CIDR range', () => {
+      expect(() => validator.validateConfig(configWithIP('10.0.0.0/8'))).not.toThrow()
+    })
+
+    it('still rejects a malformed address', () => {
+      expect(() => validator.validateConfig(configWithIP('not-an-ip'))).toThrow(ValidationError)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- \`isValidIPv6\` in \`ValidationService.ts\` required exactly 8 colon-separated hextets, rejecting valid compressed forms like \`::1\` or \`2001:db8::1\`.
- A rule condition like \`{"type":"ip_address","op":"eq","value":"::1"}\` failed \`doorman validate\`/\`sync\` with \"invalid IP address in condition\" even though \`::1\` is a valid, commonly-used IPv6 address.
- Fix: replaced the hand-rolled regex with Node's built-in \`net.isIPv6\`, the same approach used to fix the equivalent Cloudflare-side validation gap in #87 (PR #121).

## Test plan
- [x] Added regression tests covering compressed IPv6 forms (\`::1\`, \`2001:db8::1\`, \`fe80::1ff:fe23:4567:890a\`, \`::\`, and an IPv6 CIDR range), confirmed plain IPv4/IPv4-CIDR still pass, and confirmed a malformed address is still rejected.
- [x] \`pnpm test -- src/lib/services/__tests__/ValidationService.test.ts\` - 15/15 pass
- [x] \`pnpm test:ci\` - 70 suites / 1223 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #95