### PR TITLE
fix: give Vercel sync the same dry-run/confirmation safety as Cloudflare

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -235,7 +235,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
     }
 
     // Determine risk level based on changes
-    const riskLevel = this.assessOperationRisk(dryRunResult.changes, config)
+    const riskLevel = OperationSafety.assessOperationRisk(dryRunResult.changes, config)
 
     // Get user confirmation for destructive operations
     const confirmed = await OperationSafety.confirmDestructiveOperation({
@@ -739,62 +739,5 @@ export class CloudflareFirewallService extends BaseFirewallService {
     } else {
       logger.warn(`🚫 Unknown Lists API error during ${operation}. Falling back to individual IP rules.`)
     }
-  }
-
-  /**
-   * Assess the risk level of an operation based on changes and configuration
-   */
-  private assessOperationRisk(changes: ChangeSet, config: UnifiedConfig): 'low' | 'medium' | 'high' {
-    const totalRules = config.rules.length
-    const totalIPs = config.ips?.length || 0
-    const totalDeletions = (changes.rulesToDelete?.length || 0) + (changes.ipsToDelete?.length || 0)
-    const totalChanges =
-      (changes.rulesToAdd?.length || 0) +
-      (changes.rulesToUpdate?.length || 0) +
-      (changes.ipsToAdd?.length || 0) +
-      (changes.ipsToUpdate?.length || 0) +
-      totalDeletions
-
-    // High risk conditions
-    if (totalDeletions === totalRules && totalRules > 0) {
-      return 'high' // Deleting all rules
-    }
-
-    if (totalDeletions > 0 && totalDeletions / Math.max(totalRules + totalIPs, 1) > 0.5) {
-      return 'high' // Deleting more than 50% of existing rules/IPs
-    }
-
-    if (totalChanges > 50) {
-      return 'high' // Large number of changes
-    }
-
-    // Check for potentially dangerous rules
-    const hasDangerousRules = config.rules.some(
-      (rule) =>
-        rule.action.type === 'deny' &&
-        rule.conditions.some(
-          (condition) => condition.field === 'path' && (condition.value === '/' || condition.value === '*'),
-        ),
-    )
-
-    if (hasDangerousRules) {
-      return 'high'
-    }
-
-    // Medium risk conditions
-    if (totalDeletions > 0) {
-      return 'medium' // Any deletions
-    }
-
-    if (totalChanges > 10) {
-      return 'medium' // Moderate number of changes
-    }
-
-    if (changes.rulesToUpdate && changes.rulesToUpdate.length > 0) {
-      return 'medium' // Rule updates can be risky
-    }
-
-    // Low risk - only additions or small changes
-    return 'low'
   }
 }

--- a/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandlingComprehensive.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandlingComprehensive.test.ts
@@ -30,6 +30,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -27,6 +27,10 @@ jest.mock('../../../utils/operationSafety', () => ({
       warnings: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    // assessOperationRisk moved here from a CloudflareFirewallService-private
+    // method (shared with VercelFirewallService — see #104); tests don't
+    // assert on risk level here, so a fixed 'low' keeps the mock simple.
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareNetworkFailures.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareNetworkFailures.test.ts
@@ -28,6 +28,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareRetryLogic.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareRetryLogic.test.ts
@@ -31,6 +31,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareRuleScenarios.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareRuleScenarios.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       issues: [],
     }),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../utils/operationSafety', () => ({
       return { valid: true, changes, issues: [] }
     }),
     confirmDestructiveOperation: jest.fn<any>().mockResolvedValue(true as any),
+    assessOperationRisk: jest.fn<any>().mockReturnValue('low'),
   },
 }))
 

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -78,7 +78,25 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
     const { dryRun = false } = options
 
     try {
-      const changes = await this.getChanges(config)
+      // Import operation safety utilities — this gives Vercel the same
+      // dry-run validation/risk-assessment/confirmation safety check
+      // CloudflareFirewallService.syncRules already has. Previously this was
+      // scoped to Cloudflare only, so a destructive Vercel sync (e.g. one
+      // that deletes every remote rule due to a bad local config) proceeded
+      // with no dry-run check and no confirmation prompt.
+      const { OperationSafety } = require('../../utils/operationSafety')
+
+      const dryRunResult = await OperationSafety.performDryRunValidation(
+        config,
+        'sync rules',
+        async (cfg: UnifiedConfig) => await this.getChanges(cfg),
+      )
+
+      if (!dryRunResult.valid) {
+        throw new Error(`Dry-run validation failed: ${dryRunResult.issues.join(', ')}`)
+      }
+
+      const changes = dryRunResult.changes as ChangeSet & { version: number }
       const { rulesToAdd, rulesToUpdate, rulesToDelete, version } = changes
       const ipsToAdd = changes.ipsToAdd || []
       const ipsToUpdate = changes.ipsToUpdate || []
@@ -99,7 +117,22 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
           ipsUpdated: 0,
           ipsDeleted: 0,
           version,
+          warnings: dryRunResult.warnings,
         }
+      }
+
+      const riskLevel = OperationSafety.assessOperationRisk(changes, config)
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: `Vercel project ${this.client['projectId']}`,
+        changes,
+        riskLevel,
+        skipConfirmation: options.force || false,
+        dryRun: false,
+      })
+
+      if (!confirmed) {
+        throw new Error('Operation cancelled by user')
       }
 
       // Convert unified rules back to Vercel format for API calls

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -17,6 +17,8 @@ jest.mock('../../../utils/retry', () => ({
   retry: (fn: () => Promise<unknown>) => fn(),
 }))
 
+import { OperationSafety } from '../../../utils/operationSafety'
+
 describe('VercelFirewallService', () => {
   let service: VercelFirewallService
   let client: VercelClient
@@ -65,6 +67,11 @@ describe('VercelFirewallService', () => {
     client = new VercelClient('proj_123', 'team_456', 'test-token')
     service = new VercelFirewallService(client)
     jest.clearAllMocks()
+    // Auto-approve the destructive-operation confirmation prompt syncRules
+    // now performs (regression coverage for #104) — dry-run validation and
+    // risk assessment stay real so computed changes still flow through to
+    // the sync assertions below.
+    jest.spyOn(OperationSafety, 'confirmDestructiveOperation').mockResolvedValue(true)
   })
 
   describe('name', () => {
@@ -178,6 +185,74 @@ describe('VercelFirewallService', () => {
       expect(result.success).toBe(true)
       expect(result.rulesAdded).toBe(1)
       expect(result.ipsAdded).toBe(1)
+    })
+
+    it('asks for confirmation before applying a destructive sync, not just Cloudflare (regression test for #104)', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [],
+        ips: [],
+      })
+      jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+        id: 'new_rule_1',
+        name: 'Block bots',
+        active: true,
+        conditionGroup: [],
+        action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+      })
+      jest.spyOn(client, 'createIPBlockingRule').mockResolvedValue({
+        id: 'new_ip_1',
+        ip: '1.2.3.4',
+        hostname: 'example.com',
+        action: 'deny',
+      })
+
+      await service.syncRules(unifiedConfig)
+
+      expect(OperationSafety.confirmDestructiveOperation).toHaveBeenCalledTimes(1)
+      expect(OperationSafety.confirmDestructiveOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: 'sync rules', skipConfirmation: false }),
+      )
+    })
+
+    it('cancels the sync without calling the API when the user declines the confirmation', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [],
+        ips: [],
+      })
+      const createFirewallRuleSpy = jest.spyOn(client, 'createFirewallRule')
+      jest.spyOn(OperationSafety, 'confirmDestructiveOperation').mockResolvedValue(false)
+
+      await expect(service.syncRules(unifiedConfig)).rejects.toThrow('Failed to synchronize firewall rules')
+      expect(createFirewallRuleSpy).not.toHaveBeenCalled()
+    })
+
+    it('skips the confirmation prompt entirely when force is set', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [],
+        ips: [],
+      })
+      jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+        id: 'new_rule_1',
+        name: 'Block bots',
+        active: true,
+        conditionGroup: [],
+        action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+      })
+      jest.spyOn(client, 'createIPBlockingRule').mockResolvedValue({
+        id: 'new_ip_1',
+        ip: '1.2.3.4',
+        hostname: 'example.com',
+        action: 'deny',
+      })
+
+      await service.syncRules(unifiedConfig, { force: true })
+
+      expect(OperationSafety.confirmDestructiveOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ skipConfirmation: true }),
+      )
     })
 
     it('should throw on error', async () => {

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -163,6 +163,65 @@ export class OperationSafety {
   }
 
   /**
+   * Assess the risk level of an operation based on changes and configuration.
+   * Shared across providers so both get the same dry-run/confirmation safety
+   * checks, rather than each provider maintaining its own copy.
+   */
+  public static assessOperationRisk(changes: ChangeSet, config: UnifiedConfig): 'low' | 'medium' | 'high' {
+    const totalRules = config.rules.length
+    const totalIPs = config.ips?.length || 0
+    const totalDeletions = (changes.rulesToDelete?.length || 0) + (changes.ipsToDelete?.length || 0)
+    const totalChanges =
+      (changes.rulesToAdd?.length || 0) +
+      (changes.rulesToUpdate?.length || 0) +
+      (changes.ipsToAdd?.length || 0) +
+      (changes.ipsToUpdate?.length || 0) +
+      totalDeletions
+
+    // High risk conditions
+    if (totalDeletions === totalRules && totalRules > 0) {
+      return 'high' // Deleting all rules
+    }
+
+    if (totalDeletions > 0 && totalDeletions / Math.max(totalRules + totalIPs, 1) > 0.5) {
+      return 'high' // Deleting more than 50% of existing rules/IPs
+    }
+
+    if (totalChanges > 50) {
+      return 'high' // Large number of changes
+    }
+
+    // Check for potentially dangerous rules
+    const hasDangerousRules = config.rules.some(
+      (rule) =>
+        rule.action.type === 'deny' &&
+        rule.conditions.some(
+          (condition) => condition.field === 'path' && (condition.value === '/' || condition.value === '*'),
+        ),
+    )
+
+    if (hasDangerousRules) {
+      return 'high'
+    }
+
+    // Medium risk conditions
+    if (totalDeletions > 0) {
+      return 'medium' // Any deletions
+    }
+
+    if (totalChanges > 10) {
+      return 'medium' // Moderate number of changes
+    }
+
+    if (changes.rulesToUpdate && changes.rulesToUpdate.length > 0) {
+      return 'medium' // Rule updates can be risky
+    }
+
+    // Low risk - only additions or small changes
+    return 'low'
+  }
+
+  /**
    * Get backup recommendation for operation
    */
   public static getBackupRecommendation(operation: string, riskLevel: 'low' | 'medium' | 'high'): BackupRecommendation {


### PR DESCRIPTION
## Summary
- OperationSafety's docstring explicitly scoped it to "Cloudflare operations", and VercelFirewallService.syncRules never called it.
- A destructive Vercel sync (e.g. one that deletes every remote rule due to a bad local config) proceeded with no dry-run structural validation and no confirmation prompt, unlike the equivalent Cloudflare path.

## Fix
- Extracted assessOperationRisk out of CloudflareFirewallService (it was a private method operating purely on generic ChangeSet/UnifiedConfig, no Cloudflare-specific logic) into a shared OperationSafety.assessOperationRisk static method.
- Wired VercelFirewallService.syncRules through the same performDryRunValidation -> assessOperationRisk -> confirmDestructiveOperation flow CloudflareFirewallService.syncRules already uses, respecting the existing `force` option to skip confirmation (same as Cloudflare).

Note: neither sync.ts nor watch.ts currently route Vercel traffic through this IFirewallProvider.syncRules path today (they use the legacy FirewallService wrapper, which has its own inline confirmation prompt in sync.ts, and watch.ts intentionally auto-syncs without prompting for both providers). This fix closes the gap in the shared IFirewallProvider contract itself, so any current or future caller that treats providers polymorphically gets consistent safety behavior - exactly what the issue asked for ("extract the risk-assessment/confirmation logic so both providers share it").

## Test plan
- [x] Added regression tests confirming syncRules now calls confirmDestructiveOperation before applying changes, cancels without calling the API when the user declines, and skips confirmation entirely when `force` is set.
- [x] Updated CloudflareFirewallService's syncRules call site and 7 test files' OperationSafety mocks to include the now-shared assessOperationRisk (previously private, so untested by mocks).
- [x] `pnpm test -- src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts` - 69/69 pass
- [x] `pnpm test:ci` - 70 suites / 1217 tests pass
- [x] `pnpm build` - succeeds
- [x] `pnpm lint` - no new warnings/errors

Fixes #104