### PR TITLE
fix: diff Cloudflare rules in native space, keep IP-list rule across syncs

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -315,19 +315,24 @@ export class CloudflareFirewallService extends BaseFirewallService {
           logger.info(`Removed ${ipsDeleted} IPs from List`)
         }
 
-        // Add a rule to block IPs in the list (if not already present)
+        // Ensure a rule blocking IPs in the list is present in this sync's
+        // ruleset payload. `cloudflareRules` is rebuilt from scratch every
+        // sync (the whole ruleset is replaced in one PUT below), so checking
+        // the *previous* ruleset's rules for this — `ruleset.rules.some(...)`
+        // — was wrong: once sync #1 added the list rule, sync #2 would see it
+        // "already there" in that stale pre-sync snapshot and omit it from
+        // the new array, silently overwriting the ruleset without it. The
+        // List itself stayed populated, so IP blocking went dark with no
+        // error. There's nothing to append to here — `cloudflareRules` is a
+        // fresh array — so always including it once has no duplication risk.
         const listRuleExpression = `ip.src in $${ipList.name.replace(/\s+/g, '_').toLowerCase()}`
-        const hasListRule = ruleset.rules.some((r) => r.expression.includes('in $'))
-
-        if (!hasListRule && config.ips.length > 0) {
-          cloudflareRules.push({
-            id: `rule_doorman_ip_list`,
-            action: 'block',
-            expression: listRuleExpression,
-            description: 'Block IPs in Doorman IP Blocklist',
-            enabled: true,
-          })
-        }
+        cloudflareRules.push({
+          id: `rule_doorman_ip_list`,
+          action: 'block',
+          expression: listRuleExpression,
+          description: 'Block IPs in Doorman IP Blocklist',
+          enabled: true,
+        })
       } catch (error) {
         // Enhanced fallback handling with detailed messaging
         this.handleListsAPIFallback(error, 'syncing IPs via List')
@@ -374,9 +379,17 @@ export class CloudflareFirewallService extends BaseFirewallService {
 
     const result: SyncResult = {
       success: true,
-      rulesAdded: config.rules.length,
-      rulesUpdated: 0,
-      rulesDeleted: 0,
+      // The actual write below is a full-ruleset replace, not incremental
+      // add/update/delete calls — these counts come from the pre-sync diff
+      // (now accurate, see getChanges) rather than reflecting the mechanics
+      // of the write itself. Previously this always reported
+      // `rulesAdded: config.rules.length, rulesUpdated: 0, rulesDeleted: 0`
+      // regardless of what actually changed, which could flatly contradict
+      // the "Proposed Changes" preview shown moments earlier from the same
+      // diff.
+      rulesAdded: dryRunResult.changes.rulesToAdd.length,
+      rulesUpdated: dryRunResult.changes.rulesToUpdate.length,
+      rulesDeleted: dryRunResult.changes.rulesToDelete.length,
       ipsAdded,
       ipsUpdated,
       ipsDeleted,
@@ -389,39 +402,102 @@ export class CloudflareFirewallService extends BaseFirewallService {
   }
 
   /**
-   * Get changes between local and remote configurations
+   * Get changes between local and remote configurations.
+   *
+   * Diffs rules in Cloudflare's *native* space (real wirefilter expressions)
+   * rather than going through `fetchConfig()`'s lossy Unified translation —
+   * `cloudflareToUnified` always returns `conditions: []` (expression
+   * parsing isn't implemented), so a remote rule with real conditions could
+   * never diff-equal its local counterpart: every synced rule showed as
+   * `toUpdate` forever, even on a no-op sync. See
+   * `CloudflareOptimizer.diffCloudflareRules`.
    */
   public async getChanges(config: UnifiedConfig): Promise<ChangeSet> {
-    const remoteConfig = await this.fetchConfig()
+    const ruleset = await this.client.getOrCreateFirewallRuleset()
 
-    // Use optimizer's hash-based diff for better performance with large rule sets
-    const ruleDiff = this.optimizer.diffRules(config.rules, remoteConfig.rules)
+    const remoteCloudflareRules = ruleset.rules.filter(
+      (r) => r && r.id && r.expression && r.action && !this.isListBasedIPRule(r) && !this.isIPBlockingRule(r),
+    )
 
-    // Compare IPs using optimizer's diff
+    const localTranslations = config.rules.map((rule) => ({
+      rule,
+      translated: RuleTranslator.unifiedToCloudflare(rule).result,
+    }))
+
+    const ruleDiff = this.optimizer.diffCloudflareRules(localTranslations, remoteCloudflareRules)
+    // No local counterpart for a remote-only rule — best-effort translation
+    // back to Unified (still lossy on conditions) is fine for a delete
+    // preview, which only needs to identify *what* is being removed.
+    const rulesToDelete = ruleDiff.toDelete.map((r) => RuleTranslator.cloudflareToUnified(r).result)
+
+    // IP diffing is unaffected by the above: it round-trips losslessly
+    // already (only `ip`/`action` are ever compared).
     let ipDiff: { toAdd: UnifiedIPRule[]; toUpdate: UnifiedIPRule[]; toDelete: UnifiedIPRule[] } = {
       toAdd: [],
       toUpdate: [],
       toDelete: [],
     }
-    if (config.ips && remoteConfig.ips) {
-      ipDiff = this.optimizer.diffIPRules(config.ips, remoteConfig.ips)
+    if (config.ips) {
+      const remoteIPs = await this.fetchRemoteIPRulesForDiff(ruleset.rules)
+      ipDiff = this.optimizer.diffIPRules(config.ips, remoteIPs)
     }
 
     return {
       rulesToAdd: ruleDiff.toAdd,
       rulesToUpdate: ruleDiff.toUpdate,
-      rulesToDelete: ruleDiff.toDelete,
+      rulesToDelete,
       ipsToAdd: ipDiff.toAdd,
       ipsToUpdate: ipDiff.toUpdate,
       ipsToDelete: ipDiff.toDelete,
       hasChanges:
         ruleDiff.toAdd.length > 0 ||
         ruleDiff.toUpdate.length > 0 ||
-        ruleDiff.toDelete.length > 0 ||
+        rulesToDelete.length > 0 ||
         ipDiff.toAdd.length > 0 ||
         ipDiff.toUpdate.length > 0 ||
         ipDiff.toDelete.length > 0,
     }
+  }
+
+  /**
+   * Fetch the current IP blocking state directly from the ruleset's simple
+   * IP rules plus (if enabled) the Lists API, without going through
+   * `fetchConfig()`'s full Unified rule translation — `getChanges()` only
+   * needs IP state, and reusing `fetchConfig()` here would redo the very
+   * rule translation this method exists to avoid. IP rules round-trip
+   * losslessly already (only `ip`/`action` matter), so this duplicates a
+   * small amount of `fetchConfig()`'s IP-gathering logic rather than sharing
+   * it, to avoid touching that well-covered method's rule-processing loop.
+   */
+  private async fetchRemoteIPRulesForDiff(rulesetRules: CloudflareRule[]): Promise<UnifiedIPRule[]> {
+    const ips: UnifiedIPRule[] = []
+
+    for (const rule of rulesetRules) {
+      if (rule && rule.id && rule.expression && rule.action && this.isIPBlockingRule(rule)) {
+        ips.push(this.cloudflareRuleToIPRule(rule))
+      }
+    }
+
+    if (this.useListsForIPs) {
+      try {
+        const ipList = await this.client.getOrCreateIPBlocklist()
+        const listItems = await this.client.getListItems(ipList.id)
+        for (const item of listItems) {
+          if (item.ip) {
+            ips.push({
+              id: item.id,
+              ip: item.ip,
+              notes: item.comment,
+              action: 'deny',
+            })
+          }
+        }
+      } catch (error) {
+        this.handleListsAPIFallback(error, 'fetching IPs from List')
+      }
+    }
+
+    return ips
   }
 
   /**

--- a/src/lib/providers/cloudflare/CloudflareOptimizer.ts
+++ b/src/lib/providers/cloudflare/CloudflareOptimizer.ts
@@ -1,5 +1,18 @@
 import { logger } from '../../logger'
 import type { UnifiedRule, UnifiedIPRule } from '../../types/unified'
+import type { CloudflareRule } from '../../types/cloudflare'
+
+/**
+ * Result of diffing native Cloudflare rules against their translated local
+ * counterparts. `toAdd`/`toUpdate` are the *original* `UnifiedRule`s (not the
+ * translated `CloudflareRule`s) so callers keep the lossless local data;
+ * `toDelete` has no local counterpart, so it stays in Cloudflare's native form.
+ */
+export interface CloudflareRuleDiffResult {
+  toAdd: UnifiedRule[]
+  toUpdate: UnifiedRule[]
+  toDelete: CloudflareRule[]
+}
 
 /**
  * Result of an optimized rule diff operation
@@ -203,6 +216,71 @@ export class CloudflareOptimizer {
     )
 
     return { toAdd, toUpdate, toDelete, unchanged, duration }
+  }
+
+  /**
+   * Diff local rules against remote rules in Cloudflare's *native* space
+   * (comparing real wirefilter expressions) instead of `diffRules`'s unified
+   * space. `RuleTranslator.cloudflareToUnified` always returns
+   * `conditions: []` (expression parsing isn't implemented), so a hash keyed
+   * on `conditions` — `diffRules`'s approach, fed a remote array translated
+   * through `cloudflareToUnified` — could never hash-equal a local rule with
+   * real conditions: every synced rule showed as `toUpdate` forever, even
+   * with nothing to sync. Comparing the real `expression` string on both
+   * sides (translating local rules to Cloudflare's format, never translating
+   * remote rules to unified) sidesteps that entirely.
+   *
+   * Keying matches `diffRules`'s existing semantics exactly (local
+   * `rule.id || rule.name` against remote `CloudflareRule.id`, which is
+   * always what `cloudflareToUnified` sets as the unified rule's own `id`) —
+   * this method changes what counts as "equal" for a matched pair, not how
+   * pairs are matched.
+   */
+  public diffCloudflareRules(
+    local: Array<{ rule: UnifiedRule; translated: CloudflareRule }>,
+    remote: CloudflareRule[],
+  ): CloudflareRuleDiffResult {
+    const remoteById = new Map(remote.map((r) => [r.id, r]))
+    const localKeys = new Set<string>()
+    const toAdd: UnifiedRule[] = []
+    const toUpdate: UnifiedRule[] = []
+
+    for (const { rule, translated } of local) {
+      const key = rule.id || rule.name
+      localKeys.add(key)
+      const remoteRule = remoteById.get(key)
+      if (!remoteRule) {
+        toAdd.push(rule)
+      } else if (!this.cloudflareRulesEqual(translated, remoteRule)) {
+        toUpdate.push(rule)
+      }
+    }
+
+    const toDelete: CloudflareRule[] = []
+    for (const [key, remoteRule] of remoteById) {
+      if (!localKeys.has(key)) {
+        toDelete.push(remoteRule)
+      }
+    }
+
+    return { toAdd, toUpdate, toDelete }
+  }
+
+  /**
+   * Compare two native Cloudflare rules on the fields that actually
+   * determine wire behavior. `id`/`last_updated`/`version`/`ref`/`categories`
+   * are deliberately excluded — they're either identity (already used for
+   * matching, not equality) or metadata Cloudflare manages itself.
+   */
+  private cloudflareRulesEqual(a: CloudflareRule, b: CloudflareRule): boolean {
+    return (
+      a.action === b.action &&
+      a.expression === b.expression &&
+      (a.enabled ?? true) === (b.enabled ?? true) &&
+      (a.description || '') === (b.description || '') &&
+      JSON.stringify(a.ratelimit ?? null) === JSON.stringify(b.ratelimit ?? null) &&
+      JSON.stringify(a.action_parameters ?? null) === JSON.stringify(b.action_parameters ?? null)
+    )
   }
 
   /**

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -9,23 +9,22 @@ jest.mock('../../../logger', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
-// Mock OperationSafety for syncRules tests
+// Mock OperationSafety for syncRules tests. `performDryRunValidation` delegates
+// to the real `validateFn` (i.e. the real `getChanges`) instead of returning a
+// canned empty `changes` object — a fixed stub here would silently decouple
+// `rulesAdded`/`rulesUpdated`/`rulesDeleted` assertions below from the actual
+// diff logic, which is exactly the gap that previously let `syncRules` report
+// `rulesAdded: config.rules.length` unconditionally without any test catching it.
 jest.mock('../../../utils/operationSafety', () => ({
   OperationSafety: {
-    performDryRunValidation: jest.fn<() => Promise<any>>().mockResolvedValue({
-      valid: true,
-      changes: {
-        rulesToAdd: [],
-        rulesToUpdate: [],
-        rulesToDelete: [],
-        ipsToAdd: [],
-        ipsToUpdate: [],
-        ipsToDelete: [],
-        hasChanges: false,
-      },
-      issues: [],
-      warnings: [],
-    }),
+    performDryRunValidation: jest
+      .fn<(config: any, operation: string, validateFn: (c: any) => Promise<any>) => Promise<any>>()
+      .mockImplementation(async (config, _operation, validateFn) => ({
+        valid: true,
+        changes: await validateFn(config),
+        issues: [],
+        warnings: [],
+      })),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
     // assessOperationRisk moved here from a CloudflareFirewallService-private
     // method (shared with VercelFirewallService — see #104); tests don't
@@ -51,6 +50,23 @@ describe('CloudflareFirewallService', () => {
 
     // Get the client instance to mock its methods
     mockClient = service['client']
+
+    // Default Lists-API mocks so getChanges()'s IP-diffing path (now
+    // genuinely exercised, since performDryRunValidation above delegates to
+    // the real getChanges instead of skipping it) doesn't fall through to a
+    // real, hanging network call in tests that don't care about IP state.
+    // Tests that do care override these with their own jest.spyOn(...) calls.
+    jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+      id: 'list-1',
+      name: 'Doorman IP Blocklist',
+      description: 'Test',
+      kind: 'ip',
+      num_items: 0,
+      num_referencing_filters: 0,
+      created_on: '2024-01-01T00:00:00Z',
+      modified_on: '2024-01-01T00:00:00Z',
+    })
+    jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -528,6 +544,148 @@ describe('CloudflareFirewallService', () => {
       expect(mockClient.updateRuleset).toHaveBeenCalledTimes(1)
     })
 
+    // Regression test: syncRules previously reported `rulesAdded:
+    // config.rules.length, rulesUpdated: 0, rulesDeleted: 0` unconditionally —
+    // the actual write is a full-ruleset replace, but the *reported* stats
+    // must reflect the real pre-sync diff, not just echo the local rule count.
+    it('reports accurate add/update/delete counts from the actual diff, not config.rules.length', async () => {
+      const mockConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'rule-unchanged',
+            name: 'Unchanged Rule',
+            description: 'Unchanged',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/unchanged' }],
+          },
+          {
+            id: 'rule-changed',
+            name: 'Changed Rule',
+            description: 'Changed',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/new-path' }],
+          },
+          {
+            id: 'rule-new',
+            name: 'New Rule',
+            description: 'New',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/new' }],
+          },
+        ],
+        ips: [],
+      }
+
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-unchanged',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/unchanged"',
+            description: 'Unchanged',
+            enabled: true,
+          },
+          {
+            id: 'rule-changed',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/old-path"',
+            description: 'Changed',
+            enabled: true,
+          },
+          {
+            id: 'rule-to-delete',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/gone"',
+            description: 'Will be deleted',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'updateRuleset').mockResolvedValue({ ...mockRuleset, version: '2' })
+
+      const result = await service.syncRules(mockConfig)
+
+      expect(result.success).toBe(true)
+      expect(result.rulesAdded).toBe(1)
+      expect(result.rulesUpdated).toBe(1)
+      expect(result.rulesDeleted).toBe(1)
+    })
+
+    // Regression test: the rule blocking IPs in the List
+    // (`ip.src in $doorman_ip_blocklist`) was only added to the ruleset when
+    // it appeared *absent* from the ruleset fetched *before* this sync. Since
+    // the sync writes a brand-new `rules` array (full replace) rather than
+    // appending to the existing one, that check against stale pre-sync state
+    // meant sync #2 would see the rule "already there" from sync #1's
+    // snapshot and omit it from the new array — silently dropping IP
+    // blocking on the very next sync after it started working.
+    it('keeps the IP-list block rule present across repeated syncs', async () => {
+      const mockConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [{ id: 'ip-1', ip: '203.0.113.5', action: 'deny' }],
+      }
+
+      const listBlockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule_doorman_ip_list',
+            action: 'block',
+            expression: 'ip.src in $doorman_ip_blocklist',
+            description: 'Block IPs in Doorman IP Blocklist',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(listBlockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 1,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest
+        .spyOn(mockClient, 'getListItems')
+        .mockResolvedValue([
+          { id: 'item-1', ip: '203.0.113.5', created_on: '2024-01-01T00:00:00Z', modified_on: '2024-01-01T00:00:00Z' },
+        ])
+      const updateRulesetSpy = jest
+        .spyOn(mockClient, 'updateRuleset')
+        .mockResolvedValue({ ...listBlockRuleset, version: '2' })
+
+      // Simulates the *second* sync: the ruleset the mock returns already
+      // contains the list-block rule from a prior sync.
+      await service.syncRules(mockConfig)
+
+      const [, payload] = updateRulesetSpy.mock.calls[0]!
+      expect(payload.rules?.some((r) => r.expression.includes('ip.src in $'))).toBe(true)
+    })
+
     it('should sync IPs using Lists when account ID is provided', async () => {
       const mockConfig: UnifiedConfig = {
         version: '2.0',
@@ -879,6 +1037,102 @@ describe('CloudflareFirewallService', () => {
       expect(changes.rulesToUpdate).toHaveLength(0)
       expect(changes.rulesToDelete).toHaveLength(0)
       expect(changes.hasChanges).toBe(false)
+    })
+
+    // Regression test: cloudflareToUnified always returns `conditions: []`
+    // (expression parsing isn't implemented), so diffing in Unified space —
+    // the old approach — meant a local rule with real conditions could never
+    // match its remote counterpart: it showed as `toUpdate` forever, even
+    // with nothing to sync. getChanges() now diffs in Cloudflare's native
+    // space (comparing real wirefilter expressions) instead.
+    it('detects no changes for a rule with real conditions that matches its remote Cloudflare counterpart', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'rule-1',
+            name: 'Existing Rule',
+            description: 'Existing rule',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/test' }],
+          },
+        ],
+        ips: [],
+      }
+
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/test"',
+            description: 'Existing rule',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.rulesToDelete).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('detects an update when the locally-translated expression differs from the remote rule', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'rule-1',
+            name: 'Existing Rule',
+            description: 'Existing rule',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/new-path' }],
+          },
+        ],
+        ips: [],
+      }
+
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'block',
+            expression: 'http.request.uri.path eq "/old-path"',
+            description: 'Existing rule',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(1)
+      expect(changes.rulesToDelete).toHaveLength(0)
+      expect(changes.hasChanges).toBe(true)
     })
   })
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareRuleScenarios.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareRuleScenarios.test.ts
@@ -10,21 +10,19 @@ jest.mock('../../../logger', () => ({
 }))
 
 // Mock OperationSafety for syncRules tests
+// `performDryRunValidation` delegates to the real `validateFn` (the real
+// `getChanges`) rather than a canned empty `changes` object — see the longer
+// comment in CloudflareFirewallService.test.ts for why a fixed stub here
+// would decouple `rulesAdded` assertions below from the actual diff logic.
 jest.mock('../../../utils/operationSafety', () => ({
   OperationSafety: {
-    performDryRunValidation: jest.fn<() => Promise<any>>().mockResolvedValue({
-      valid: true,
-      changes: {
-        rulesToAdd: [],
-        rulesToUpdate: [],
-        rulesToDelete: [],
-        ipsToAdd: [],
-        ipsToUpdate: [],
-        ipsToDelete: [],
-        hasChanges: false,
-      },
-      issues: [],
-    }),
+    performDryRunValidation: jest
+      .fn<(config: any, operation: string, validateFn: (c: any) => Promise<any>) => Promise<any>>()
+      .mockImplementation(async (config, _operation, validateFn) => ({
+        valid: true,
+        changes: await validateFn(config),
+        issues: [],
+      })),
     confirmDestructiveOperation: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
     assessOperationRisk: jest.fn<() => 'low' | 'medium' | 'high'>().mockReturnValue('low'),
   },
@@ -42,6 +40,22 @@ describe('Cloudflare Rule Scenarios', () => {
     jest.clearAllMocks()
     service = new CloudflareFirewallService(API_TOKEN, ZONE_ID, ACCOUNT_ID)
     mockClient = service['client']
+
+    // Default Lists-API mocks so getChanges()'s IP-diffing path (now
+    // genuinely exercised, since performDryRunValidation above delegates to
+    // the real getChanges instead of skipping it) doesn't fall through to a
+    // real, hanging network call in tests that don't care about IP state.
+    jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+      id: 'list-1',
+      name: 'Doorman IP Blocklist',
+      description: 'Test',
+      kind: 'ip',
+      num_items: 0,
+      num_referencing_filters: 0,
+      created_on: '2024-01-01T00:00:00Z',
+      modified_on: '2024-01-01T00:00:00Z',
+    })
+    jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Three related Cloudflare sync/diff bugs, all invisible to the existing test suite because every test seeded an empty remote ruleset (which trivially "converges" regardless of the underlying bugs):

**1. Rule diffing could never converge for rules with real conditions.** `RuleTranslator.cloudflareToUnified` always returns `conditions: []` (expression parsing isn't implemented). `CloudflareOptimizer.diffRules` hashed rules on `conditions`, so a local rule with real conditions could never hash-equal its remote counterpart fetched through `cloudflareToUnified` — every synced rule showed as `toUpdate` forever, even on a no-op sync. `getChanges()` now diffs in Cloudflare's *native* rule space instead, comparing real wirefilter expression strings (new `CloudflareOptimizer.diffCloudflareRules`), rather than round-tripping the remote side through the lossy Unified translation.

**2. Sync always reported `rulesAdded: config.rules.length` regardless of the actual diff.** `syncRules()` computed an accurate diff for the pre-sync "Proposed Changes" preview, then discarded it for the completed-sync summary — the two could flatly contradict each other. Now reports real counts from the (now-accurate) diff.

**3. The Lists-based IP-block rule was silently dropped on the second sync.** `ip.src in $doorman_ip_blocklist` was only added to the sync payload when absent from the ruleset fetched *before* this sync. Since the payload is a fresh array each time (full replace), sync #2 saw the rule "already there" from sync #1's stale snapshot and omitted it — silently disabling IP blocking while the underlying List stayed populated. Now always included when Lists-based blocking is active.

Builds on #164 (merged) for the `allowDeletions` safety gate. Second of three PRs from a broader WAF-adapter review.

Note: fix #1 addresses the *diffing* symptom, not the underlying gap that `doorman download`/`list`/`status`/`diff` still show empty conditions for Cloudflare-sourced rules — tracked separately in #153 (wirefilter expression parsing).

Closes #158, #159, #160

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green, 4 new regression tests: no-changes-detected for a rule with real conditions matching its remote counterpart, update-detected when the translated expression differs, accurate add/update/delete counts from a mixed diff (not `config.rules.length`), IP-list block rule present across two consecutive syncs
- [x] `pnpm eslint` — clean