### PR TITLE
test: fix withCredentials test hang after #102 changed the token prompt

### DIFF
--- a/src/lib/utils/__tests__/withCredentials.test.ts
+++ b/src/lib/utils/__tests__/withCredentials.test.ts
@@ -3,6 +3,9 @@ jest.mock('../../logger', () => ({ logger: require('../../../tests/testHelpers/l
 const promptMock = jest.fn()
 jest.mock('../../ui/prompt', () => ({ prompt: (...args: unknown[]) => promptMock(...args) }))
 
+const promptSecretMock = jest.fn()
+jest.mock('../../ui/promptSecret', () => ({ promptSecret: (...args: unknown[]) => promptSecretMock(...args) }))
+
 import { withCredentials } from '../withCredentials'
 
 describe('withCredentials', () => {
@@ -14,8 +17,11 @@ describe('withCredentials', () => {
     delete process.env.VERCEL_TOKEN
     delete process.env.VERCEL_PROJECT_ID
     delete process.env.VERCEL_TEAM_ID
+    // The token prompt is masked (see #102) and goes through promptSecret,
+    // not the plaintext prompt — team ID / project ID aren't secrets and
+    // still go through prompt.
+    promptSecretMock.mockResolvedValue('prompted-token')
     promptMock.mockImplementation((message: string) => {
-      if (message.includes('Auth Token')) return Promise.resolve('prompted-token')
       if (message.includes('Team ID')) return Promise.resolve('prompted-team')
       if (message.includes('Project ID')) return Promise.resolve('prompted-project')
       throw new Error(`Unexpected prompt: ${message}`)
@@ -48,8 +54,10 @@ describe('withCredentials', () => {
       },
     )
 
-    // One prompt each for token, team ID, and project ID — three total, not six.
-    expect(promptMock).toHaveBeenCalledTimes(3)
+    // One prompt each for token (masked), team ID, and project ID — three
+    // total across the two prompt functions, not six.
+    expect(promptSecretMock).toHaveBeenCalledTimes(1)
+    expect(promptMock).toHaveBeenCalledTimes(2)
     expect(receivedToken).toBe('prompted-token')
     expect(receivedProjectId).toBe('prompted-project')
     expect(receivedTeamId).toBe('prompted-team')


### PR DESCRIPTION
## Summary
Found while verifying \`main\` after merging the full batch of pending fixes.

- #93's \`withCredentials.test.ts\` (merged as PR #124) only mocked \`../ui/prompt\`, assuming the Vercel token prompt used it directly.
- #102 (merged as PR #133) changed \`promptForCredentials\` to prompt for the token via the new masked \`promptSecret()\` instead of \`prompt()\`.
- Individually, both PRs passed CI against \`main\` at the time they were opened. Merged together, this test fell through to the *real* \`promptSecret\` implementation for the token, which tries to read raw-mode input from the Jest process's stdin - it hung until the 5s test timeout.

## Fix
Mocks \`promptSecret\` alongside \`prompt\` and updates the call-count assertions: one \`promptSecret\` call for the token (masked), two \`prompt\` calls for team ID/project ID (not secrets).

## Test plan
- [x] \`pnpm test -- src/lib/utils/__tests__/withCredentials.test.ts\` - 1/1 pass (previously hung/timed out)
- [x] \`pnpm test:ci\` - 72 suites / 1230 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors