### PR TITLE
fix: stop quoting IP values in wirefilter expressions for ip.src

### DIFF
--- a/src/lib/translators/ExpressionBuilder.ts
+++ b/src/lib/translators/ExpressionBuilder.ts
@@ -2,6 +2,14 @@ import type { VercelRuleCondition, VercelConditionGroup } from '../types/vercel'
 import type { UnifiedCondition } from '../types/unified'
 import { FieldMapper } from './FieldMapper'
 import { escapeWirefilterString } from './wirefilterEscape'
+import { ipAddressSchema } from '../schemas/commonSchemas'
+
+/**
+ * wirefilter fields this codebase's field mappers ever produce that hold a
+ * native `Ip` type rather than `String` — comparing one against a quoted
+ * string literal is a type mismatch Cloudflare's ruleset API rejects.
+ */
+const UNQUOTED_IP_FIELDS = new Set(['ip.src'])
 
 /**
  * Builds Cloudflare wirefilter expressions from structured conditions
@@ -36,7 +44,7 @@ export class ExpressionBuilder {
     const field = FieldMapper.toCloudflare(condition.type, condition.key)
     let expression = this.buildExistsOrComparisonExpression(field, condition.op, () => {
       const operator = this.mapVercelOperator(condition.op)
-      return `${operator} ${this.formatValue(condition.value, condition.op)}`
+      return `${operator} ${this.formatValue(field, condition.value)}`
     })
 
     // Handle negation
@@ -107,14 +115,14 @@ export class ExpressionBuilder {
    */
   private static buildUnifiedExpression(field: string, op: UnifiedCondition['operator'], value: unknown): string {
     if (op === 'not_contains') {
-      return `not (${field} contains ${this.formatValue(value, 'contains')})`
+      return `not (${field} contains ${this.formatValue(field, value)})`
     }
     if (op === 'not_in') {
-      return `not (${field} in ${this.formatValue(value, 'in')})`
+      return `not (${field} in ${this.formatValue(field, value)})`
     }
     return this.buildExistsOrComparisonExpression(field, op, () => {
       const operator = this.mapUnifiedOperator(op)
-      return `${operator} ${this.formatValue(value, operator)}`
+      return `${operator} ${this.formatValue(field, value)}`
     })
   }
 
@@ -194,21 +202,33 @@ export class ExpressionBuilder {
   /**
    * Format value for wirefilter expression
    */
-  private static formatValue(value: unknown, _operator?: string): string {
+  private static formatValue(field: string, value: unknown): string {
     // Handle arrays (for 'in' operator)
     if (Array.isArray(value)) {
-      const formattedValues = value.map((v) => this.formatSingleValue(v)).join(' ')
+      const formattedValues = value.map((v) => this.formatSingleValue(field, v)).join(' ')
       return `{${formattedValues}}`
     }
 
-    return this.formatSingleValue(value)
+    return this.formatSingleValue(field, value)
   }
 
   /**
-   * Format a single value
+   * Format a single value. IP-typed fields (ip.src) are wirefilter's native
+   * `Ip` type, not `String` — comparing one against a quoted string literal
+   * is a type mismatch Cloudflare's ruleset API rejects, so those values are
+   * interpolated unquoted instead (mirrors RuleTranslator.unifiedIPToCloudflare's
+   * dedicated IP-blocking-rule path). An unquoted value has no delimiter to
+   * contain it — a more direct wirefilter-injection primitive than a quoted
+   * string — so it's validated as a real IP/CIDR first and rejected otherwise.
    */
-  private static formatSingleValue(value: unknown): string {
+  private static formatSingleValue(field: string, value: unknown): string {
     if (typeof value === 'string') {
+      if (UNQUOTED_IP_FIELDS.has(field)) {
+        if (!ipAddressSchema.safeParse(value).success) {
+          throw new Error(`Invalid IP address or CIDR range: ${value}`)
+        }
+        return value
+      }
       return `"${escapeWirefilterString(value)}"`
     }
 

--- a/src/lib/translators/__tests__/ExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/ExpressionBuilder.test.ts
@@ -105,9 +105,18 @@ describe('ExpressionBuilder', () => {
       expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('not (http.request.uri.path eq "/public")')
     })
 
-    it('handles ip_address field', () => {
+    it('handles ip_address field, unquoted since ip.src is a native Ip type in wirefilter (regression test for the quoting bug found post-#85/#119)', () => {
       const condition: VercelRuleCondition = { type: 'ip_address', op: 'eq', value: '192.168.1.1' }
-      expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('ip.src eq "192.168.1.1"')
+      expect(ExpressionBuilder.fromVercelCondition(condition)).toBe('ip.src eq 192.168.1.1')
+    })
+
+    it('rejects a non-IP value for the ip_address field instead of interpolating it unquoted', () => {
+      const condition: VercelRuleCondition = {
+        type: 'ip_address',
+        op: 'eq',
+        value: '1.2.3.4 or (true) or ip.src eq 1.2.3.4',
+      }
+      expect(() => ExpressionBuilder.fromVercelCondition(condition)).toThrow('Invalid IP address or CIDR range')
     })
 
     it('handles header with key', () => {
@@ -198,8 +207,11 @@ describe('ExpressionBuilder', () => {
 
   describe('fromUnifiedCondition', () => {
     it('maps unified field types to Cloudflare fields', () => {
+      // ip.src is a native Ip type in wirefilter, unlike every other field
+      // here — its value is interpolated unquoted (regression test for the
+      // quoting bug found post-#85/#119).
       expect(ExpressionBuilder.fromUnifiedCondition({ field: 'ip', operator: 'eq', value: '1.2.3.4' })).toBe(
-        'ip.src eq "1.2.3.4"',
+        'ip.src eq 1.2.3.4',
       )
 
       expect(ExpressionBuilder.fromUnifiedCondition({ field: 'country', operator: 'eq', value: 'US' })).toBe(
@@ -209,6 +221,22 @@ describe('ExpressionBuilder', () => {
       expect(ExpressionBuilder.fromUnifiedCondition({ field: 'host', operator: 'eq', value: 'example.com' })).toBe(
         'http.host eq "example.com"',
       )
+    })
+
+    it('handles an ip field with a CIDR value, still unquoted', () => {
+      expect(ExpressionBuilder.fromUnifiedCondition({ field: 'ip', operator: 'in', value: ['1.2.3.0/24'] })).toBe(
+        'ip.src in {1.2.3.0/24}',
+      )
+    })
+
+    it('rejects a non-IP value for an ip field instead of interpolating it unquoted', () => {
+      expect(() =>
+        ExpressionBuilder.fromUnifiedCondition({
+          field: 'ip',
+          operator: 'eq',
+          value: '1.2.3.4 or (true) or ip.src eq 1.2.3.4',
+        }),
+      ).toThrow('Invalid IP address or CIDR range')
     })
 
     it('maps unified operators to Cloudflare operators', () => {


### PR DESCRIPTION
## Summary
Found during a post-merge review of the recent wirefilter-correctness batch (#85/#108/#109/#119) — this bug predates that batch but wasn't caught by it, even though those PRs touched this exact file.

- `ExpressionBuilder.formatSingleValue` always quoted string values as wirefilter string literals.
- But `ip.src` (the field produced by both `FieldMapper`'s Vercel `ip_address` mapping and the unified `ip` field mapping) is wirefilter's native `Ip` type, not `String`. Comparing it against a quoted string literal (e.g. `ip.src eq "1.2.3.4"`) is a type mismatch Cloudflare's ruleset API rejects at rule-creation time.
- **Failure scenario:** any custom rule condition on an IP address (`{"type":"ip_address","op":"eq","value":"1.2.3.4"}` on the Vercel side, or `{"field":"ip",...}` on the unified side) fails Cloudflare sync.
- `RuleTranslator.unifiedIPToCloudflare`'s dedicated IP-blocking-rule path already interpolated IPs unquoted for exactly this reason (with a comment explaining why) - that fix was just never applied to this general condition-building path. Two existing tests asserted the buggy quoted output, locking the bug in rather than catching it.

## Fix
IP-typed field values (`ip.src`) are now interpolated unquoted - but only after validating them as a real IP/CIDR first (reusing the same `ipAddressSchema` `RuleTranslator` already uses for the same purpose). An unquoted value has no delimiter to contain it, so skipping validation would trade a correctness bug for a wirefilter-injection vulnerability.

## Test plan
- [x] Updated the two existing tests that asserted the buggy quoted `ip.src eq "..."` output to expect the correct unquoted form.
- [x] Added a regression test for a CIDR value in an `in {...}` set (still unquoted).
- [x] Added a regression test confirming a non-IP value is rejected with a clear error instead of being interpolated unquoted (injection guard).
- [x] Searched the rest of the test suite for any other stale assertions on quoted `ip.src` output - none found.
- [x] `pnpm test -- src/lib/translators/__tests__/ExpressionBuilder.test.ts` - 51/51 pass
- [x] `pnpm test:ci` - 72 suites / 1233 tests pass
- [x] `pnpm build` - succeeds
- [x] `pnpm lint` - no new warnings/errors