### PR TITLE
fix: make template --dryRun preview the duplicate-name warning too

### DIFF
--- a/src/commands/__tests__/template.test.ts
+++ b/src/commands/__tests__/template.test.ts
@@ -58,6 +58,25 @@ describe('template command', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Dry run'))
   })
 
+  it('warns about a duplicate rule name during a dry run too, not just a real apply (regression test)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Deny WordPress URLs',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/wp-admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({ name: 'wordpress', dryRun: true, debug: false } as any)
+
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Deny WordPress URLs'))
+  })
+
   it('exits with an error for an unknown template name', async () => {
     await expect(handler({ name: 'not-a-real-template', dryRun: false, debug: false } as any)).rejects.toThrow(
       'process.exit called with "1"',

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -90,15 +90,22 @@ export const handler = async (argv: Arguments<TemplateOptions>) => {
     const config = await getConfig(argv.config, 'raw')
     const existingRules = config.rules || []
 
+    // Check for rules that would collide with existing ones by name —
+    // otherwise re-running the same template silently appends duplicates.
+    // Computed before the dry-run branch so --dryRun actually previews this
+    // warning too, instead of silently skipping the one thing a preview
+    // most needs to surface.
+    const duplicateNames = findDuplicateNames(existingRules, templateConfig.rules)
+
     if (argv.dryRun) {
       logger.info(chalk.cyan('\nDry run - The following rules would be added:'))
       logger.log(JSON.stringify(templateConfig.rules, null, 2))
+      if (duplicateNames.length > 0) {
+        logger.warn(chalk.yellow(`⚠️  Rule name(s) already exist in the configuration: ${duplicateNames.join(', ')}`))
+      }
       return
     }
 
-    // Check for rules that would collide with existing ones by name —
-    // otherwise re-running the same template silently appends duplicates.
-    const duplicateNames = findDuplicateNames(existingRules, templateConfig.rules)
     if (duplicateNames.length > 0) {
       logger.warn(chalk.yellow(`⚠️  Rule name(s) already exist in the configuration: ${duplicateNames.join(', ')}`))
       const proceed = (await prompt('Proceed anyway?', {


### PR DESCRIPTION
## Summary
Found during a post-merge review of the recent template.ts fix (#97).

- \`findDuplicateNames\` ran after the \`--dryRun\` early-return, so a dry-run preview of a template that collides with existing rule names showed nothing about the collision - the one thing a preview most needs to surface, given the real (non-dry-run) path warns and prompts to confirm before proceeding.

## Fix
Moved the duplicate check ahead of the dry-run branch so \`--dryRun\` now reports the same warning (without prompting - a preview should never prompt).

## Test plan
- [x] Added a regression test confirming a dry run against a colliding template name logs the warning without calling \`saveConfig\`.
- [x] \`pnpm test -- src/commands/__tests__/template.test.ts\` - 8/8 pass
- [x] \`pnpm test:ci\` - 72 suites / 1242 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors