### PR TITLE
test: add direct coverage for OperationSafety.assessOperationRisk

### DIFF
--- a/src/lib/utils/__tests__/operationSafety.test.ts
+++ b/src/lib/utils/__tests__/operationSafety.test.ts
@@ -136,6 +136,96 @@ describe('OperationSafety', () => {
     })
   })
 
+  describe('assessOperationRisk', () => {
+    // Shared across Vercel and Cloudflare (see #104) — this is the one place
+    // both providers' dry-run/confirmation safety checks actually branch on,
+    // so its classification logic needs direct coverage rather than only
+    // being exercised indirectly through mocked confirmDestructiveOperation
+    // calls in the provider-level test suites.
+    const configWithRules = (ruleCount: number, ipCount = 0): UnifiedConfig => ({
+      version: '2.0',
+      provider: 'cloudflare',
+      rules: Array.from({ length: ruleCount }, (_, i) => ({
+        id: `rule_${i}`,
+        name: `Rule ${i}`,
+        enabled: true,
+        action: { type: 'log' },
+        conditions: [{ field: 'path', operator: 'eq', value: '/test' }],
+      })),
+      ips: Array.from({ length: ipCount }, (_, i) => ({
+        id: `ip_${i}`,
+        ip: `10.0.0.${i}`,
+        action: 'deny',
+      })),
+    })
+
+    const changesWith = (overrides: Partial<ChangeSet>): ChangeSet => ({
+      rulesToAdd: [],
+      rulesToUpdate: [],
+      rulesToDelete: [],
+      ipsToAdd: [],
+      ipsToUpdate: [],
+      ipsToDelete: [],
+      hasChanges: true,
+      ...overrides,
+    })
+
+    it('is low risk for additions only', () => {
+      const changes = changesWith({ rulesToAdd: [{}] as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(0))).toBe('low')
+    })
+
+    it('is high risk when deleting every existing rule', () => {
+      const changes = changesWith({ rulesToDelete: [{}, {}] as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(2))).toBe('high')
+    })
+
+    it('is high risk when deleting more than half of existing rules/IPs', () => {
+      // 6 deletions out of 10 existing (rules + ips) = 60% > 50%, but not "all"
+      const changes = changesWith({ rulesToDelete: Array.from({ length: 6 }, () => ({})) as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(8, 2))).toBe('high')
+    })
+
+    it('is high risk when the total change count exceeds 50', () => {
+      const changes = changesWith({ rulesToAdd: Array.from({ length: 51 }, () => ({})) as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(0))).toBe('high')
+    })
+
+    it('is high risk for a deny rule matching all traffic on path "/"', () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'r1',
+            name: 'Block everything',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/' }],
+          },
+        ],
+        ips: [],
+      }
+      const changes = changesWith({ rulesToAdd: [{}] as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, config)).toBe('high')
+    })
+
+    it('is medium risk for any deletion below the high-risk thresholds', () => {
+      const changes = changesWith({ rulesToDelete: [{}] as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(10))).toBe('medium')
+    })
+
+    it('is medium risk when the total change count exceeds 10 but not 50', () => {
+      const changes = changesWith({ rulesToAdd: Array.from({ length: 11 }, () => ({})) as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(0))).toBe('medium')
+    })
+
+    it('is medium risk for rule updates', () => {
+      const changes = changesWith({ rulesToUpdate: [{}] as UnifiedConfig['rules'] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(5))).toBe('medium')
+    })
+  })
+
   describe('getBackupRecommendation', () => {
     it('should recommend backup for high-risk operations', () => {
       const recommendation = OperationSafety.getBackupRecommendation('delete ruleset', 'high')


### PR DESCRIPTION
## Summary
Found during a post-merge review of the recent Vercel/Cloudflare sync safety-check batch (#104, #129).

- \`assessOperationRisk\` is the shared risk-classification logic both Vercel's and Cloudflare's sync dry-run/confirmation safety checks depend on - the one place both providers' behavior actually branches on.
- Neither \`operationSafety.test.ts\` nor the provider-level test suites (\`VercelFirewallService.test.ts\`, \`CloudflareFirewallService.test.ts\`) asserted a specific risk level coming out of it - they only mocked/spied \`confirmDestructiveOperation\` and checked it was called with an \`operation\`/\`skipConfirmation\`, never checking what risk level actually triggered it.
- All the branch logic (delete-all-rules → high, >50% deletion ratio → high, >50 changes → high, dangerous deny-\`/\`-or-\`*\` rule detection → high, any-deletion → medium, >10 changes → medium, rule updates → medium) ran uncovered by any assertion - confirmed by coverage output showing this file's private helpers at ~52% statement coverage.
- A regression here (e.g. one provider computing local vs. remote rule counts inconsistently, silently changing what counts as \"high risk\") would not be caught by CI today.

## Fix
Added direct tests for every risk-level branch.

## Test plan
- [x] \`pnpm test -- src/lib/utils/__tests__/operationSafety.test.ts\` - 17/17 pass
- [x] \`pnpm test:ci\` - 72 suites / 1242 tests pass
- [x] \`pnpm build\` - succeeds
- [x] \`pnpm lint\` - no new warnings/errors