### PR TITLE
fix: template command honors --config and warns on duplicate rule names

### DIFF
--- a/src/commands/__tests__/template.test.ts
+++ b/src/commands/__tests__/template.test.ts
@@ -1,5 +1,6 @@
 import { getConfig, saveConfig } from '../../lib/utils/config'
 import { logger } from '../../lib/logger'
+import { prompt } from '../../lib/ui/prompt'
 import { handler } from '../template'
 
 jest.mock('../../lib/logger', () => ({
@@ -8,6 +9,7 @@ jest.mock('../../lib/logger', () => ({
     start: jest.fn(),
     success: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
     info: jest.fn(),
     debug: jest.fn(),
   },
@@ -18,8 +20,13 @@ jest.mock('../../lib/utils/config', () => ({
   saveConfig: jest.fn(),
 }))
 
+jest.mock('../../lib/ui/prompt', () => ({
+  prompt: jest.fn(),
+}))
+
 const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
 const mockedSaveConfig = saveConfig as jest.MockedFunction<typeof saveConfig>
+const mockedPrompt = prompt as jest.MockedFunction<typeof prompt>
 
 describe('template command', () => {
   beforeEach(() => {
@@ -56,5 +63,66 @@ describe('template command', () => {
       'process.exit called with "1"',
     )
     expect(mockedSaveConfig).not.toHaveBeenCalled()
+  })
+
+  it('respects --config, loading and saving through the given path (regression test for #97)', async () => {
+    await handler({ name: 'wordpress', config: '/custom/.doorman.json', dryRun: false, debug: false } as any)
+
+    expect(mockedGetConfig).toHaveBeenCalledWith('/custom/.doorman.json', 'raw')
+    expect(mockedSaveConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      '/custom/.doorman.json',
+      expect.objectContaining({ validate: false }),
+    )
+  })
+
+  it('warns and cancels on a duplicate rule name when the user declines to proceed (regression test for #97)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Deny WordPress URLs',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/wp-admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+    mockedPrompt.mockResolvedValue(false as any)
+
+    await handler({ name: 'wordpress', dryRun: false, debug: false } as any)
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Deny WordPress URLs'))
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith('Cancelled.')
+  })
+
+  it('applies the template anyway when the user confirms past a duplicate warning', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Deny WordPress URLs',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/wp-admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+    mockedPrompt.mockResolvedValue(true as any)
+
+    await handler({ name: 'wordpress', dryRun: false, debug: false } as any)
+
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+    // Original rule plus the duplicate-named template rule, both retained.
+    expect((savedConfig as any).rules.length).toBe(2)
+  })
+
+  it('does not warn when running the template against an empty config', async () => {
+    await handler({ name: 'wordpress', dryRun: false, debug: false } as any)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -4,13 +4,14 @@ import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import { firewallConfigSchema } from '../lib/schemas/firewallSchemas'
 import { TemplateName, getTemplateConfig, templates } from '../lib/templates'
-import { FirewallConfig } from '../lib/types'
+import { CustomRule, FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
 
 interface TemplateOptions {
   name?: string
+  config?: string
   dryRun?: boolean
   debug?: boolean
 }
@@ -23,6 +24,11 @@ export const builder = {
     type: 'string',
     description: 'Name of the template to add',
   },
+  config: {
+    alias: 'c',
+    type: 'string',
+    description: 'Path to firewall config file (defaults to .doorman.json)',
+  },
   dryRun: {
     alias: 'd',
     type: 'boolean',
@@ -34,6 +40,16 @@ export const builder = {
     description: 'Enable debug logging',
     default: false,
   },
+}
+
+/**
+ * Check the incoming template rules for name collisions with the existing
+ * config, the same way add.ts's checkDuplicates does for a single rule.
+ */
+function findDuplicateNames(existingRules: CustomRule[], newRules: CustomRule[]): string[] {
+  const existingNames = new Set(existingRules.map((r) => r.name.toLowerCase()))
+  const duplicates = newRules.filter((rule) => existingNames.has(rule.name.toLowerCase())).map((rule) => rule.name)
+  return [...new Set(duplicates)]
 }
 
 const getAvailableTemplates = (): TemplateName[] => {
@@ -71,7 +87,8 @@ export const handler = async (argv: Arguments<TemplateOptions>) => {
     // Load config without validation — we're about to modify it,
     // so we validate the result instead of the input.
     logger.start('Loading current configuration...')
-    const config = await getConfig(undefined, 'raw')
+    const config = await getConfig(argv.config, 'raw')
+    const existingRules = config.rules || []
 
     if (argv.dryRun) {
       logger.info(chalk.cyan('\nDry run - The following rules would be added:'))
@@ -79,10 +96,25 @@ export const handler = async (argv: Arguments<TemplateOptions>) => {
       return
     }
 
+    // Check for rules that would collide with existing ones by name —
+    // otherwise re-running the same template silently appends duplicates.
+    const duplicateNames = findDuplicateNames(existingRules, templateConfig.rules)
+    if (duplicateNames.length > 0) {
+      logger.warn(chalk.yellow(`⚠️  Rule name(s) already exist in the configuration: ${duplicateNames.join(', ')}`))
+      const proceed = (await prompt('Proceed anyway?', {
+        type: 'confirm',
+        initial: false,
+      })) as boolean
+      if (!proceed) {
+        logger.info('Cancelled.')
+        return
+      }
+    }
+
     // Append the new rules to the existing configuration
     const updatedConfig: FirewallConfig = {
       ...config,
-      rules: [...config.rules, ...templateConfig.rules],
+      rules: [...existingRules, ...templateConfig.rules],
     }
 
     // Validate the resulting config before saving
@@ -98,7 +130,7 @@ export const handler = async (argv: Arguments<TemplateOptions>) => {
     }
 
     logger.start('Saving updated configuration...')
-    await saveConfig(updatedConfig, undefined, { validate: false })
+    await saveConfig(updatedConfig, argv.config, { validate: false })
     logger.success(chalk.green(`Successfully added template '${templateName}' to configuration`))
   } catch (error) {
     handleCommandError(error, 'adding template')


### PR DESCRIPTION
## Summary
Unlike every other mutating command, template.ts:
1. Always called getConfig(undefined, 'raw')/saveConfig(..., undefined, ...) regardless of --config.
2. Never checked for name collisions the way add.ts's checkDuplicates does for a single rule.

Failure scenario: running `doorman template wordpress` twice silently appended two identical un-ID'd "Deny WordPress URLs" rules; the next sync would create duplicate rules remotely since neither matches an existing remote rule in FirewallService.diffRules.

## Fix
- Added a --config/-c option, threaded through both getConfig and saveConfig, matching every other mutating command.
- Added a duplicate-name check across all of a template's incoming rules against the existing config's rule names (case-insensitive), warning and prompting to proceed - the same pattern add.ts already uses for a single rule.

## Test plan
- [x] Added a regression test confirming --config is passed through to both getConfig and saveConfig.
- [x] Added regression tests for the duplicate-name path: cancels and doesn't save when the user declines, applies anyway when confirmed, and doesn't warn at all against an empty config.
- [x] pnpm test -- src/commands/__tests__/template.test.ts - 7/7 pass
- [x] pnpm test:ci - 70 suites / 1219 tests pass
- [x] pnpm build - succeeds
- [x] pnpm lint - no new warnings/errors

Fixes #97