### PR TITLE
fix: mask API token input instead of echoing it in plaintext

### DIFF
--- a/src/lib/ui/__tests__/promptForCredentials.test.ts
+++ b/src/lib/ui/__tests__/promptForCredentials.test.ts
@@ -1,0 +1,44 @@
+const promptMock = jest.fn()
+const promptSecretMock = jest.fn()
+jest.mock('../prompt', () => ({ prompt: (...args: unknown[]) => promptMock(...args) }))
+jest.mock('../promptSecret', () => ({ promptSecret: (...args: unknown[]) => promptSecretMock(...args) }))
+
+import { promptForCredentials } from '../promptForCredentials'
+
+describe('promptForCredentials', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.VERCEL_TOKEN
+    delete process.env.VERCEL_TEAM_ID
+    delete process.env.VERCEL_PROJECT_ID
+    promptSecretMock.mockResolvedValue('typed-token')
+    promptMock.mockImplementation((message: string) => {
+      if (message.includes('Team ID')) return Promise.resolve('typed-team')
+      if (message.includes('Project ID')) return Promise.resolve('typed-project')
+      throw new Error(`Unexpected prompt: ${message}`)
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('prompts for the token via the masked promptSecret, not the plaintext prompt (regression test for #102)', async () => {
+    const result = await promptForCredentials({})
+
+    expect(result).toEqual({ token: 'typed-token', teamId: 'typed-team', projectId: 'typed-project' })
+    expect(promptSecretMock).toHaveBeenCalledTimes(1)
+    expect(promptSecretMock.mock.calls[0]?.[0]).toContain('Vercel API Auth Token')
+    // Team ID / project ID aren't secrets — they still use the plaintext prompt.
+    expect(promptMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not prompt for the token at all when already provided', async () => {
+    await promptForCredentials({ token: 'given-token', teamId: 'team', projectId: 'project' })
+
+    expect(promptSecretMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/ui/__tests__/promptSecret.test.ts
+++ b/src/lib/ui/__tests__/promptSecret.test.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from 'events'
+
+jest.mock('readline', () => ({
+  emitKeypressEvents: jest.fn(),
+  createInterface: jest.fn(),
+}))
+
+import { classifyKeypress, applyKeypressAction, promptSecret } from '../promptSecret'
+
+describe('classifyKeypress', () => {
+  it('classifies a printable character as append', () => {
+    expect(classifyKeypress('a', { name: 'a' })).toEqual({ type: 'append', char: 'a' })
+  })
+
+  it('classifies ctrl+c as cancel', () => {
+    expect(classifyKeypress(undefined, { name: 'c', ctrl: true })).toEqual({ type: 'cancel' })
+  })
+
+  it('classifies return as submit', () => {
+    expect(classifyKeypress(undefined, { name: 'return' })).toEqual({ type: 'submit' })
+  })
+
+  it('classifies enter as submit', () => {
+    expect(classifyKeypress(undefined, { name: 'enter' })).toEqual({ type: 'submit' })
+  })
+
+  it('classifies backspace as backspace', () => {
+    expect(classifyKeypress(undefined, { name: 'backspace' })).toEqual({ type: 'backspace' })
+  })
+
+  it('ignores other ctrl combinations', () => {
+    expect(classifyKeypress(undefined, { name: 'a', ctrl: true })).toEqual({ type: 'ignore' })
+  })
+
+  it('ignores arrow keys and other non-printable sequences', () => {
+    expect(classifyKeypress(undefined, { name: 'up' })).toEqual({ type: 'ignore' })
+  })
+})
+
+describe('applyKeypressAction', () => {
+  it('appends a character and requests a mask be added', () => {
+    expect(applyKeypressAction('ab', { type: 'append', char: 'c' })).toEqual({
+      value: 'abc',
+      done: false,
+      cancelled: false,
+      echo: 'add',
+    })
+  })
+
+  it('removes the last character on backspace', () => {
+    expect(applyKeypressAction('abc', { type: 'backspace' })).toEqual({
+      value: 'ab',
+      done: false,
+      cancelled: false,
+      echo: 'remove',
+    })
+  })
+
+  it('is a no-op backspace on an empty buffer', () => {
+    expect(applyKeypressAction('', { type: 'backspace' })).toEqual({
+      value: '',
+      done: false,
+      cancelled: false,
+      echo: 'none',
+    })
+  })
+
+  it('finishes on submit without touching the buffer', () => {
+    expect(applyKeypressAction('secret', { type: 'submit' })).toEqual({
+      value: 'secret',
+      done: true,
+      cancelled: false,
+      echo: 'none',
+    })
+  })
+
+  it('finishes as cancelled on cancel', () => {
+    expect(applyKeypressAction('partial', { type: 'cancel' })).toEqual({
+      value: 'partial',
+      done: true,
+      cancelled: true,
+      echo: 'none',
+    })
+  })
+})
+
+describe('promptSecret', () => {
+  let stdin: EventEmitter & {
+    isTTY: boolean
+    isRaw: boolean
+    setRawMode: jest.Mock
+    resume: jest.Mock
+  }
+  let stdoutWrites: string[]
+  let originalExit: typeof process.exit
+  let exitMock: jest.Mock
+
+  beforeEach(() => {
+    stdin = Object.assign(new EventEmitter(), {
+      isTTY: true,
+      isRaw: false,
+      setRawMode: jest.fn(),
+      resume: jest.fn(),
+    })
+    jest.spyOn(process, 'stdin', 'get').mockReturnValue(stdin as unknown as NodeJS.ReadStream & { fd: 0 })
+
+    stdoutWrites = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutWrites.push(String(chunk))
+      return true
+    })
+
+    originalExit = process.exit
+    exitMock = jest.fn()
+    process.exit = exitMock as unknown as typeof process.exit
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    process.exit = originalExit
+  })
+
+  const typeAndSubmit = (secret: string) => {
+    for (const char of secret) {
+      stdin.emit('keypress', char, { name: char })
+    }
+    stdin.emit('keypress', undefined, { name: 'return' })
+  }
+
+  it('resolves with the typed value and never echoes it in plaintext (regression test for #102)', async () => {
+    const promise = promptSecret('Token: ')
+    typeAndSubmit('super-secret-token')
+
+    const result = await promise
+
+    expect(result).toBe('super-secret-token')
+    const allOutput = stdoutWrites.join('')
+    expect(allOutput).not.toContain('super-secret-token')
+    // One '*' per typed character.
+    expect((allOutput.match(/\*/g) ?? []).length).toBe('super-secret-token'.length)
+  })
+
+  it('handles backspace by erasing the last masked character', async () => {
+    const promise = promptSecret('Token: ')
+    stdin.emit('keypress', 'a', { name: 'a' })
+    stdin.emit('keypress', 'b', { name: 'b' })
+    stdin.emit('keypress', undefined, { name: 'backspace' })
+    stdin.emit('keypress', 'c', { name: 'c' })
+    stdin.emit('keypress', undefined, { name: 'return' })
+
+    const result = await promise
+    expect(result).toBe('ac')
+  })
+
+  it('exits the process on ctrl+c without resolving the returned secret', async () => {
+    const promise = promptSecret('Token: ')
+    stdin.emit('keypress', 'a', { name: 'a' })
+    stdin.emit('keypress', undefined, { name: 'c', ctrl: true })
+
+    // process.exit is mocked (doesn't actually exit), so the promise never
+    // settles — just assert exit(0) was requested with nothing resolved yet.
+    await Promise.resolve()
+    expect(exitMock).toHaveBeenCalledWith(0)
+    void promise
+  })
+
+  it('restores the terminal raw-mode state after finishing', async () => {
+    const promise = promptSecret('Token: ')
+    typeAndSubmit('x')
+    await promise
+
+    expect(stdin.setRawMode).toHaveBeenCalledWith(true)
+    expect(stdin.setRawMode).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/lib/ui/promptForCredentials.ts
+++ b/src/lib/ui/promptForCredentials.ts
@@ -1,4 +1,5 @@
 import { prompt } from './prompt'
+import { promptSecret } from './promptSecret'
 
 export async function promptForCredentials(args: {
   token?: string
@@ -8,9 +9,8 @@ export async function promptForCredentials(args: {
   const token =
     args.token ||
     process.env.VERCEL_TOKEN ||
-    (await prompt(
-      `What is your Vercel API Auth Token? (https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token#creating-an-access-token)`,
-      { type: 'text' },
+    (await promptSecret(
+      `What is your Vercel API Auth Token? (https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token#creating-an-access-token) `,
     ))
 
   const teamId =

--- a/src/lib/ui/promptSecret.ts
+++ b/src/lib/ui/promptSecret.ts
@@ -1,0 +1,127 @@
+import { emitKeypressEvents } from 'readline'
+
+export interface KeypressKey {
+  name?: string
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+}
+
+export type KeypressAction =
+  | { type: 'append'; char: string }
+  | { type: 'backspace' }
+  | { type: 'submit' }
+  | { type: 'cancel' }
+  | { type: 'ignore' }
+
+export interface KeypressResult {
+  value: string
+  done: boolean
+  cancelled: boolean
+  echo: 'add' | 'remove' | 'none'
+}
+
+/**
+ * Decide what a keypress should do to a masked-input buffer. Pure and
+ * testable in isolation — no terminal I/O.
+ */
+export function classifyKeypress(char: string | undefined, key: KeypressKey | undefined): KeypressAction {
+  if (key?.ctrl && key.name === 'c') {
+    return { type: 'cancel' }
+  }
+  if (key?.name === 'return' || key?.name === 'enter') {
+    return { type: 'submit' }
+  }
+  if (key?.name === 'backspace') {
+    return { type: 'backspace' }
+  }
+  // A printable character: no ctrl/meta modifier, and an actual visible
+  // character was produced (excludes lone modifier keys, arrows, etc., which
+  // readline reports with an empty or control-code `char`).
+  if (char && !key?.ctrl && !key?.meta && char.length === 1 && char >= ' ') {
+    return { type: 'append', char }
+  }
+  return { type: 'ignore' }
+}
+
+/**
+ * Apply a keypress action to the current buffer. Pure and testable —
+ * returns the new buffer plus what the caller should do on screen.
+ */
+export function applyKeypressAction(value: string, action: KeypressAction): KeypressResult {
+  switch (action.type) {
+    case 'append':
+      return { value: value + action.char, done: false, cancelled: false, echo: 'add' }
+    case 'backspace':
+      if (value.length === 0) {
+        return { value, done: false, cancelled: false, echo: 'none' }
+      }
+      return { value: value.slice(0, -1), done: false, cancelled: false, echo: 'remove' }
+    case 'submit':
+      return { value, done: true, cancelled: false, echo: 'none' }
+    case 'cancel':
+      return { value, done: true, cancelled: true, echo: 'none' }
+    case 'ignore':
+      return { value, done: false, cancelled: false, echo: 'none' }
+  }
+}
+
+/**
+ * Prompt for a secret value (e.g. an API token) with input masked as `*`
+ * instead of echoed in plaintext, so it can't be read off a shared terminal
+ * or screen recording. Falls back to a normal (unmasked) line read when
+ * stdin isn't a TTY — raw mode requires one, and piped/non-interactive input
+ * (e.g. CI) has no screen to shoulder-surf in the first place.
+ */
+export async function promptSecret(message: string): Promise<string> {
+  process.stdout.write(message)
+
+  if (!process.stdin.isTTY) {
+    const { createInterface } = await import('readline')
+    const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false })
+    return new Promise((resolve) => {
+      rl.question('', (answer) => {
+        rl.close()
+        resolve(answer)
+      })
+    })
+  }
+
+  return new Promise((resolve) => {
+    const stdin = process.stdin
+    const wasRaw = stdin.isRaw
+    emitKeypressEvents(stdin)
+    stdin.setRawMode(true)
+    stdin.resume()
+
+    let value = ''
+
+    const cleanup = () => {
+      stdin.removeListener('keypress', onKeypress)
+      stdin.setRawMode(wasRaw ?? false)
+    }
+
+    const onKeypress = (char: string | undefined, key: KeypressKey | undefined) => {
+      const action = classifyKeypress(char, key)
+      const result = applyKeypressAction(value, action)
+      value = result.value
+
+      if (result.echo === 'add') {
+        process.stdout.write('*')
+      } else if (result.echo === 'remove') {
+        process.stdout.write('\b \b')
+      }
+
+      if (result.done) {
+        cleanup()
+        process.stdout.write('\n')
+        if (result.cancelled) {
+          process.exit(0)
+        }
+        resolve(value)
+      }
+    }
+
+    stdin.on('keypress', onKeypress)
+  })
+}

--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -6,6 +6,10 @@ jest.mock('../../ui/prompt', () => ({
   prompt: jest.fn(),
 }))
 
+jest.mock('../../ui/promptSecret', () => ({
+  promptSecret: jest.fn(),
+}))
+
 // Mock the providers
 jest.mock('../../providers/vercel', () => ({
   VercelProvider: {
@@ -29,6 +33,8 @@ import { getProviderInstance, getProviderDisplayName, verifyProviderCredentials 
 import { VercelProvider } from '../../providers/vercel'
 import { CloudflareProvider } from '../../providers/cloudflare'
 import { ProviderDetector } from '../../providers/ProviderDetector'
+import { prompt } from '../../ui/prompt'
+import { promptSecret } from '../../ui/promptSecret'
 import type { IFirewallProvider } from '../../providers/IFirewallProvider'
 
 describe('providerHelper', () => {
@@ -146,6 +152,23 @@ describe('providerHelper', () => {
     it('throws for Cloudflare when credentials missing and non-interactive', async () => {
       await expect(getProviderInstance({ provider: 'cloudflare', interactive: false })).rejects.toThrow(
         /credentials missing/,
+      )
+    })
+
+    it('prompts for a missing Cloudflare API token via the masked promptSecret, not the plaintext prompt (regression test for #102)', async () => {
+      ;(promptSecret as jest.MockedFunction<typeof promptSecret>).mockResolvedValue('typed-cf-token')
+      ;(prompt as jest.MockedFunction<typeof prompt>).mockImplementation((message: unknown) => {
+        const text = String(message)
+        if (text.includes('Zone ID')) return Promise.resolve('typed-zone')
+        if (text.includes('Account ID')) return Promise.resolve('')
+        throw new Error(`Unexpected prompt: ${text}`)
+      })
+
+      await getProviderInstance({ provider: 'cloudflare', interactive: true })
+
+      expect(promptSecret).toHaveBeenCalledWith(expect.stringContaining('Cloudflare API Token'))
+      expect(CloudflareProvider.fromConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ apiToken: 'typed-cf-token' }),
       )
     })
   })

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { logger } from '../logger'
 import { prompt } from '../ui/prompt'
+import { promptSecret } from '../ui/promptSecret'
 import { ProviderDetector } from '../providers/ProviderDetector'
 import { VercelProvider } from '../providers/vercel'
 import { CloudflareProvider } from '../providers/cloudflare'
@@ -134,11 +135,7 @@ async function getCloudflareProvider(options: ProviderOptions): Promise<IFirewal
     logger.warn('Missing Cloudflare credentials')
     logger.info('Please provide your Cloudflare credentials:')
 
-    const apiTokenInput =
-      apiToken ||
-      (await prompt('Cloudflare API Token:', {
-        type: 'text',
-      }))
+    const apiTokenInput = apiToken || (await promptSecret('Cloudflare API Token: '))
 
     const zoneIdInput =
       zoneId ||


### PR DESCRIPTION
## Summary
- API token prompts used consola's plain \`text\` prompt type, so the secret was echoed to the terminal character-by-character as it was typed.
- Failure scenario: anyone shoulder-surfing or reviewing a terminal recording/screen-share during interactive \`doorman init\`/\`doorman sync\` setup could read the API token directly off the screen.
- consola (the only prompt library this project depends on) has no masked/password prompt type at all - confirmed by inspecting its type definitions and bundled implementation.

## Fix
Added a small raw-mode readline-based \`promptSecret()\` (\`src/lib/ui/promptSecret.ts\`) that echoes \`*\` per keystroke instead of the real character, with:
- Proper backspace / enter / ctrl+c handling (ctrl+c exits like every other prompt in this codebase does on cancel).
- A non-TTY fallback (raw mode requires a real terminal; piped/non-interactive input has no screen to shoulder-surf in the first place).
- The keystroke-classification and buffer-update logic is split into small pure functions (\`classifyKeypress\`, \`applyKeypressAction\`) so the masking behavior itself is directly unit-testable, separate from the terminal I/O wiring.

Wired it into the two actual secret-value prompts: the Vercel API token (\`promptForCredentials.ts\`) and the Cloudflare API token (\`providerHelper.ts\`). Team ID / project ID / zone ID aren't secrets and keep using the existing plaintext prompt.

## Test plan
- [x] 16 new tests directly on \`promptSecret\`: keystroke classification, buffer updates, full simulated-stdin flow (masking, backspace, submit, ctrl+c-exits, raw-mode restored afterward) - verifies the typed secret is never written to stdout in plaintext.
- [x] New regression tests confirming \`promptForCredentials\` uses \`promptSecret\` for the token (not \`prompt\`), and \`providerHelper\`'s interactive Cloudflare credential flow does the same for the API token.
- [x] \`pnpm test -- src/lib/ui/__tests__/promptSecret.test.ts src/lib/ui/__tests__/promptForCredentials.test.ts src/lib/utils/__tests__/providerHelper.test.ts\` - 32/32 pass
- [x] \`pnpm test:ci\` - 72 suites / 1237 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #102