### PR TITLE
fix: stop Vercel sync from corrupting rules and discarding real errors

### DIFF
--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -28,6 +28,22 @@ export interface VercelConfig {
 
 export const VERCEL_API_BASE_URL = 'https://api.vercel.com/v1/security/firewall/config'
 
+export interface FetchFirewallConfigOptions {
+  /**
+   * Whether a missing firewall configuration may be created on the caller's
+   * behalf — i.e. whether it's OK to prompt "Would you like to create one?"
+   * and, if confirmed, issue the mutating PUT that creates an empty config.
+   *
+   * Defaults to `true`, preserving the original create-on-first-use
+   * behavior for real syncs. Read-only callers (e.g. dry-run validation)
+   * MUST pass `false` so a project with no firewall config yet never
+   * triggers an interactive prompt (which hangs with no TTY, e.g. in CI)
+   * or a real write during what's supposed to be a side-effect-free
+   * operation.
+   */
+  allowCreate?: boolean
+}
+
 /**
  * A client for interacting with the Vercel API to manage firewall rules.
  */
@@ -75,7 +91,8 @@ export class VercelClient extends BaseFirewallClient {
    * @returns A promise that resolves to the firewall config.
    * @throws An error if the fetch request fails.
    */
-  async fetchFirewallConfig(configVersion?: number): Promise<VercelConfig> {
+  async fetchFirewallConfig(configVersion?: number, options?: FetchFirewallConfigOptions): Promise<VercelConfig> {
+    const { allowCreate = true } = options ?? {}
     const response = await this.get<ApiResponse>(this.getUrl(configVersion))
 
     logger.debug('Config Version:', configVersion ?? 'latest')
@@ -87,6 +104,15 @@ export class VercelClient extends BaseFirewallClient {
 
     if (!response || ('active' in response && response.active === null)) {
       logger.warn(chalk.bold('No firewall configuration found.'))
+
+      if (!allowCreate) {
+        // Read-only fetch (e.g. dry-run validation) — never prompt or
+        // mutate remote state. Return a synthetic empty config so diffing
+        // logic still has something to compare against.
+        logger.debug('Skipping create-configuration prompt for read-only fetch.')
+        return this.emptyConfigPlaceholder()
+      }
+
       const createEmptyFirstVersion = await prompt('Would you like to create one?', {
         type: 'confirm',
       })
@@ -104,6 +130,26 @@ export class VercelClient extends BaseFirewallClient {
     }
 
     return (response as LatestConfigResponse).active
+  }
+
+  /**
+   * A synthetic, never-persisted empty config used when a read-only caller
+   * (e.g. dry-run validation) asks for the firewall config of a project
+   * that doesn't have one yet, and creation is disallowed. Never sent to
+   * the Vercel API.
+   */
+  private emptyConfigPlaceholder(): VercelConfig {
+    return {
+      version: 0,
+      id: '',
+      firewallEnabled: true,
+      crs: null,
+      rules: [],
+      ips: [],
+      projectKey: '',
+      ownerId: '',
+      updatedAt: new Date(0).toISOString(),
+    }
   }
 
   async putEmptyConfig(): Promise<VercelConfig> {

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -86,10 +86,14 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       // with no dry-run check and no confirmation prompt.
       const { OperationSafety } = require('../../utils/operationSafety')
 
+      // Compute changes without allowing a missing remote config to be
+      // created — that create-prompt/mutating-PUT path (in
+      // VercelClient.fetchFirewallConfig) must not run before we know
+      // whether this is a dry run. See getChanges' `allowCreate` option.
       const dryRunResult = await OperationSafety.performDryRunValidation(
         config,
         'sync rules',
-        async (cfg: UnifiedConfig) => await this.getChanges(cfg),
+        async (cfg: UnifiedConfig) => await this.getChanges(cfg, { allowCreate: !dryRun }),
       )
 
       if (!dryRunResult.valid) {
@@ -172,56 +176,96 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       const updatedIPRules: IPBlockingRule[] = []
       const deletedIPRules: IPBlockingRule[] = []
 
+      // Collected per-item failures across all six sub-loops below. A
+      // single item exhausting its retries no longer aborts the whole sync
+      // (and every independent operation still queued) — it's recorded
+      // here, the loop moves on, and the final SyncResult reports exactly
+      // what succeeded and what didn't via `errors`/`success`, instead of
+      // throwing away all progress information.
+      const errors: string[] = []
+      const describeError = (context: string, error: unknown): string =>
+        `${context}: ${error instanceof Error ? error.message : String(error)}`
+
       // Delete custom rules
       for (const rule of toDelete) {
-        logger.debug(`Deleting custom rule: ${rule.id}`)
-        await retry(() => this.client.deleteFirewallRule(rule), { maxAttempts: 3 })
-        deletedRules.push(rule)
-        logger.debug(`Custom rule deleted: ${rule.id}`)
+        try {
+          logger.debug(`Deleting custom rule: ${rule.id}`)
+          await retry(() => this.client.deleteFirewallRule(rule), { maxAttempts: 3 })
+          deletedRules.push(rule)
+          logger.debug(`Custom rule deleted: ${rule.id}`)
+        } catch (error) {
+          logger.error(`Failed to delete custom rule ${rule.id}:`, error)
+          errors.push(describeError(`Failed to delete custom rule ${rule.id}`, error))
+        }
       }
 
       // Delete IP blocking rules
       for (const rule of ipRulesToDelete) {
-        logger.debug(`Deleting IP blocking rule: ${rule.id}`)
-        await retry(() => this.client.deleteIPBlockingRule(rule), { maxAttempts: 3 })
-        deletedIPRules.push(rule)
-        logger.debug(`IP blocking rule deleted: ${rule.id}`)
+        try {
+          logger.debug(`Deleting IP blocking rule: ${rule.id}`)
+          await retry(() => this.client.deleteIPBlockingRule(rule), { maxAttempts: 3 })
+          deletedIPRules.push(rule)
+          logger.debug(`IP blocking rule deleted: ${rule.id}`)
+        } catch (error) {
+          logger.error(`Failed to delete IP blocking rule ${rule.id}:`, error)
+          errors.push(describeError(`Failed to delete IP blocking rule ${rule.id}`, error))
+        }
       }
 
       // Add new custom rules
       for (const rule of toAdd) {
-        logger.debug(`Adding new custom rule: ${rule.name}`)
-        const newRule = await retry(() => this.client.createFirewallRule(rule), {
-          maxAttempts: 3,
-        })
-        addedRules.push(newRule)
-        logger.debug(`New custom rule added: ${newRule.id}`)
+        try {
+          logger.debug(`Adding new custom rule: ${rule.name}`)
+          const newRule = await retry(() => this.client.createFirewallRule(rule), {
+            maxAttempts: 3,
+          })
+          addedRules.push(newRule)
+          logger.debug(`New custom rule added: ${newRule.id}`)
+        } catch (error) {
+          logger.error(`Failed to add custom rule "${rule.name}":`, error)
+          errors.push(describeError(`Failed to add custom rule "${rule.name}"`, error))
+        }
       }
 
       // Add new IP blocking rules
       for (const rule of ipRulesToAdd) {
-        logger.debug(`Adding new IP blocking rule: ${rule.ip}`)
-        const newIPRule = await retry(() => this.client.createIPBlockingRule(rule), {
-          maxAttempts: 3,
-        })
-        addedIPRules.push(newIPRule)
-        logger.debug(`New IP blocking rule added: (hostname): ${newIPRule.hostname} (ip): ${newIPRule.ip}`)
+        try {
+          logger.debug(`Adding new IP blocking rule: ${rule.ip}`)
+          const newIPRule = await retry(() => this.client.createIPBlockingRule(rule), {
+            maxAttempts: 3,
+          })
+          addedIPRules.push(newIPRule)
+          logger.debug(`New IP blocking rule added: (hostname): ${newIPRule.hostname} (ip): ${newIPRule.ip}`)
+        } catch (error) {
+          logger.error(`Failed to add IP blocking rule ${rule.ip}:`, error)
+          errors.push(describeError(`Failed to add IP blocking rule ${rule.ip}`, error))
+        }
       }
 
       // Update existing custom rules
       for (const rule of toUpdate) {
-        logger.debug(`Updating custom rule: ${rule.id}`)
-        const updatedRule = await retry(() => this.client.updateFirewallRule(rule), { maxAttempts: 3 })
-        updatedRules.push(updatedRule)
-        logger.debug(`Custom rule updated: ${updatedRule.id}`)
+        try {
+          logger.debug(`Updating custom rule: ${rule.id}`)
+          const updatedRule = await retry(() => this.client.updateFirewallRule(rule), { maxAttempts: 3 })
+          updatedRules.push(updatedRule)
+          logger.debug(`Custom rule updated: ${updatedRule.id}`)
+        } catch (error) {
+          logger.error(`Failed to update custom rule ${rule.id}:`, error)
+          errors.push(describeError(`Failed to update custom rule ${rule.id}`, error))
+        }
       }
 
       // Update existing IP blocking rules
       for (const rule of ipRulesToUpdate) {
-        logger.debug(`Updating IP blocking rule: ${rule.id}`)
-        const updatedRule = await retry(() => this.client.updateIPBlockingRule(rule), { maxAttempts: 3 })
-        updatedIPRules.push(updatedRule)
-        logger.debug(`IP blocking rule updated: ${updatedRule.id}`)
+        try {
+          logger.debug(`Updating IP blocking rule: ${rule.id}`)
+          const updatedRule = await retry(() => this.client.updateIPBlockingRule(rule), { maxAttempts: 3 })
+          updatedIPRules.push(updatedRule)
+          logger.debug(`IP blocking rule updated: ${updatedRule.id}`)
+        } catch (error) {
+          logger.error(`Failed to update IP blocking rule ${rule.id}:`, error)
+          errors.push(describeError(`Failed to update IP blocking rule ${rule.id}`, error))
+        }
       }
 
       logger.debug(
@@ -233,32 +277,58 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
           `${chalk.cyan('Updated:')} ${chalk.cyan(updatedIPRules.length)}, ${chalk.red('Deleted:')} ${chalk.red(deletedIPRules.length)}`,
       )
 
-      // Fetch updated version
-      const activeConfig = await this.client.fetchFirewallConfig()
+      // Fetch updated version. Best-effort: a failure here shouldn't
+      // discard the sync results already collected above. Falls back to
+      // the pre-sync version (captured before any mutations) if it fails.
+      let finalVersion: number = version
+      try {
+        const activeConfig = await this.client.fetchFirewallConfig()
+        finalVersion = activeConfig.version
+      } catch (error) {
+        logger.error('Failed to fetch updated firewall configuration version after sync:', error)
+        errors.push(describeError('Failed to fetch updated configuration version after sync', error))
+      }
 
       return {
-        success: true,
+        success: errors.length === 0,
         rulesAdded: addedRules.length,
         rulesUpdated: updatedRules.length,
         rulesDeleted: deletedRules.length,
         ipsAdded: addedIPRules.length,
         ipsUpdated: updatedIPRules.length,
         ipsDeleted: deletedIPRules.length,
-        version: activeConfig.version,
+        version: finalVersion,
+        errors: errors.length > 0 ? errors : undefined,
       }
     } catch (error) {
       logger.error('Error during sync:', error)
-      throw new Error('Failed to synchronize firewall rules')
+      // Preserve the real error instead of discarding it behind a generic
+      // message — callers (and anyone debugging a failed sync) need to
+      // know *why* it failed, not just that it did.
+      throw new Error(
+        `Failed to synchronize firewall rules: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      )
     }
   }
 
   /**
    * Get changes between local and remote configuration
    */
-  async getChanges(config: UnifiedConfig): Promise<ChangeSet & { version: number }> {
+  async getChanges(
+    config: UnifiedConfig,
+    options?: { allowCreate?: boolean },
+  ): Promise<ChangeSet & { version: number }> {
     try {
       logger.debug('Fetching existing firewall configuration')
-      const activeConfig = await this.client.fetchFirewallConfig()
+      // `allowCreate: false` is threaded down from syncRules' dry-run path
+      // so a project without a firewall config yet never triggers the
+      // interactive create-prompt (or the mutating PUT behind it) while
+      // we're only computing what a sync *would* do. Real (non-dry-run)
+      // syncs keep the default `true`, preserving create-on-first-use.
+      const activeConfig = await this.client.fetchFirewallConfig(undefined, {
+        allowCreate: options?.allowCreate ?? true,
+      })
       logger.debug(`Fetched ${activeConfig.rules.length} custom rules and ${activeConfig.ips.length} IP blocking rules`)
 
       // Convert unified rules back to Vercel format for comparison

--- a/src/lib/providers/vercel/__tests__/VercelClient.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelClient.test.ts
@@ -16,6 +16,8 @@ jest.mock('../../../ui/prompt', () => ({
   prompt: jest.fn().mockResolvedValue(false),
 }))
 
+import { prompt } from '../../../ui/prompt'
+
 describe('VercelClient', () => {
   const projectId = 'proj_123'
   const teamId = 'team_456'
@@ -131,6 +133,45 @@ describe('VercelClient', () => {
       fetchSpy.mockResolvedValue(createMockResponse({ error: 'Unauthorized' }, 401, 'Unauthorized'))
 
       await expect(client.fetchFirewallConfig()).rejects.toThrow()
+    })
+
+    describe('when no firewall configuration exists yet (active: null)', () => {
+      it('prompts to create one by default (allowCreate defaults to true)', async () => {
+        fetchSpy.mockResolvedValue(createMockResponse({ active: null }))
+        ;(prompt as jest.Mock).mockResolvedValueOnce(false)
+
+        const result = await client.fetchFirewallConfig()
+
+        expect(prompt).toHaveBeenCalledWith('Would you like to create one?', { type: 'confirm' })
+        expect(result).toBeNull()
+      })
+
+      it('creates an empty config when the user confirms the prompt (allowCreate defaults to true)', async () => {
+        fetchSpy
+          .mockResolvedValueOnce(createMockResponse({ active: null }))
+          .mockResolvedValueOnce(createMockResponse(mockVercelConfig))
+        ;(prompt as jest.Mock).mockResolvedValueOnce(true)
+
+        const result = await client.fetchFirewallConfig()
+
+        expect(prompt).toHaveBeenCalled()
+        // putEmptyConfig() issues the mutating PUT — verify it actually fired.
+        expect(fetchSpy).toHaveBeenCalledTimes(2)
+        expect(fetchSpy.mock.calls[1]![1]).toEqual(expect.objectContaining({ method: 'PUT' }))
+        expect(result).toEqual(mockVercelConfig.active)
+      })
+
+      it('never prompts or mutates when allowCreate is false, and returns a synthetic empty config instead', async () => {
+        fetchSpy.mockResolvedValue(createMockResponse({ active: null }))
+
+        const result = await client.fetchFirewallConfig(undefined, { allowCreate: false })
+
+        expect(prompt).not.toHaveBeenCalled()
+        // Only the initial GET should have fired — no follow-up PUT.
+        expect(fetchSpy).toHaveBeenCalledTimes(1)
+        expect(result.rules).toEqual([])
+        expect(result.ips).toEqual([])
+      })
     })
   })
 

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -17,7 +17,14 @@ jest.mock('../../../utils/retry', () => ({
   retry: (fn: () => Promise<unknown>) => fn(),
 }))
 
+// Mock the prompt module — used to assert the create-firewall-config prompt
+// is never triggered during a dry run (regression coverage, see below).
+jest.mock('../../../ui/prompt', () => ({
+  prompt: jest.fn(),
+}))
+
 import { OperationSafety } from '../../../utils/operationSafety'
+import { prompt } from '../../../ui/prompt'
 
 describe('VercelFirewallService', () => {
   let service: VercelFirewallService
@@ -259,6 +266,136 @@ describe('VercelFirewallService', () => {
       jest.spyOn(client, 'fetchFirewallConfig').mockRejectedValue(new Error('API error'))
 
       await expect(service.syncRules(unifiedConfig)).rejects.toThrow('Failed to synchronize firewall rules')
+    })
+
+    describe('dry-run side effects (regression: --dry-run must never prompt or mutate)', () => {
+      it('computes changes without allowing the remote config to be auto-created during a dry run', async () => {
+        const spy = jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+          ...mockVercelConfig,
+          rules: [],
+          ips: [],
+        })
+
+        await service.syncRules(unifiedConfig, { dryRun: true })
+
+        expect(spy).toHaveBeenCalledWith(undefined, { allowCreate: false })
+      })
+
+      it('still allows the remote config to be auto-created for a real (non-dry-run) sync', async () => {
+        const spy = jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+          ...mockVercelConfig,
+          rules: [],
+          ips: [],
+        })
+        jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+          id: 'new_rule_1',
+          name: 'Block bots',
+          active: true,
+          conditionGroup: [],
+          action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+        })
+        jest.spyOn(client, 'createIPBlockingRule').mockResolvedValue({
+          id: 'new_ip_1',
+          ip: '1.2.3.4',
+          hostname: 'example.com',
+          action: 'deny',
+        })
+
+        await service.syncRules(unifiedConfig)
+
+        expect(spy).toHaveBeenCalledWith(undefined, { allowCreate: true })
+      })
+
+      it('never prompts to create a firewall config, or performs the mutating create, during a dry run against an unconfigured project (end-to-end through the real VercelClient)', async () => {
+        // Uses the real VercelClient (not a stubbed fetchFirewallConfig) so this
+        // exercises the fix all the way down to the HTTP layer: a project with
+        // no active firewall config yet must never trigger the interactive
+        // "Would you like to create one?" prompt during --dry-run, since that
+        // prompt (a) hangs with no TTY in CI/non-interactive runs and (b) is
+        // followed by a real mutating PUT if confirmed.
+        const realClient = new VercelClient('proj_123', 'team_456', 'test-token')
+        const realService = new VercelFirewallService(realClient)
+
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          json: jest.fn().mockResolvedValue({ active: null }),
+          text: jest.fn().mockResolvedValue(JSON.stringify({ active: null })),
+          clone: jest.fn(),
+        } as unknown as Response)
+        const putEmptyConfigSpy = jest.spyOn(realClient, 'putEmptyConfig')
+
+        const result = await realService.syncRules(unifiedConfig, { dryRun: true })
+
+        expect(prompt).not.toHaveBeenCalled()
+        expect(putEmptyConfigSpy).not.toHaveBeenCalled()
+        expect(result.success).toBe(true)
+
+        fetchSpy.mockRestore()
+      })
+    })
+
+    describe('partial failure handling (regression: a single failing operation used to abort the whole sync and discard the real error)', () => {
+      it('preserves the real underlying error message and cause when sync fails outside the per-item loops', async () => {
+        jest.spyOn(client, 'fetchFirewallConfig').mockRejectedValue(new Error('Vercel API unavailable'))
+
+        await expect(service.syncRules(unifiedConfig)).rejects.toThrow(
+          /Failed to synchronize firewall rules:.*Failed to fetch existing firewall configuration/,
+        )
+
+        const error: unknown = await service.syncRules(unifiedConfig).catch((e) => e)
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).cause).toBeInstanceOf(Error)
+      })
+
+      it('returns a partial SyncResult (success: false, errors populated) when one operation in the middle of a loop fails, without discarding what succeeded', async () => {
+        const config: UnifiedConfig = {
+          version: '2.0',
+          provider: 'vercel',
+          rules: [
+            {
+              name: 'Rule A',
+              enabled: true,
+              conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+              action: { type: 'deny' },
+            },
+            {
+              name: 'Rule B',
+              enabled: true,
+              conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+              action: { type: 'deny' },
+            },
+          ],
+          ips: [],
+        }
+
+        jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+          ...mockVercelConfig,
+          rules: [],
+          ips: [],
+        })
+
+        const createFirewallRuleSpy = jest.spyOn(client, 'createFirewallRule')
+        createFirewallRuleSpy.mockResolvedValueOnce({
+          id: 'new_rule_a',
+          name: 'Rule A',
+          active: true,
+          conditionGroup: [],
+          action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+        })
+        createFirewallRuleSpy.mockRejectedValueOnce(new Error('Vercel API 500'))
+
+        const result = await service.syncRules(config)
+
+        expect(createFirewallRuleSpy).toHaveBeenCalledTimes(2)
+        expect(result.success).toBe(false)
+        expect(result.rulesAdded).toBe(1)
+        expect(result.errors).toBeDefined()
+        expect(result.errors!.some((e) => e.includes('Rule B'))).toBe(true)
+        expect(result.errors!.some((e) => e.includes('Vercel API 500'))).toBe(true)
+      })
     })
   })
 

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -1,4 +1,4 @@
-import type { VercelCustomRule, VercelIPBlockingRule, VercelConditionGroup } from '../types/vercel'
+import type { VercelCustomRule, VercelIPBlockingRule, VercelConditionGroup, VercelRuleCondition } from '../types/vercel'
 import type { CloudflareRule } from '../types/cloudflare'
 import type { UnifiedRule, UnifiedIPRule, UnifiedCondition, UnifiedAction } from '../types/unified'
 import { ExpressionBuilder } from './ExpressionBuilder'
@@ -340,14 +340,42 @@ export class RuleTranslator {
     const warnings: TranslationWarning[] = []
     const conditionGroups: VercelConditionGroup[] = []
 
-    // Convert unified conditions to Vercel condition groups
-    const conditions = rule.conditions.map((condition) => ({
-      op: this.mapUnifiedOperatorToVercel(condition.operator),
-      neg: condition.negated,
-      type: this.mapUnifiedTypeToVercel(condition.field),
-      key: condition.key,
-      value: condition.value,
-    }))
+    // Convert unified conditions to Vercel condition groups. A condition whose
+    // field has no Vercel equivalent (e.g. Cloudflare-only `referer`/`port`) is
+    // dropped with a critical warning rather than mistranslated — silently
+    // relabeling it (the previous behavior defaulted to `path`) rewrote what
+    // the rule actually matches with no indication anything was wrong.
+    const conditions: VercelRuleCondition[] = []
+    for (const condition of rule.conditions) {
+      const type = this.mapUnifiedTypeToVercel(condition.field)
+      if (!type) {
+        const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+        warnings.push(
+          TranslationWarningSystem.createUnsupportedFeatureWarning(
+            `condition field '${condition.field}'`,
+            'unified config',
+            'Vercel',
+            rule.id,
+            condition.field,
+          ),
+        )
+        continue
+      }
+      conditions.push({
+        op: this.mapUnifiedOperatorToVercel(condition.operator),
+        neg: condition.negated,
+        type,
+        key: condition.key,
+        value: condition.value,
+      })
+    }
+
+    if (conditions.length === 0) {
+      throw new Error(
+        `Rule "${rule.name}" has no conditions Vercel can represent — every condition field is unsupported ` +
+          'by Vercel (e.g. Cloudflare-only fields like referer/port). Cannot sync this rule to Vercel.',
+      )
+    }
 
     conditionGroups.push({ conditions })
 
@@ -488,6 +516,14 @@ export class RuleTranslator {
     return mapping[op] || 'eq'
   }
 
+  /**
+   * Vercel types with no entry here (e.g. `target_path`, `region`, `protocol`,
+   * `environment`, `geo_continent`, `geo_country_region`, `ja4_digest`,
+   * `ja3_digest`, `rate_limit_api_id`) fall through to `mapping[type] || type`
+   * below and are preserved as-is as the unified field name. `mapUnifiedTypeToVercel`
+   * (the reverse direction) has an explicit entry for every one of those
+   * pass-through fields so the round trip is lossless — keep the two in sync.
+   */
   private static mapVercelTypeToUnified(type: string): string {
     const mapping: Record<string, string> = {
       host: 'host',
@@ -507,23 +543,49 @@ export class RuleTranslator {
     return mapping[type] || type
   }
 
-  private static mapUnifiedTypeToVercel(type: string): import('../types/vercel').VercelRuleType {
-    const mapping: Record<string, import('../types/vercel').VercelRuleType> = {
-      host: 'host',
-      path: 'path',
-      method: 'method',
-      header: 'header',
-      query: 'query',
-      cookie: 'cookie',
-      ip: 'ip_address',
-      user_agent: 'user_agent',
-      country: 'geo_country',
-      city: 'geo_city',
-      asn: 'geo_as_number',
-      scheme: 'scheme',
-    }
+  /**
+   * Unified condition fields with a Vercel condition-type equivalent. Covers
+   * both the renamed unified fields (e.g. `ip` -> `ip_address`) and every
+   * Vercel-native type `mapVercelTypeToUnified` passes through unchanged
+   * (`region`, `protocol`, `environment`, `geo_continent`, `geo_country_region`,
+   * `ja4_digest`, `ja3_digest`, `rate_limit_api_id`, `target_path`) — those must
+   * map back to themselves, not fall through to a default.
+   */
+  private static readonly UNIFIED_TO_VERCEL_TYPE_MAP: Record<string, import('../types/vercel').VercelRuleType> = {
+    host: 'host',
+    path: 'path',
+    method: 'method',
+    header: 'header',
+    query: 'query',
+    cookie: 'cookie',
+    ip: 'ip_address',
+    user_agent: 'user_agent',
+    country: 'geo_country',
+    city: 'geo_city',
+    asn: 'geo_as_number',
+    scheme: 'scheme',
+    target_path: 'target_path',
+    region: 'region',
+    protocol: 'protocol',
+    environment: 'environment',
+    geo_continent: 'geo_continent',
+    geo_country_region: 'geo_country_region',
+    ja4_digest: 'ja4_digest',
+    ja3_digest: 'ja3_digest',
+    rate_limit_api_id: 'rate_limit_api_id',
+  }
 
-    return mapping[type] || 'path'
+  /**
+   * Map a unified condition field to its Vercel condition type, or `null` if
+   * Vercel has no equivalent (e.g. unified `referer`/`port`, which only
+   * Cloudflare supports). Previously this defaulted unmapped fields to `'path'`,
+   * which silently rewrote the *meaning* of a condition into a bogus path
+   * match — with no warning — corrupting a live rule on every routine sync,
+   * not just a cross-provider migration. Returning `null` lets the caller
+   * (`unifiedToVercel`) drop the condition and warn instead.
+   */
+  private static mapUnifiedTypeToVercel(type: string): import('../types/vercel').VercelRuleType | null {
+    return this.UNIFIED_TO_VERCEL_TYPE_MAP[type] ?? null
   }
 
   private static mapCloudflareActionToUnified(action: CloudflareRule['action']): import('../types/common').ActionType {

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -244,6 +244,59 @@ describe('RuleTranslator', () => {
       }
     })
 
+    // Regression test: Vercel-native fields not covered by the renamed-field
+    // table above (e.g. `region`, `ja3_digest`) must map back to themselves,
+    // not silently collapse to `path` — see mapUnifiedTypeToVercel.
+    it('round-trips Vercel-native field types that have no renamed unified counterpart', () => {
+      const vercelNativeFields = [
+        'target_path',
+        'region',
+        'protocol',
+        'environment',
+        'geo_continent',
+        'geo_country_region',
+        'ja4_digest',
+        'ja3_digest',
+        'rate_limit_api_id',
+      ] as const
+
+      for (const field of vercelNativeFields) {
+        const rule = makeUnifiedRule({
+          conditions: [{ field, operator: 'eq', value: 'test' }],
+        })
+        const { result } = RuleTranslator.unifiedToVercel(rule)
+        expect(result.conditionGroup[0]!.conditions[0]!.type).toBe(field)
+      }
+    })
+
+    // Regression test: a condition field with no Vercel equivalent (e.g.
+    // Cloudflare-only `referer`/`port`) must be dropped with a warning, never
+    // silently mislabeled as `path`.
+    it('drops a condition with no Vercel equivalent and warns instead of defaulting to path', () => {
+      const rule = makeUnifiedRule({
+        conditions: [
+          { field: 'referer', operator: 'eq', value: 'https://example.com' },
+          { field: 'path', operator: 'eq', value: '/api' },
+        ],
+      })
+      const { result, warnings } = RuleTranslator.unifiedToVercel(rule)
+
+      expect(result.conditionGroup[0]!.conditions).toHaveLength(1)
+      expect(result.conditionGroup[0]!.conditions[0]!.type).toBe('path')
+      expect(warnings.some((w) => w.severity === 'critical' && w.field === 'referer')).toBe(true)
+    })
+
+    // Regression test: if every condition on a rule is unsupported by Vercel,
+    // there's nothing safe to drop down to — this must fail loudly rather
+    // than sync a rule with zero conditions (which would match everything).
+    it('throws when no condition on the rule has a Vercel equivalent', () => {
+      const rule = makeUnifiedRule({
+        conditions: [{ field: 'referer', operator: 'eq', value: 'https://example.com' }],
+      })
+
+      expect(() => RuleTranslator.unifiedToVercel(rule)).toThrow(/no conditions Vercel can represent/)
+    })
+
     it('translates rate_limit action', () => {
       const rule = makeUnifiedRule({
         action: {


### PR DESCRIPTION
## Summary

Three related Vercel translation/sync bugs, all invisible to the existing test suite because it only exercised the 12 renamed condition fields and never a mid-loop sync failure:

**1. Unmapped condition fields were silently corrupted to `path`.** `VercelRuleType` has 20 members; `RuleTranslator.mapUnifiedTypeToVercel` only explicitly mapped 12 and fell back to `mapping[type] || 'path'` for anything unrecognized — silently, with no warning. Any rule using a JA3/JA4 fingerprint, `geo_continent`, `region`, `protocol`, or `environment` condition (all legitimate Vercel-native types) got silently reinterpreted as a path match on the *next routine sync*, not just a migration. Now has explicit entries for all 9 previously-missing Vercel-native types, and drops (with a critical warning) rather than mislabels anything genuinely unrepresentable in Vercel (e.g. Cloudflare-only `referer`/`port`) — throwing only if *every* condition on a rule turns out unrepresentable, since a rule with zero conditions would match all traffic.

**2. `--dry-run` was not side-effect-free.** `syncRules()` computed dry-run validation via `getChanges()` -> `VercelClient.fetchFirewallConfig()` *before* checking `options.dryRun`. A project with no firewall config yet triggers an interactive create-prompt there, and a confirmed prompt issues a real mutating PUT — regardless of `dryRun`. In CI (no TTY) this could hang; either way it broke the dry-run-is-side-effect-free contract. `fetchFirewallConfig` gained an `allowCreate` option; `syncRules` now passes `allowCreate: !dryRun` before branching on dry-run, so a dry run can never reach the prompt/mutation path.

**3. A single mid-sync failure aborted the whole sync and discarded the real error.** The six sequential add/update/delete sub-loops each let a single retry-exhausted failure propagate straight out of `syncRules`, and the outer catch replaced the real error with a generic `"Failed to synchronize firewall rules"` — discarding the actual cause and any information about what had already succeeded. Since deletes run first, this could leave production mid-migration (old rules gone, replacements never applied) with no rollback and no explanation. Each sub-loop now catches its own failures, collects them into `SyncResult.errors`, and continues; the outer catch now preserves the real error as both the message and the `cause`.

Builds on #164 (merged). Third of three PRs from a broader WAF-adapter review.

Closes #161, #162, #163

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green, new regression tests: round-trip for the 9 previously-broken Vercel-native field types, drop+warn for a field with no Vercel equivalent, throw when every condition is unrepresentable, dry-run never triggers the create-prompt (mocked and real-client end-to-end), real sync still allows create-on-first-use, real error/cause preserved on failure, partial `SyncResult` returned when one operation in a loop fails
- [x] `pnpm eslint` — clean