### PR TITLE
fix: require explicit --allow-deletions for non-interactive rule deletions

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -20,6 +20,7 @@ interface SyncOptions {
   accountId?: string
   debug?: boolean
   ci?: boolean
+  allowDeletions?: boolean
 }
 
 export const command = 'sync'
@@ -55,6 +56,12 @@ export const builder = {
     default: false,
   },
   ci: { type: 'boolean', description: 'Run in CI mode (non-interactive)', default: false },
+  allowDeletions: {
+    type: 'boolean',
+    description:
+      'Required together with --ci to let a non-interactive sync delete existing rules/IPs. Without it, a --ci sync that would delete anything is refused rather than applied silently.',
+    default: false,
+  },
 }
 
 export const handler = async (argv: Arguments<SyncOptions>) => {
@@ -246,8 +253,9 @@ async function syncWithProvider(
 
   logger.start('Starting firewall rules sync...')
   // Non-vercel providers prompt for confirmation internally (unless --ci); no need
-  // to prompt again here.
-  const result = await provider.syncRules(unifiedConfig, { force: argv.ci })
+  // to prompt again here. In --ci mode, a sync that would delete anything still
+  // requires --allow-deletions — see OperationSafety.confirmDestructiveOperation.
+  const result = await provider.syncRules(unifiedConfig, { force: argv.ci, allowDeletions: argv.allowDeletions })
 
   if (!result.success) {
     throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -176,7 +176,10 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
  * Mirrors the Vercel branch above but via the generic IFirewallProvider interface.
  * Always applies changes without prompting (force: true) — same as the Vercel path,
  * which goes straight from diff to sync without a confirmation prompt, since watch
- * mode is opt-in unattended auto-sync.
+ * mode is opt-in unattended auto-sync. `allowDeletions: true` is likewise deliberate
+ * here (unlike plain `doorman sync --ci`): a `watch` session is opted into by an
+ * actively-present developer editing the local config file, not a headless CI job,
+ * so a deletion driven by their own edit is exactly what they asked for.
  */
 async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfig: UnifiedConfig): Promise<void> {
   const changes = await provider.getChanges(updatedConfig)
@@ -195,7 +198,7 @@ async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfi
     (changes.ipsToDelete?.length ?? 0)
   logger.log(chalk.cyan(`Syncing ${totalChanges} changes...`))
 
-  const result = await provider.syncRules(updatedConfig, { force: true })
+  const result = await provider.syncRules(updatedConfig, { force: true, allowDeletions: true })
 
   if (!result.success) {
     throw new Error(`Sync failed: ${result.errors?.join(', ') || 'unknown error'}`)

--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -14,7 +14,16 @@ export type ProviderType = 'vercel' | 'cloudflare'
 export interface SyncOptions {
   dryRun?: boolean
   skipBackup?: boolean
+  /** Run non-interactively (no confirmation prompt). Does NOT by itself authorize
+   * deleting existing rules — see `allowDeletions`. */
   force?: boolean
+  /** Required, in addition to `force`, to let a non-interactive sync delete
+   * existing rules/IPs. Doorman has no state file, so a rule that exists
+   * remotely but not in the local config could be one the user genuinely
+   * removed, or a pre-existing rule (created by another tool, or found on
+   * doorman's very first sync against an already-configured zone/project)
+   * that's about to be silently destroyed with no one watching CI logs. */
+  allowDeletions?: boolean
 }
 
 /**

--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -246,6 +246,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
       riskLevel,
       skipConfirmation: options?.force || false,
       dryRun: options?.dryRun || false,
+      allowDeletions: options?.allowDeletions || false,
     })
 
     if (!confirmed) {

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -129,6 +129,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
         riskLevel,
         skipConfirmation: options.force || false,
         dryRun: false,
+        allowDeletions: options.allowDeletions || false,
       })
 
       if (!confirmed) {

--- a/src/lib/utils/__tests__/operationSafety.test.ts
+++ b/src/lib/utils/__tests__/operationSafety.test.ts
@@ -226,6 +226,80 @@ describe('OperationSafety', () => {
     })
   })
 
+  describe('confirmDestructiveOperation', () => {
+    // Regression coverage for the CI-deletion safety gate: `skipConfirmation`
+    // (--force/--ci) authorizes running non-interactively, but must never by
+    // itself authorize deleting rules — see the comment in operationSafety.ts.
+    const changesWithDeletions: ChangeSet = {
+      rulesToAdd: [],
+      rulesToUpdate: [],
+      rulesToDelete: [{}] as UnifiedConfig['rules'],
+      ipsToAdd: [],
+      ipsToUpdate: [],
+      ipsToDelete: [],
+      hasChanges: true,
+    }
+
+    const changesWithoutDeletions: ChangeSet = {
+      rulesToAdd: [{}] as UnifiedConfig['rules'],
+      rulesToUpdate: [],
+      rulesToDelete: [],
+      ipsToAdd: [],
+      ipsToUpdate: [],
+      ipsToDelete: [],
+      hasChanges: true,
+    }
+
+    it('refuses a non-interactive operation that would delete rules without allowDeletions', async () => {
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: 'Cloudflare zone test',
+        changes: changesWithDeletions,
+        riskLevel: 'high',
+        skipConfirmation: true,
+      })
+
+      expect(confirmed).toBe(false)
+    })
+
+    it('allows a non-interactive operation that would delete rules when allowDeletions is set', async () => {
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: 'Cloudflare zone test',
+        changes: changesWithDeletions,
+        riskLevel: 'high',
+        skipConfirmation: true,
+        allowDeletions: true,
+      })
+
+      expect(confirmed).toBe(true)
+    })
+
+    it('allows a non-interactive operation with no deletions without needing allowDeletions', async () => {
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: 'Cloudflare zone test',
+        changes: changesWithoutDeletions,
+        riskLevel: 'low',
+        skipConfirmation: true,
+      })
+
+      expect(confirmed).toBe(true)
+    })
+
+    it('short-circuits true for dry runs regardless of deletions or allowDeletions', async () => {
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: 'Cloudflare zone test',
+        changes: changesWithDeletions,
+        riskLevel: 'high',
+        dryRun: true,
+      })
+
+      expect(confirmed).toBe(true)
+    })
+  })
+
   describe('getBackupRecommendation', () => {
     it('should recommend backup for high-risk operations', () => {
       const recommendation = OperationSafety.getBackupRecommendation('delete ruleset', 'high')

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -13,6 +13,10 @@ export interface SafetyConfirmationOptions {
   riskLevel: 'low' | 'medium' | 'high'
   skipConfirmation?: boolean
   dryRun?: boolean
+  /** Required, in addition to `skipConfirmation`, to let a non-interactive
+   * operation proceed when it would delete existing rules/IPs — see
+   * `confirmDestructiveOperation`. */
+  allowDeletions?: boolean
 }
 
 /**
@@ -43,12 +47,44 @@ export class OperationSafety {
    * Confirm destructive operations with user
    */
   public static async confirmDestructiveOperation(options: SafetyConfirmationOptions): Promise<boolean> {
-    const { operation, target, changes, riskLevel, skipConfirmation = false, dryRun = false } = options
+    const {
+      operation,
+      target,
+      changes,
+      riskLevel,
+      skipConfirmation = false,
+      dryRun = false,
+      allowDeletions = false,
+    } = options
 
-    // Skip confirmation if explicitly requested or in dry-run mode
-    if (skipConfirmation || dryRun) {
-      if (dryRun) {
-        logger.info(`🔍 Dry run mode: Would perform ${operation} on ${target}`)
+    if (dryRun) {
+      logger.info(`🔍 Dry run mode: Would perform ${operation} on ${target}`)
+      return true
+    }
+
+    const deletionCount = (changes?.rulesToDelete?.length || 0) + (changes?.ipsToDelete?.length || 0)
+
+    if (skipConfirmation) {
+      // `skipConfirmation` (--force/--ci) authorizes running non-interactively,
+      // but never by itself authorizes deleting rules. Doorman has no state
+      // file, so a rule present remotely but absent from the local config
+      // could be one the user genuinely removed — or a pre-existing rule
+      // that's about to be silently destroyed with nobody watching CI logs
+      // to catch it (e.g. Cloudflare's full-ruleset-replace adopting and
+      // then overwriting whatever was already in the zone's custom rules
+      // list on the very first sync). Deletions always require the separate
+      // `allowDeletions` opt-in when running unattended.
+      if (deletionCount > 0 && !allowDeletions) {
+        logger.error(
+          `\n🚨 Refusing to run ${operation} non-interactively: this would delete ${deletionCount} existing rule(s)/IP(s), and there is no confirmation prompt to catch a mistake.`,
+        )
+        if (changes) {
+          this.displayChangeSummary(changes)
+        }
+        logger.error(
+          `\nIf this is intended, re-run with --allow-deletions. Run "doorman diff" first if you're not sure what would be removed.`,
+        )
+        return false
       }
       return true
     }


### PR DESCRIPTION
## Summary

Cloudflare's full-ruleset-replace sync adopts whatever ruleset already exists at the `http_request_firewall_custom` phase (the same one the dashboard's Custom Rules UI edits) and overwrites it entirely with the local config's rules. In `--ci` mode this happened with zero confirmation, so a first sync against a zone with pre-existing (dashboard- or Terraform-managed) custom rules could silently delete them.

`OperationSafety.confirmDestructiveOperation` now requires a separate `allowDeletions` opt-in, distinct from `skipConfirmation` (`--force`/`--ci`), before a non-interactive sync is allowed to delete anything. Without it, a `--ci` sync that would delete rules/IPs is refused with a clear log of what would've been removed, instead of applying silently. Exposed as `doorman sync --ci --allow-deletions`. `doorman watch` opts in directly (`allowDeletions: true`) since it's an interactively-started session, not headless CI.

Wired into both `CloudflareFirewallService` and `VercelFirewallService` for architectural consistency, though only the Cloudflare path is currently reachable from the CLI (tracked separately in #155, the dual-Vercel-implementation issue).

This is the first of three PRs from a broader WAF-adapter review (Cloudflare and Vercel provider correctness/safety issues). The other two build on top of this one.

Closes #157

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green (new `confirmDestructiveOperation` regression tests cover: refuses non-interactive deletions without the flag, allows them with it, allows non-deleting non-interactive syncs without needing the flag, dry-run always short-circuits regardless)
- [x] `pnpm eslint` — clean