### PR TITLE
fix: allowlist-reconstruct IP rules too when sanitizing a backup

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -36,7 +36,20 @@ const vercelRemoteConfig = {
       validationErrors: [],
     },
   ],
-  ips: [],
+  // Includes a hypothetical future API-only field on the IP rule too (see
+  // #114) — not observed from the real Vercel API yet, but IPBlockingRule
+  // has the same additionalProperties: false restriction as CustomRule, so
+  // this guards against the same bug class recurring there.
+  ips: [
+    {
+      id: 'ip_1',
+      ip: '203.0.113.5',
+      hostname: 'example.com',
+      notes: 'Known bad actor',
+      action: 'deny',
+      valid: true,
+    },
+  ],
   projectKey: 'pk_123',
   ownerId: 'owner_1',
   updatedAt: '2024-01-01T00:00:00Z',
@@ -100,6 +113,15 @@ describe('backup command', () => {
     expect(content.rules[0].valid).toBeUndefined()
     expect(content.rules[0].validationErrors).toBeUndefined()
     expect(content.rules[0].name).toBe('Block Admin')
+    // Per-IP-rule API-only fields must not leak into the saved backup either
+    // (regression test for #114) — legitimate fields must still survive.
+    expect(content.ips).toHaveLength(1)
+    expect(content.ips[0].valid).toBeUndefined()
+    expect(content.ips[0].id).toBe('ip_1')
+    expect(content.ips[0].ip).toBe('203.0.113.5')
+    expect(content.ips[0].hostname).toBe('example.com')
+    expect(content.ips[0].notes).toBe('Known bad actor')
+    expect(content.ips[0].action).toBe('deny')
   })
 
   it('creates a backup file for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -6,7 +6,7 @@ import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import { ValidationService } from '../lib/services/ValidationService'
 import type { VercelConfig } from '../lib/services/VercelClient'
-import { FirewallConfig } from '../lib/types'
+import { FirewallConfig, IPBlockingRule } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
@@ -184,15 +184,27 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         // validating/saving, the same way download.ts builds its saved config.
         // The API also attaches valid/validationErrors to every rule object
         // (download.ts strips these too, for the same reason — CustomRule also
-        // has additionalProperties: false). Cloudflare's fetchConfig() already
-        // returns a clean UnifiedConfig with no extra fields, so it's used as-is.
+        // has additionalProperties: false). IP-blocking rules are similarly
+        // allowlist-reconstructed by known schema field names (id, ip,
+        // hostname, notes, action) rather than passed through as-is — no
+        // extra fields have been observed there yet, but IPBlockingRule also
+        // has additionalProperties: false, so this closes off the same bug
+        // class before it can trigger a third time. Cloudflare's
+        // fetchConfig() already returns a clean UnifiedConfig with no extra
+        // fields, so it's used as-is.
         const sanitizedConfig =
           provider.name === 'vercel'
             ? {
                 version: remoteConfig.version,
                 firewallEnabled: (remoteConfig as VercelConfig).firewallEnabled,
                 rules: remoteConfig.rules.map(({ valid, validationErrors, ...rule }: any) => rule),
-                ips: remoteConfig.ips,
+                ips: (remoteConfig.ips as IPBlockingRule[]).map(({ id, ip, hostname, notes, action }) => ({
+                  ...(id !== undefined && { id }),
+                  ip,
+                  hostname,
+                  ...(notes !== undefined && { notes }),
+                  action,
+                })),
                 updatedAt: (remoteConfig as VercelConfig).updatedAt,
               }
             : remoteConfig


### PR DESCRIPTION
## Summary
- backup.ts's Vercel-path sanitization (fixed for custom rules in #112) allowlisted top-level fields explicitly and stripped the two known API-only fields (\`valid\`/\`validationErrors\`) from each custom rule via destructuring, but passed \`ips: remoteConfig.ips\` straight through with no equivalent stripping.
- \`IPBlockingRule\` has the same \`additionalProperties: false\` restriction as \`CustomRule\`, so if Vercel's API ever attaches metadata to IP-blocking-rule objects the way it does to custom rules, \`doorman backup\` would fail a third time for any project with real IP rules - the same bug class, just not yet proven to trigger (no evidence in any test fixture that Vercel does this today).

## Fix
Reconstructs each IP rule by known schema field names (\`id\`, \`ip\`, \`hostname\`, \`notes\`, \`action\`) instead of passing it through as-is - the more robust long-term fix the issue itself suggested, so an unknown future field can't cause a fourth round of this same bug class (rather than just reactively stripping whatever specific field shows up next).

## Test plan
- [x] Added a non-empty IP rule to the backup test fixture carrying a hypothetical extra field (\`valid: true\`), and asserted it's stripped while all legitimate fields (\`id\`/\`ip\`/\`hostname\`/\`notes\`/\`action\`) survive.
- [x] \`pnpm test -- src/commands/__tests__/backup.test.ts\` - 6/6 pass
- [x] \`pnpm test:ci\` - 70 suites / 1218 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors

Fixes #114