### PR TITLE
docs: fix CLAUDE.md/AGENTS.md's stale test-coverage numbers and command list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `src/commands/`: CLI subcommands (`list`, `sync`, `download`, `validate`, `template`, `diff`, `status`, `watch`, `backup`, `export`, `init`, `setup`).
+- `src/commands/`: CLI subcommands (`list`, `add`, `remove`, `sync`, `download`, `validate`, `template`, `diff`, `status`, `watch`, `backup`, `export`, `init`, `setup`).
 - `src/lib/`: shared code (`services/`, `utils/`, `templates/`, `types.ts`, `ui/`).
 - `src/lib/providers/`: Multi-provider abstraction layer (`IFirewallProvider`, `ProviderRegistry`, `ProviderDetector`).
 - `src/lib/providers/vercel/`: Vercel provider implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ Doorman is a CLI tool for managing firewall rules as code across multiple provid
 All commands accept `--provider vercel|cloudflare` (auto-detected if not specified), `--debug`, and `--ci` flags.
 
 - **list:** Display firewall rules - `doorman list [configVersion]`
+- **add:** Add a new firewall rule or IP entry - `doorman add [type]`
+- **remove:** Remove a firewall rule or IP entry - `doorman remove [type]`
 - **sync:** Push local config to provider - `doorman sync`
 - **download:** Import rules from provider - `doorman download [configVersion]`
 - **template:** Add rule templates - `doorman template [templateName]`
@@ -55,7 +57,7 @@ All commands accept `--provider vercel|cloudflare` (auto-detected if not specifi
 - Mock `process.exit` in tests to prevent Jest worker crashes
 
 ## Testing
-- **Test Coverage:** 141+ passing Vercel tests, 26+ passing Cloudflare test suites
+- **Test Coverage:** 1200+ passing tests across 70+ test suites (Vercel and Cloudflare). Run `pnpm test:ci` for the current count — these numbers drift as tests are added.
 - **Test Structure:** Integration tests, edge cases, validation, sync/download
 - **Mocking:** Mock VercelClient, process.exit, and external dependencies
 - **CI/CD:** Tests run on every push to main and beta via GitHub Actions


### PR DESCRIPTION
## Summary
- CLAUDE.md claimed "141+ passing Vercel tests, 26+ passing Cloudflare test suites" (actual right now: 70+ suites, 1200+ passing) and its command list omitted the \`add\` and \`remove\` commands that exist in \`src/commands\`.
- AGENTS.md's command list had the identical add/remove omission.
- A contributor relying on these docs for orientation got a materially wrong picture of test coverage scale and an incomplete view of available commands.

## Fix
- Replaced the hardcoded test numbers with an approximate figure plus a pointer to \`pnpm test:ci\` for the exact current count, since exact numbers go stale again the moment more tests are added.
- Added \`add\`/\`remove\` to both command lists (verified against the full \`src/commands/*.ts\` listing - all 14 commands are now represented).

## Test plan
- [x] Verified all 14 command files in \`src/commands/\` are now listed in CLAUDE.md.
- [x] \`pnpm lint\` - no new warnings/errors (docs-only change)

Fixes #106