### PR TITLE
fix: cap rate-limit wait derived from X-RateLimit-Reset at 1 minute

### DIFF
--- a/src/lib/providers/BaseFirewallClient.ts
+++ b/src/lib/providers/BaseFirewallClient.ts
@@ -241,16 +241,20 @@ export abstract class BaseFirewallClient {
    * Calculate wait time for rate limit with exponential backoff
    */
   private calculateRateLimitWait(attempt: number = 0): number {
+    const maxWait = 60000 // Cap at 1 minute
+
     if (this.rateLimitInfo.reset) {
       const now = Math.floor(Date.now() / 1000)
       const waitTime = (this.rateLimitInfo.reset - now) * 1000
-      return Math.max(waitTime, 1000) // Minimum 1 second
+      // A far-future X-RateLimit-Reset (e.g. an hour out) would otherwise
+      // block the command for the full duration on a single retry with no
+      // way to override — cap it the same way the exponential fallback below is.
+      return Math.min(Math.max(waitTime, 1000), maxWait) // Minimum 1 second, capped at 1 minute
     }
 
     // Use exponential backoff for rate limits when reset time is not available
     const baseWait = 5000 // 5 seconds base
     const exponentialWait = baseWait * Math.pow(2, attempt)
-    const maxWait = 60000 // Cap at 1 minute
 
     return Math.min(exponentialWait, maxWait)
   }

--- a/src/lib/providers/__tests__/BaseFirewallClient.test.ts
+++ b/src/lib/providers/__tests__/BaseFirewallClient.test.ts
@@ -85,6 +85,27 @@ describe('BaseFirewallClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('caps the rate-limit wait at 1 minute even when X-RateLimit-Reset is an hour out (regression test for #96)', async () => {
+    const delaySpy = jest.spyOn(client as unknown as { delay: (ms: number) => Promise<void> }, 'delay')
+    const now = Math.floor(Date.now() / 1000)
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          jsonBody: { message: 'Rate limit' },
+          headers: { 'X-RateLimit-Reset': String(now + 3600) }, // an hour out
+        }),
+      )
+      .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: { ok: true } }))
+
+    await client.getJson('/retry-far-future', { retries: 1, retryDelay: 1 })
+
+    expect(delaySpy).toHaveBeenCalledWith(60000)
+  })
+
   it('does not retry on 400 and throws formatted error', async () => {
     const fetchMock = jest
       .spyOn(globalThis, 'fetch')


### PR DESCRIPTION
## Summary
- \`calculateRateLimitWait\` computed \`(reset-now)*1000\` with only a 1s minimum and no maximum cap, unlike the exponential-backoff fallback branch a few lines below which caps at 60s.
- **Failure scenario:** a 429 response with \`X-RateLimit-Reset\` set an hour out made the CLI block for the full hour on a single retry, with no way to override - effectively hanging the command.
- Fix: cap the reset-derived wait at the same 60s maximum already used by the exponential-backoff fallback.

## Test plan
- [x] Added a regression test that returns a 429 with \`X-RateLimit-Reset\` an hour in the future and asserts the client waits exactly 60000ms (not 3,600,000ms).
- [x] \`pnpm test -- src/lib/providers/__tests__/BaseFirewallClient.test.ts\` - 7/7 pass
- [x] \`pnpm test:ci\` - 70 suites / 1223 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #96