### PR TITLE
fix: clean up notes clearing, referer key, duplicate ids, redundant retry

### DIFF
--- a/src/lib/providers/BaseFirewallService.ts
+++ b/src/lib/providers/BaseFirewallService.ts
@@ -75,6 +75,36 @@ export abstract class BaseFirewallService implements IFirewallProvider {
       })
     }
 
+    // Both providers' diffing keys rules by `rule.id || rule.name`
+    // (CloudflareOptimizer.diffCloudflareRules, VercelFirewallService's
+    // diffRules/diffIPRules) — two rules that produce the same key collide
+    // in that lookup, and one becomes invisible to the diff (silently never
+    // correctly added/updated/deleted) rather than erroring. This is most
+    // likely to happen for two id-less rules sharing a name, since
+    // RuleTranslator freely generates rules without ids.
+    if (config && Array.isArray(config.rules)) {
+      const firstIndexByKey = new Map<string, number>()
+      config.rules.forEach((rule, index) => {
+        const key = rule.id || rule.name
+        if (!key) return
+
+        const firstIndex = firstIndexByKey.get(key)
+        if (firstIndex === undefined) {
+          firstIndexByKey.set(key, index)
+          return
+        }
+
+        const firstRule = config.rules[firstIndex]
+        warnings.push({
+          path: `rules[${index}]`,
+          message: rule.id
+            ? `Rule "${rule.name}" has the same id ("${rule.id}") as rules[${firstIndex}] ("${firstRule?.name}") — they will collide during sync diffing and one may be silently skipped.`
+            : `Rule "${rule.name}" has the same name as rules[${firstIndex}] and neither has an explicit id — they will collide during sync diffing and one may be silently skipped. Add unique ids to disambiguate.`,
+          code: 'DUPLICATE_RULE_IDENTIFIER',
+        })
+      })
+    }
+
     return {
       valid: errors.length === 0,
       errors,

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -1290,6 +1290,66 @@ describe('CloudflareFirewallService', () => {
       expect(result.errors).toHaveLength(0)
     })
 
+    // Regression test for shared base-class logic (BaseFirewallService):
+    // both providers' diffing keys rules by `rule.id || rule.name`, so two
+    // id-less rules sharing a name collide during sync diffing and one
+    // silently becomes invisible to it. This must be a warning, not a hard
+    // error, since it's real risk a user can knowingly accept, but they
+    // should be told about it.
+    it('warns when two id-less rules share the same name', () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            name: 'Duplicate Name',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+          },
+          {
+            name: 'Duplicate Name',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+          },
+        ],
+        ips: [],
+      }
+
+      const result = service.validateConfig(config)
+
+      expect(result.warnings.some((w) => w.code === 'DUPLICATE_RULE_IDENTIFIER')).toBe(true)
+    })
+
+    it('does not warn about duplicate identifiers when rules have distinct explicit ids', () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'rule-a',
+            name: 'Same Name',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+          },
+          {
+            id: 'rule-b',
+            name: 'Same Name',
+            enabled: true,
+            action: { type: 'deny' },
+            conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+          },
+        ],
+        ips: [],
+      }
+
+      const result = service.validateConfig(config)
+
+      expect(result.warnings.some((w) => w.code === 'DUPLICATE_RULE_IDENTIFIER')).toBe(false)
+    })
+
     it('should detect rule count exceeding limit', () => {
       const rules: UnifiedRule[] = Array.from({ length: 130 }, (_, i) => ({
         id: `rule-${i}`,

--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -234,7 +234,14 @@ export class VercelClient extends BaseFirewallClient {
         action: rule.action,
         hostname: rule.hostname,
         ip: rule.ip,
-        ...(rule.notes && { notes: rule.notes }),
+        // Always send `notes`, even when falsy. This is a partial-update-
+        // style action (`ip.update`), so omitting the key when a user
+        // clears their local note (leaving `rule.notes` undefined) reads
+        // to Vercel's API as "leave the existing note alone" rather than
+        // "clear it" — the note would silently persist remotely after a
+        // sync that was supposed to remove it. An explicit `null` is
+        // unambiguous either way.
+        notes: rule.notes ?? null,
       },
     }
 

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -5,7 +5,6 @@ import { VercelClient } from './VercelClient'
 import { RuleTranslator } from '../../translators'
 import { isDeepEqual } from '../../utils/isDeepEqual'
 import { omitId } from '../../utils/omitId'
-import { retry } from '../../utils/retry'
 import { firewallConfigSchema } from '../../schemas/firewallSchemas'
 import type {
   IFirewallProvider,
@@ -190,7 +189,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of toDelete) {
         try {
           logger.debug(`Deleting custom rule: ${rule.id}`)
-          await retry(() => this.client.deleteFirewallRule(rule), { maxAttempts: 3 })
+          await this.client.deleteFirewallRule(rule)
           deletedRules.push(rule)
           logger.debug(`Custom rule deleted: ${rule.id}`)
         } catch (error) {
@@ -203,7 +202,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of ipRulesToDelete) {
         try {
           logger.debug(`Deleting IP blocking rule: ${rule.id}`)
-          await retry(() => this.client.deleteIPBlockingRule(rule), { maxAttempts: 3 })
+          await this.client.deleteIPBlockingRule(rule)
           deletedIPRules.push(rule)
           logger.debug(`IP blocking rule deleted: ${rule.id}`)
         } catch (error) {
@@ -216,9 +215,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of toAdd) {
         try {
           logger.debug(`Adding new custom rule: ${rule.name}`)
-          const newRule = await retry(() => this.client.createFirewallRule(rule), {
-            maxAttempts: 3,
-          })
+          const newRule = await this.client.createFirewallRule(rule)
           addedRules.push(newRule)
           logger.debug(`New custom rule added: ${newRule.id}`)
         } catch (error) {
@@ -231,9 +228,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of ipRulesToAdd) {
         try {
           logger.debug(`Adding new IP blocking rule: ${rule.ip}`)
-          const newIPRule = await retry(() => this.client.createIPBlockingRule(rule), {
-            maxAttempts: 3,
-          })
+          const newIPRule = await this.client.createIPBlockingRule(rule)
           addedIPRules.push(newIPRule)
           logger.debug(`New IP blocking rule added: (hostname): ${newIPRule.hostname} (ip): ${newIPRule.ip}`)
         } catch (error) {
@@ -246,7 +241,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of toUpdate) {
         try {
           logger.debug(`Updating custom rule: ${rule.id}`)
-          const updatedRule = await retry(() => this.client.updateFirewallRule(rule), { maxAttempts: 3 })
+          const updatedRule = await this.client.updateFirewallRule(rule)
           updatedRules.push(updatedRule)
           logger.debug(`Custom rule updated: ${updatedRule.id}`)
         } catch (error) {
@@ -259,7 +254,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       for (const rule of ipRulesToUpdate) {
         try {
           logger.debug(`Updating IP blocking rule: ${rule.id}`)
-          const updatedRule = await retry(() => this.client.updateIPBlockingRule(rule), { maxAttempts: 3 })
+          const updatedRule = await this.client.updateIPBlockingRule(rule)
           updatedIPRules.push(updatedRule)
           logger.debug(`IP blocking rule updated: ${updatedRule.id}`)
         } catch (error) {

--- a/src/lib/providers/vercel/__tests__/VercelClient.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelClient.test.ts
@@ -286,6 +286,23 @@ describe('VercelClient', () => {
       expect(body.id).toBe('ip_1')
     })
 
+    // Regression test: `notes` was previously omitted from the PATCH body
+    // entirely when falsy (`...(rule.notes && { notes: rule.notes })`),
+    // which — since ip.update is a partial-update action — reads to Vercel's
+    // API as "leave the existing note alone" rather than "clear it". A user
+    // who removed their local note would see it silently persist remotely.
+    it('sends an explicit null for notes when the local note was cleared, rather than omitting the key', async () => {
+      const ruleWithoutNotes = { ...ipRule, notes: undefined }
+      fetchSpy.mockResolvedValue(createMockResponse(ipRule))
+
+      await client.updateIPBlockingRule(ruleWithoutNotes)
+
+      const calledOptions = fetchSpy.mock.calls[0]![1] as RequestInit
+      const body = JSON.parse(calledOptions.body as string)
+      expect(body.value).toHaveProperty('notes')
+      expect(body.value.notes).toBeNull()
+    })
+
     it('should create a new IP blocking rule when id is "-"', async () => {
       const newIpRule = { ...ipRule, id: '-' }
       fetchSpy.mockResolvedValue(createMockResponse({ ...ipRule, id: 'new_ip_1' }))

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -12,11 +12,6 @@ jest.mock('../../../logger', () => ({
   },
 }))
 
-// Mock the retry utility to execute immediately
-jest.mock('../../../utils/retry', () => ({
-  retry: (fn: () => Promise<unknown>) => fn(),
-}))
-
 // Mock the prompt module — used to assert the create-firewall-config prompt
 // is never triggered during a dry run (regression coverage, see below).
 jest.mock('../../../ui/prompt', () => ({
@@ -396,6 +391,53 @@ describe('VercelFirewallService', () => {
         expect(result.errors!.some((e) => e.includes('Rule B'))).toBe(true)
         expect(result.errors!.some((e) => e.includes('Vercel API 500'))).toBe(true)
       })
+    })
+
+    // Regression test: each client call was previously wrapped in an
+    // additional `retry(fn, { maxAttempts: 3 })` on top of the retry/backoff
+    // BaseFirewallClient (which VercelClient extends) already performs
+    // internally — up to 3x the intended retry budget per operation, and
+    // 3x the wait time before a failure surfaces. VercelFirewallService
+    // should call the client exactly once per item and let the client's own
+    // retry logic (invisible at this mocked-client level) handle failures.
+    it('does not wrap client calls in an additional outer retry layer', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule-to-delete',
+            name: 'Stale Rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/stale' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [
+          {
+            id: 'rule-to-delete',
+            name: 'Stale Rule',
+            active: true,
+            conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/stale' }] }],
+            action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+          },
+        ],
+        ips: [],
+      })
+
+      const deleteFirewallRuleSpy = jest
+        .spyOn(client, 'deleteFirewallRule')
+        .mockRejectedValue(new Error('Vercel API 500'))
+
+      const result = await service.syncRules({ ...config, rules: [] })
+
+      expect(deleteFirewallRuleSpy).toHaveBeenCalledTimes(1)
+      expect(result.success).toBe(false)
     })
   })
 

--- a/src/lib/translators/FieldMapper.ts
+++ b/src/lib/translators/FieldMapper.ts
@@ -35,7 +35,20 @@ export class FieldMapper {
   }
 
   /**
-   * Cloudflare field → Vercel type mapping (reverse)
+   * Cloudflare field → Vercel type mapping (reverse).
+   *
+   * Three forward-mapping entries collapse two distinct Vercel types onto
+   * one Cloudflare field, so the reverse direction is necessarily lossy —
+   * this table picks one canonical Vercel type per Cloudflare field rather
+   * than trying to recover which of the two the value originally was:
+   *   - `region` and `geo_country_region` both -> `ip.geoip.subdivision_1`;
+   *     resolves back to `region`.
+   *   - `scheme` and `protocol` both -> `ssl`; resolves back to `protocol`.
+   *   - `path` and `target_path` both -> `http.request.uri.path`; resolves
+   *     back to `path` (no entry recovers `target_path`).
+   * `http.referer` is handled separately in `toVercel()`, not here — it
+   * needs `key: 'referer'` set on the returned condition, which a flat
+   * type->type table can't express.
    */
   private static readonly cloudflareToVercel: Record<string, VercelRuleType> = {
     'http.host': 'host',
@@ -48,7 +61,6 @@ export class FieldMapper {
     'ip.geoip.subdivision_1': 'region',
     ssl: 'protocol',
     'http.user_agent': 'user_agent',
-    'http.referer': 'header', // Map to header with key 'referer'
     'ip.geoip.continent': 'geo_continent',
     'ip.geoip.country': 'geo_country',
     'ip.geoip.city': 'geo_city',
@@ -93,6 +105,14 @@ export class FieldMapper {
       return { type: 'cookie', key: cookieMatch[1] }
     }
 
+    // Vercel has no dedicated referer condition type — it's just a header
+    // condition keyed on 'referer'. Handled here rather than in the flat
+    // cloudflareToVercel table below because it needs `key` set, which that
+    // table (type -> type only) can't express.
+    if (cloudflareField === 'http.referer') {
+      return { type: 'header', key: 'referer' }
+    }
+
     // Direct mapping
     const vercelType = this.cloudflareToVercel[cloudflareField]
     if (vercelType) {
@@ -117,6 +137,13 @@ export class FieldMapper {
   public static isVercelSupported(cloudflareField: string): boolean {
     // Check direct mapping
     if (this.cloudflareToVercel[cloudflareField]) {
+      return true
+    }
+
+    // http.referer is handled specially in toVercel() (see there), not via
+    // the direct mapping table above — must be checked here too, or this
+    // would report `false` for a field toVercel() can actually translate.
+    if (cloudflareField === 'http.referer') {
       return true
     }
 

--- a/src/lib/translators/__tests__/FieldMapper.test.ts
+++ b/src/lib/translators/__tests__/FieldMapper.test.ts
@@ -147,8 +147,13 @@ describe('FieldMapper', () => {
       expect(FieldMapper.toVercel('http.user_agent')).toEqual({ type: 'user_agent' })
     })
 
-    it('maps http.referer to header', () => {
-      expect(FieldMapper.toVercel('http.referer')).toEqual({ type: 'header' })
+    // Regression test: Vercel has no dedicated referer condition type — it's
+    // a header condition keyed on 'referer'. The key was previously dropped
+    // (the field mapped to a bare `{ type: 'header' }` with no key), which
+    // would translate into a header condition matching *any* header rather
+    // than specifically Referer.
+    it('maps http.referer to a header condition keyed on referer', () => {
+      expect(FieldMapper.toVercel('http.referer')).toEqual({ type: 'header', key: 'referer' })
     })
 
     it('maps ip.geoip.continent to geo_continent', () => {


### PR DESCRIPTION
## Summary

Four smaller, mostly-independent cleanups (Group B from the broader WAF-adapter review):

**1. Vercel IP rule `notes` could never be explicitly cleared.** `VercelClient.updateIPBlockingRule` omitted `notes` from the PATCH body entirely when falsy. Since `ip.update` is a partial-update action, a missing key reads as "leave the existing note alone" rather than "clear it" — a user who removed their local note would see it silently persist remotely. Now always sends `notes: rule.notes ?? null`.

**2. FieldMapper's `referer` reverse-mapping didn't match its own comment.** `FieldMapper.toVercel`'s reverse mapping for `http.referer` had a comment saying "map to header with key 'referer'" that the code never actually did — it fell through to the generic type table and returned a bare `{ type: 'header' }` with no key, which would translate into a header condition matching *any* header rather than specifically Referer. Currently unreachable in production (only `FieldMapper.toCloudflare` is wired into `ExpressionBuilder`), but fixed before it's used for real. `isVercelSupported` updated to match. Also documents (without changing) the three collision pairs where two Vercel types map onto one Cloudflare field (`region`/`geo_country_region`, `scheme`/`protocol`, `path`/`target_path`) — the reverse direction is necessarily lossy there and picks a canonical type by design.

**3. Rules sharing a name with no explicit id could collide during diffing.** Both providers' rule diffing keys rules by `rule.id || rule.name` (`CloudflareOptimizer.diffCloudflareRules`, `VercelFirewallService`'s `diffRules`/`diffIPRules`). Two id-less rules sharing a name produce the same key and collide, silently making one invisible to sync — a realistic scenario since `RuleTranslator` freely generates rules without ids. `BaseFirewallService.validateConfig` now warns when this would happen, covering both providers since they share this base class.

**4. Vercel sync double-wrapped every client call in retry logic.** `VercelFirewallService` wrapped every client call in an additional `retry(fn, { maxAttempts: 3 })` on top of the retry/backoff `BaseFirewallClient` (which `VercelClient` extends) already performs internally — up to 3x the intended retry budget and 3x the wait before a failure surfaces, and inconsistent with `CloudflareFirewallService` which relies solely on the shared client's own retry logic. Removed; the legacy `services/FirewallService.ts` (a different, non-`BaseFirewallClient` Vercel path) keeps its own `retry()` usage since it has no internal client retry to double up on.

Fifth PR from the broader WAF-adapter review; independent of the previous four (all merged).

Closes #150, #151, #152, #154

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green, new regression tests: explicit `null` sent for cleared notes, `referer` reverse-maps with its key, duplicate-identifier warning fires for id-less name collisions (and not for rules with distinct explicit ids), client calls are no longer double-retried
- [x] `pnpm eslint` — clean