### PR TITLE
fix: harden Cloudflare Lists API and IP-rule handling

### DIFF
--- a/src/lib/providers/BaseFirewallClient.ts
+++ b/src/lib/providers/BaseFirewallClient.ts
@@ -96,7 +96,20 @@ export abstract class BaseFirewallClient {
 
           // Handle rate limiting with exponential backoff
           if (response.status === 429) {
-            const waitTime = this.calculateRateLimitWait(attempt)
+            const waitTime = this.calculateRateLimitWait(attempt, response)
+
+            // Retrying past the last attempt would just fall through to the
+            // generic `lastError || new Error('Request failed after all
+            // retries')` below, discarding the fact this was a rate-limit
+            // exhaustion. Throw a real error with that context instead —
+            // it flows through the same catch-block handling as any other
+            // attempt (isNonRetryableError, last-attempt re-throw).
+            if (attempt === retries) {
+              throw new Error(
+                `${this.providerName} API rate limit exceeded after ${retries + 1} attempt(s) (429 Too Many Requests). Retry after ~${Math.round(waitTime / 1000)}s.`,
+              )
+            }
+
             logger.warn(
               `Rate limit exceeded for ${this.providerName}. Waiting ${waitTime}ms before retry (attempt ${attempt + 1}/${retries + 1})...`,
             )
@@ -238,10 +251,24 @@ export abstract class BaseFirewallClient {
   }
 
   /**
-   * Calculate wait time for rate limit with exponential backoff
+   * Calculate wait time for rate limit with exponential backoff.
+   *
+   * `Retry-After` (RFC 9110 §10.2.3) is the standard header servers use to
+   * tell a client how long to wait after a 429/503 — Cloudflare's API sends
+   * it — and takes priority over the non-standard `X-RateLimit-Reset` this
+   * client also tracks, which not every provider even sends. Falls back to
+   * exponential backoff only when the response gives no explicit guidance.
    */
-  private calculateRateLimitWait(attempt: number = 0): number {
+  private calculateRateLimitWait(attempt: number = 0, response?: Response): number {
     const maxWait = 60000 // Cap at 1 minute
+
+    const retryAfterMs = response ? this.parseRetryAfter(response.headers.get('Retry-After')) : null
+    if (retryAfterMs !== null) {
+      // Minimum 1 second, capped at 1 minute — same reasoning as the
+      // X-RateLimit-Reset cap below: a far-future value shouldn't block the
+      // command for its full duration on a single retry with no override.
+      return Math.min(Math.max(retryAfterMs, 1000), maxWait)
+    }
 
     if (this.rateLimitInfo.reset) {
       const now = Math.floor(Date.now() / 1000)
@@ -257,6 +284,27 @@ export abstract class BaseFirewallClient {
     const exponentialWait = baseWait * Math.pow(2, attempt)
 
     return Math.min(exponentialWait, maxWait)
+  }
+
+  /**
+   * Parse a `Retry-After` header value into a millisecond delay from now.
+   * Per RFC 9110 §10.2.3 the value is either an integer number of seconds,
+   * or an HTTP-date. Returns `null` if the header is absent or unparseable.
+   */
+  private parseRetryAfter(value: string | null): number | null {
+    if (!value) return null
+
+    const seconds = Number(value)
+    if (Number.isFinite(seconds)) {
+      return seconds * 1000
+    }
+
+    const dateMs = Date.parse(value)
+    if (!Number.isNaN(dateMs)) {
+      return dateMs - Date.now()
+    }
+
+    return null
   }
 
   /**

--- a/src/lib/providers/__tests__/BaseFirewallClient.test.ts
+++ b/src/lib/providers/__tests__/BaseFirewallClient.test.ts
@@ -106,6 +106,76 @@ describe('BaseFirewallClient', () => {
     expect(delaySpy).toHaveBeenCalledWith(60000)
   })
 
+  // Regression test: Retry-After (RFC 9110) is the standard header servers
+  // use on 429s — Cloudflare sends it — and previously wasn't read at all,
+  // only the non-standard X-RateLimit-Reset was. Must take priority.
+  it('honors Retry-After over X-RateLimit-Reset when both are present', async () => {
+    const delaySpy = jest.spyOn(client as unknown as { delay: (ms: number) => Promise<void> }, 'delay')
+    const now = Math.floor(Date.now() / 1000)
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          jsonBody: { message: 'Rate limit' },
+          headers: {
+            'Retry-After': '5',
+            'X-RateLimit-Reset': String(now + 3600), // would otherwise dominate and wait ~1hr (capped to 60s)
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: { ok: true } }))
+
+    await client.getJson('/retry-after', { retries: 1, retryDelay: 1 })
+
+    expect(delaySpy).toHaveBeenCalledWith(5000)
+  })
+
+  it('parses a Retry-After HTTP-date as well as a delay-in-seconds', async () => {
+    const delaySpy = jest.spyOn(client as unknown as { delay: (ms: number) => Promise<void> }, 'delay')
+    const retryAt = new Date(Date.now() + 10000)
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          jsonBody: { message: 'Rate limit' },
+          headers: { 'Retry-After': retryAt.toUTCString() },
+        }),
+      )
+      .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: { ok: true } }))
+
+    await client.getJson('/retry-after-date', { retries: 1, retryDelay: 1 })
+
+    // Allow a little slack for time elapsed during the test itself.
+    const waitMs = delaySpy.mock.calls[0]?.[0] as number
+    expect(waitMs).toBeGreaterThan(8000)
+    expect(waitMs).toBeLessThanOrEqual(10000)
+  })
+
+  // Regression test: exhausting retries while still getting 429s previously
+  // fell through to a generic "Request failed after all retries" error,
+  // losing all rate-limit context.
+  it('throws a rate-limit-specific error when retries are exhausted while still getting 429', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeResponse({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        jsonBody: { message: 'Rate limit' },
+        headers: { 'Retry-After': '1' },
+      }),
+    )
+
+    await expect(client.getJson('/exhausted', { retries: 1, retryDelay: 1 })).rejects.toThrow(
+      /rate limit exceeded after 2 attempt/i,
+    )
+  })
+
   it('does not retry on 400 and throws formatted error', async () => {
     const fetchMock = jest
       .spyOn(globalThis, 'fetch')

--- a/src/lib/providers/cloudflare/CloudflareClient.ts
+++ b/src/lib/providers/cloudflare/CloudflareClient.ts
@@ -666,8 +666,28 @@ export class CloudflareClient extends BaseFirewallClient {
     // Deduplicate concurrent requests for the same list items
     const dedupKey = CloudflareOptimizer.requestKey('GET', `/accounts/${this.accountId}/rules/lists/${listId}/items`)
     return this.optimizer.deduplicateRequest(dedupKey, async () => {
+      const items = await this.fetchAllListItemPages(listId)
+      this.cache.set(cacheKey, items, CacheTTL.LIST_ITEMS)
+      return items
+    })
+  }
+
+  /**
+   * Fetch every page of a List's items. Cloudflare paginates the Lists API
+   * (`result_info.page`/`total_pages`); a single unparameterized GET only
+   * ever returns page 1, so any List beyond one page silently looked
+   * incomplete to every caller (fetchConfig, getChanges's IP diffing,
+   * syncRules's add/remove-IP logic) — IPs beyond page 1 looked "missing"
+   * (redundant re-add attempts) and stale IPs beyond page 1 were never
+   * identified for removal.
+   */
+  private async fetchAllListItemPages(listId: string): Promise<CloudflareListItem[]> {
+    const items: CloudflareListItem[] = []
+    let page = 1
+
+    for (;;) {
       const response = await this.get<CloudflareListItemsResponse>(
-        `/accounts/${this.accountId}/rules/lists/${listId}/items`,
+        `/accounts/${this.accountId}/rules/lists/${listId}/items?page=${page}`,
       )
 
       if (!response.success) {
@@ -680,9 +700,16 @@ export class CloudflareClient extends BaseFirewallClient {
         )
       }
 
-      this.cache.set(cacheKey, response.result, CacheTTL.LIST_ITEMS)
-      return response.result
-    })
+      items.push(...response.result)
+
+      const totalPages = response.result_info?.total_pages ?? 1
+      if (response.result.length === 0 || page >= totalPages) {
+        break
+      }
+      page++
+    }
+
+    return items
   }
 
   /**

--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -281,7 +281,13 @@ export class CloudflareFirewallService extends BaseFirewallService {
     let ipsDeleted = 0
 
     if (this.useListsForIPs && config.ips && config.ips.length > 0) {
-      // Use Lists for IP blocking
+      // Use Lists for IP blocking. Tracks which IPs are confirmed present in
+      // the List as each step actually completes, so a failure *partway*
+      // through (e.g. addListItems succeeds but a later step throws) doesn't
+      // fall back to creating individual rules for IPs that already made it
+      // into the List — that would leave them in both places (duplicate,
+      // inconsistent state) and double-count them in ipsAdded.
+      const confirmedInList = new Set<string>()
       try {
         const ipList = await this.client.getOrCreateIPBlocklist()
         // Cache for potential future use
@@ -290,6 +296,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
         // Get current IPs in list
         const currentItems = await this.client.getListItems(ipList.id)
         const currentIPs = new Set(currentItems.map((item) => item.ip))
+        currentIPs.forEach((ip) => ip && confirmedInList.add(ip))
         const desiredIPs = new Set(config.ips.map((ip) => ip.ip))
 
         // Add new IPs
@@ -302,6 +309,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
             })),
           })
           ipsAdded = ipsToAdd.length
+          ipsToAdd.forEach((ip) => confirmedInList.add(ip.ip))
           logger.info(`Added ${ipsAdded} IPs to List`)
         }
 
@@ -312,6 +320,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
             items: ipsToRemove.map((item) => ({ id: item.id! })),
           })
           ipsDeleted = ipsToRemove.length
+          ipsToRemove.forEach((item) => item.ip && confirmedInList.delete(item.ip))
           logger.info(`Removed ${ipsDeleted} IPs from List`)
         }
 
@@ -337,18 +346,25 @@ export class CloudflareFirewallService extends BaseFirewallService {
         // Enhanced fallback handling with detailed messaging
         this.handleListsAPIFallback(error, 'syncing IPs via List')
 
-        // Fall back to individual IP rules
-        logger.info(`🔄 Falling back to individual IP rules for ${config.ips.length} IPs`)
-        for (const ip of config.ips) {
-          const cloudflareRule = RuleTranslator.unifiedIPToCloudflare(ip)
-          cloudflareRules.push(cloudflareRule)
+        // Only fall back to individual rules for IPs not already confirmed
+        // committed to the List by the time the failure happened.
+        const ipsNeedingFallback = config.ips.filter((ip) => !confirmedInList.has(ip.ip))
+
+        if (ipsNeedingFallback.length > 0) {
+          logger.info(`🔄 Falling back to individual IP rules for ${ipsNeedingFallback.length} IPs`)
+          for (const ip of ipsNeedingFallback) {
+            const cloudflareRule = RuleTranslator.unifiedIPToCloudflare(ip)
+            cloudflareRules.push(cloudflareRule)
+          }
+          ipsAdded = ipsNeedingFallback.length
+        } else {
+          logger.info('All IPs were already confirmed in the List before the failure; no fallback rules needed.')
         }
-        ipsAdded = config.ips.length
 
         // Warn about performance impact for large lists
-        if (config.ips.length > 50) {
+        if (ipsNeedingFallback.length > 50) {
           logger.warn(
-            `⚠️  Performance warning: Using ${config.ips.length} individual IP rules instead of Lists. ` +
+            `⚠️  Performance warning: Using ${ipsNeedingFallback.length} individual IP rules instead of Lists. ` +
               'This may impact rule processing speed and count against your rule limit.',
           )
         }
@@ -776,8 +792,19 @@ export class CloudflareFirewallService extends BaseFirewallService {
    * `eq` only matches a single literal, so CIDR ranges use the `in` set
    * operator instead). The address pattern allows IPv4 dotted-decimal and
    * IPv6 hex/colon forms.
+   *
+   * Also requires the rule's action to be one `unifiedIPToCloudflare` could
+   * actually have produced (`block`/`allow`) — without this, any rule from
+   * another tool (or hand-crafted) that happens to match the expression
+   * shape but uses a different action (e.g. `challenge`/`log` a single IP)
+   * gets misclassified as an IP rule, and `cloudflareRuleToIPRule` below
+   * collapses that real action down to a plain allow/deny, silently
+   * changing what the rule does on the next sync.
    */
   private isIPBlockingRule(rule: CloudflareRule): boolean {
+    if (rule.action !== 'block' && rule.action !== 'allow') {
+      return false
+    }
     const expression = rule.expression.trim()
     return (
       CloudflareFirewallService.IP_EQ_PATTERN.test(expression) ||

--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -622,6 +622,69 @@ describe('CloudflareClient', () => {
       expect(result).toEqual(mockItems)
     })
 
+    // Regression test: getListItems previously issued a single unparameterized
+    // GET and returned page 1 only, silently dropping items beyond it.
+    it('paginates through every page of List items', async () => {
+      const page1Items: CloudflareListItem[] = [
+        { id: 'item-1', ip: '10.0.0.1', created_on: '2024-01-01T00:00:00Z', modified_on: '2024-01-01T00:00:00Z' },
+      ]
+      const page2Items: CloudflareListItem[] = [
+        { id: 'item-2', ip: '10.0.0.2', created_on: '2024-01-01T00:00:00Z', modified_on: '2024-01-01T00:00:00Z' },
+      ]
+      const page3Items: CloudflareListItem[] = [
+        { id: 'item-3', ip: '10.0.0.3', created_on: '2024-01-01T00:00:00Z', modified_on: '2024-01-01T00:00:00Z' },
+      ]
+
+      fetchMock
+        .mockResolvedValueOnce(
+          makeResponse({
+            ok: true,
+            status: 200,
+            jsonBody: {
+              success: true,
+              errors: [],
+              messages: [],
+              result: page1Items,
+              result_info: { count: 1, page: 1, per_page: 1, total_count: 3, total_pages: 3 },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            ok: true,
+            status: 200,
+            jsonBody: {
+              success: true,
+              errors: [],
+              messages: [],
+              result: page2Items,
+              result_info: { count: 1, page: 2, per_page: 1, total_count: 3, total_pages: 3 },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            ok: true,
+            status: 200,
+            jsonBody: {
+              success: true,
+              errors: [],
+              messages: [],
+              result: page3Items,
+              result_info: { count: 1, page: 3, per_page: 1, total_count: 3, total_pages: 3 },
+            },
+          }),
+        )
+
+      const result = await client.getListItems('multi-page-list')
+
+      expect(result).toEqual([...page1Items, ...page2Items, ...page3Items])
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchMock.mock.calls[0]?.[0]).toContain('page=1')
+      expect(fetchMock.mock.calls[1]?.[0]).toContain('page=2')
+      expect(fetchMock.mock.calls[2]?.[0]).toContain('page=3')
+    })
+
     it('should add items to a List', async () => {
       const newItems = [
         {

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -241,6 +241,50 @@ describe('CloudflareFirewallService', () => {
       expect(config.ips?.[0]?.hostname).toBe('example.com')
     })
 
+    // Regression test: a single-IP-shaped rule (`ip.src eq <ip>`) whose
+    // action is something other than block/allow — e.g. challenge or log —
+    // was previously misclassified as a plain IP block/allow rule anyway,
+    // silently discarding its real action. It must instead be treated as a
+    // regular rule.
+    it('does not treat a single-IP rule with a non-block/allow action as an IP blocking rule', async () => {
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [
+          {
+            id: 'rule-1',
+            action: 'challenge',
+            expression: 'ip.src eq 192.168.1.100',
+            description: 'Challenge a specific IP',
+            enabled: true,
+          },
+        ],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 0,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+      const config = await service.fetchConfig()
+
+      expect(config.ips).toHaveLength(0)
+      expect(config.rules).toHaveLength(1)
+      expect(config.rules[0]?.action.type).toBe('challenge')
+    })
+
     it('should recognize a CIDR IP-blocking rule using the `in {...}` set form (regression test)', async () => {
       const mockRuleset: CloudflareRuleset = {
         id: 'ruleset-1',
@@ -847,6 +891,71 @@ describe('CloudflareFirewallService', () => {
       expect(result.success).toBe(true)
       expect(result.ipsAdded).toBe(1)
       // Should have used individual IP rules as fallback
+    })
+
+    // Regression test: a Lists API failure *after* addListItems already
+    // succeeded previously fell back to creating individual rules for every
+    // IP in config.ips — including ones already confirmed added to the List
+    // — leaving them in both places (duplicate/inconsistent state) and
+    // double-counting them in ipsAdded.
+    it('does not create duplicate individual IP rules for IPs already confirmed in the List after a partial failure', async () => {
+      const mockConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [
+          { id: 'ip-1', ip: '192.168.1.1', action: 'deny' },
+          { id: 'ip-2', ip: '192.168.1.2', action: 'deny' },
+        ],
+      }
+
+      const mockRuleset: CloudflareRuleset = {
+        id: 'ruleset-1',
+        name: 'Test Ruleset',
+        description: 'Test',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [],
+      }
+
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(mockRuleset)
+      jest.spyOn(mockClient, 'getOrCreateIPBlocklist').mockResolvedValue({
+        id: 'list-1',
+        name: 'Doorman IP Blocklist',
+        description: 'Test',
+        kind: 'ip',
+        num_items: 1,
+        num_referencing_filters: 0,
+        created_on: '2024-01-01T00:00:00Z',
+        modified_on: '2024-01-01T00:00:00Z',
+      })
+      // A stale item currently in the list (not in the desired config) forces
+      // removeListItems to be called, which is where the failure happens —
+      // *after* addListItems has already succeeded.
+      jest.spyOn(mockClient, 'getListItems').mockResolvedValue([
+        {
+          id: 'stale-item',
+          ip: '10.0.0.99',
+          created_on: '2024-01-01T00:00:00Z',
+          modified_on: '2024-01-01T00:00:00Z',
+        },
+      ])
+      jest.spyOn(mockClient, 'addListItems').mockResolvedValue([])
+      jest.spyOn(mockClient, 'removeListItems').mockRejectedValue(new Error('Lists API error during removal'))
+      const updateRulesetSpy = jest
+        .spyOn(mockClient, 'updateRuleset')
+        .mockResolvedValue({ ...mockRuleset, version: '2' })
+
+      const result = await service.syncRules(mockConfig)
+
+      expect(result.success).toBe(true)
+      // Both IPs were confirmed added to the List before removeListItems failed
+      expect(result.ipsAdded).toBe(2)
+
+      const [, payload] = updateRulesetSpy.mock.calls[0]!
+      expect(payload.rules?.some((r) => r.expression.includes('192.168.1.1'))).toBe(false)
+      expect(payload.rules?.some((r) => r.expression.includes('192.168.1.2'))).toBe(false)
     })
 
     it('should use individual IP rules when no account ID provided', async () => {


### PR DESCRIPTION
## Summary

Four related bugs in Cloudflare Lists-API/IP-blocking and the shared HTTP retry engine:

**1. Lists API partial failure could duplicate IP state.** A failure *after* `addListItems` already succeeded fell back to creating individual rules for every IP in `config.ips`, including ones already confirmed added to the List — leaving them in both places (duplicate/inconsistent state) and double-counting them in `ipsAdded`. Now tracks which IPs are confirmed committed to the List as each step completes, and only falls back for the rest.

**2. Missing `Retry-After` handling.** `BaseFirewallClient`'s retry engine only read the non-standard `X-RateLimit-*` headers, never the standard `Retry-After` (RFC 9110) header Cloudflare's API actually sends on 429s — and exhausting retries while still 429 fell through to a generic `"Request failed after all retries"` error with no rate-limit context. `Retry-After` (both delay-in-seconds and HTTP-date forms) now takes priority over `X-RateLimit-Reset`, and exhausting retries under sustained 429s throws a specific error.

**3. `getListItems()` never paginated.** A single unparameterized GET returned page 1 only. Any IP list beyond one page silently looked incomplete to every caller (`fetchConfig`, `getChanges`'s IP diffing, `syncRules`'s add/remove logic) — IPs beyond page 1 looked "missing" and stale IPs beyond page 1 were never identified for removal. Now paginates through `result_info.total_pages`.

**4. Single-IP rules with non-deny/allow actions lost their real action.** Any Cloudflare rule shaped like a single-IP match (`ip.src eq <ip>` or `ip.src in {<cidr>}`) was treated as an IP blocking rule regardless of its actual action, collapsing e.g. a `challenge`/`log` action down to a plain allow/deny on the next fetch/sync. `isIPBlockingRule` now also requires the action to be one `unifiedIPToCloudflare` could actually have produced (`block`/`allow`).

Fourth PR from the broader WAF-adapter review; independent of the previous three (all merged).

Closes #146, #147, #148, #149

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green, 6 new regression tests: no duplicate individual rules after a partial Lists failure, `Retry-After` takes priority over `X-RateLimit-Reset` (both seconds and HTTP-date forms), specific error on 429 retry exhaustion, multi-page List pagination, a non-block/allow single-IP rule is treated as a regular rule not an IP rule
- [x] `pnpm eslint` — clean