### PR TITLE
docs: fix CLAUDE.md/AGENTS.md's false skipped-Cloudflare-tests claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - Location: co-locate as `*.test.ts` or use `src/tests/`.
 - Mocks: place under `src/tests/__mocks__/` (e.g., `chalk.ts`).
 - Run a single test: `pnpm test -- src/tests/validation.test.ts`.
-- Some Cloudflare provider tests are temporarily skipped in `jest.config.js` (pre-existing timeout/mock issues).
+- 3 Vercel sync integration tests are skipped inline (`test.skip(...)` in `src/tests/commands.integration.test.ts`), not Cloudflare tests, and not via `jest.config.js` (which has no skip configuration).
 
 ## Commit & Pull Request Guidelines
 - Commits: Conventional Commits enforced by commitlint. Use `pnpm commit` (commitizen) for prompts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ All commands accept `--provider vercel|cloudflare` (auto-detected if not specifi
 - **Test Structure:** Integration tests, edge cases, validation, sync/download
 - **Mocking:** Mock VercelClient, process.exit, and external dependencies
 - **CI/CD:** Lint/test/build run on every PR targeting main or beta (`.github/workflows/ci.yml`); the full release pipeline (lint/test/build/publish) runs again on every push to main or beta (`.github/workflows/release.yml`)
-- **Skipped Tests:** Some Cloudflare tests temporarily skipped in jest.config.js (timeout/mock issues)
+- **Skipped Tests:** 3 Vercel sync integration tests are skipped inline (`test.skip(...)` in `src/tests/commands.integration.test.ts`), not Cloudflare tests, and not via `jest.config.js` (which has no skip configuration)
 
 ## Security & Dependencies
 - **Audit Level:** Moderate severity threshold in CI/CD


### PR DESCRIPTION
## Summary
- Both CLAUDE.md and AGENTS.md stated Cloudflare tests are "temporarily skipped in jest.config.js (timeout/mock issues)".
- jest.config.js has no skip configuration, and grepping all Cloudflare test files finds zero .skip/.xit calls.
- The actual 3 skipped tests are Vercel sync tests (test.skip(...) inline in src/tests/commands.integration.test.ts:245,357,427), not Cloudflare.
- A contributor trusting this line would misdiagnose Cloudflare test gaps or waste time looking for skip config that doesn't exist, while the real skipped coverage (Vercel sync edge cases) goes unnoticed.

## Fix
Corrected both docs to accurately describe the 3 skipped Vercel sync integration tests and where they're actually skipped.

Fixes #92