### PR TITLE
ci: add a pull_request workflow so PRs get lint/test/build feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - main
+      - beta
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Lint, Test, Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+
+      - name: Install pnpm
+        run: npm i pnpm@10 -g
+
+      # Frozen lockfile: a PR that changes package.json without updating
+      # pnpm-lock.yaml should fail fast here, not silently resolve to
+      # whatever the CI runner happens to pick (see #88).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test:ci
+
+      - name: Build
+        run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@
   - `feat!:` or `BREAKING CHANGE:` footer → major bump (1.x → 2.0.0)
   - `chore:`, `docs:`, `ci:`, `test:` → no release
 - **Beta → Stable**: Merge `beta` into `main` to promote. Add `BREAKING CHANGE:` footer if major bump desired.
-- **CI/CD**: GitHub Actions workflow (`.github/workflows/release.yml`) runs on both `main` and `beta` branches.
+- **CI/CD**: `.github/workflows/ci.yml` runs lint/test/build on every PR targeting `main` or `beta`. `.github/workflows/release.yml` runs the same checks plus build/publish on every push to `main` or `beta`.
 - **Husky hooks**: Disabled during semantic-release commits via `HUSKY=0` env var in CI.
 
 ## Security & Configuration Tips

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ All commands accept `--provider vercel|cloudflare` (auto-detected if not specifi
 - **Test Coverage:** 141+ passing Vercel tests, 26+ passing Cloudflare test suites
 - **Test Structure:** Integration tests, edge cases, validation, sync/download
 - **Mocking:** Mock VercelClient, process.exit, and external dependencies
-- **CI/CD:** Tests run on every push to main and beta via GitHub Actions
+- **CI/CD:** Lint/test/build run on every PR targeting main or beta (`.github/workflows/ci.yml`); the full release pipeline (lint/test/build/publish) runs again on every push to main or beta (`.github/workflows/release.yml`)
 - **Skipped Tests:** Some Cloudflare tests temporarily skipped in jest.config.js (timeout/mock issues)
 
 ## Security & Dependencies


### PR DESCRIPTION
## Summary
- release.yml only triggers on push to main/beta; there was no pull_request trigger anywhere in .github/workflows.
- CLAUDE.md's claim "Tests run on every push to main and beta" was technically true but misleading - PRs and feature branches got zero automated lint/test/build feedback before merge.
- Failure scenario: a broken PR merges to main with no CI signal; the first automated test run happens after the code already lands on the protected branch, at which point a failure blocks release but the bad commit is already merged.

## Fix
- Added .github/workflows/ci.yml - lint/test/build (no publish step) on every PR targeting main or beta.
- Uses `pnpm install --frozen-lockfile` (release.yml intentionally uses `--no-frozen-lockfile` for its own reasons) so a PR that changes package.json without updating pnpm-lock.yaml fails fast here, instead of resolving silently differently later (related to #88).
- Updated CLAUDE.md/AGENTS.md's CI/CD descriptions to describe both workflows accurately.

## Test plan
- [x] Validated the new workflow YAML parses correctly and mirrors release.yml's proven checkout/setup-node/pnpm steps.
- [x] `pnpm test:ci` - 70 suites / 1218 tests pass
- [x] `pnpm build` - succeeds
- [x] `pnpm lint` - no new warnings/errors

Fixes #91