### PR TITLE
fix: stop leaking partial API tokens into debug logs

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareClient.ts
+++ b/src/lib/providers/cloudflare/CloudflareClient.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { BaseFirewallClient } from '../BaseFirewallClient'
 import { logger } from '../../logger'
 import { providerErrors, cloudflareErrors } from '../../errors'
@@ -423,7 +424,10 @@ export class CloudflareClient extends BaseFirewallClient {
    */
   public async verifyCredentials(): Promise<boolean> {
     // Check cache for recent successful validation
-    const tokenHash = this.apiToken.slice(-8) // Use last 8 chars as a safe hash
+    // A real hash, not a raw token substring — cache.ts logs this key verbatim
+    // under --debug (`Cache set: cred:<hash> ...`), and a substring of the
+    // actual token would leak a fragment of the secret into those logs.
+    const tokenHash = createHash('sha256').update(this.apiToken).digest('hex').slice(0, 8)
     const cacheKey = CacheKeys.credentialValidation(tokenHash)
     const cached = this.cache.get<boolean>(cacheKey)
     if (cached !== undefined) {

--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -405,6 +405,27 @@ describe('CloudflareClient', () => {
 
       expect(result).toBe(false)
     })
+
+    it('never leaks a fragment of the real API token into debug logs (regression test for #101)', async () => {
+      const mockResponse: CloudflareAPIResponse<CloudflareRuleset[]> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: [],
+      }
+      fetchMock.mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: mockResponse }))
+
+      await client.verifyCredentials()
+      // Second call hits the cache, which logs the cache key — the exact
+      // path where a raw token substring used to leak (see #101).
+      await client.verifyCredentials()
+
+      const debugMock = require('../../../logger').logger.debug as jest.Mock
+      const loggedText = debugMock.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+      // The cache key is derived from the token — assert it's not just the
+      // token's own last 8 characters (the old "safe hash").
+      expect(loggedText).not.toContain(API_TOKEN.slice(-8))
+    })
   })
 
   describe('getZoneInfo', () => {

--- a/src/lib/providers/vercel/VercelProvider.ts
+++ b/src/lib/providers/vercel/VercelProvider.ts
@@ -61,7 +61,6 @@ export class VercelProvider {
     logger.debug('Creating Vercel provider with config:', {
       projectId,
       teamId,
-      token: token.substring(0, 10) + '...',
     })
 
     const client = new VercelClient(projectId, teamId, token)

--- a/src/lib/providers/vercel/__tests__/VercelProvider.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelProvider.test.ts
@@ -1,0 +1,42 @@
+const debugMock = jest.fn()
+jest.mock('../../../logger', () => ({
+  logger: { debug: (...args: unknown[]) => debugMock(...args), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+import { VercelProvider } from '../VercelProvider'
+
+describe('VercelProvider', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    debugMock.mockClear()
+    process.env = { ...originalEnv }
+    delete process.env.VERCEL_TOKEN
+    delete process.env.VERCEL_PROJECT_ID
+    delete process.env.VERCEL_TEAM_ID
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  describe('fromConfig', () => {
+    it('never logs any fragment of the API token, even under debug (regression test for #101)', () => {
+      const secretToken = 'vercel_super_secret_token_12345'
+
+      VercelProvider.fromConfig({
+        token: secretToken,
+        projectId: 'prj_123',
+        teamId: 'team_456',
+      })
+
+      const loggedText = debugMock.mock.calls.map((call) => JSON.stringify(call)).join('\n')
+      expect(loggedText).not.toContain(secretToken)
+      expect(loggedText).not.toContain(secretToken.substring(0, 10))
+    })
+
+    it('throws when token is missing', () => {
+      expect(() => VercelProvider.fromConfig({ projectId: 'p', teamId: 't' })).toThrow('Vercel API token is required')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- VercelProvider logged token.substring(0,10)+'...' under --debug.
- CloudflareClient used apiToken.slice(-8) as a "cache key" (mislabeled a hash), which cache.ts's debug logging then prints verbatim (e.g. "Cache set: cred:aB3dEf12 ...").
- Failure scenario: running any command with --debug in a CI log or shared terminal session prints partial real token fragments to stdout - not enough alone to reconstruct the token, but unnecessary partial secret disclosure in logs that may be retained or shared.

## Fix
- Dropped the token entirely from VercelProvider's debug log (projectId/teamId are enough for debugging context).
- Replaced the raw token substring with an actual SHA-256 hash (truncated to 8 hex chars, same length as before) for CloudflareClient's credential-validation cache key, so the logged cache key no longer contains any fragment of the real secret.

## Test plan
- [x] Added a regression test asserting no VercelProvider debug log call contains any fragment of the token.
- [x] Added a regression test asserting the Cloudflare credential-validation cache key (which gets logged under --debug on cache hit/set) doesn't contain the token's actual trailing characters.
- [x] `pnpm test -- src/lib/providers/vercel/__tests__/VercelProvider.test.ts src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts` - 45/45 pass
- [x] `pnpm test:ci` - 71 suites / 1221 tests pass
- [x] `pnpm build` - succeeds
- [x] `pnpm lint` - no new warnings/errors

Fixes #101