### PR TITLE
fix: preserve condition-group fidelity in Vercel<->Unified translation

### DIFF
--- a/src/lib/translators/ExpressionBuilder.ts
+++ b/src/lib/translators/ExpressionBuilder.ts
@@ -56,17 +56,47 @@ export class ExpressionBuilder {
   }
 
   /**
-   * Build expression from unified conditions
+   * Build expression from unified conditions.
+   *
+   * Conditions may carry a `group` index — set when translated from a
+   * provider with a two-level AND-within/OR-across condition model (e.g.
+   * Vercel's `conditionGroup[]`, via RuleTranslator.vercelToUnified).
+   * wirefilter fully supports arbitrary nesting, so conditions sharing a
+   * `group` are AND'd, and each group's sub-expression is OR'd against the
+   * others — without this, a rule with 2+ Vercel-originated groups would
+   * flatten into one big AND/OR block and stop matching what it used to.
+   * Ungrouped conditions (no `group` set on any of them, e.g. a
+   * hand-authored config) fall back to the flat `logic`-joined behavior
+   * this function has always had.
    */
   public static fromUnifiedConditions(conditions: UnifiedCondition[], logic: 'AND' | 'OR' = 'AND'): string {
     if (!conditions || conditions.length === 0) {
       throw new Error('At least one condition is required')
     }
 
-    const expressions = conditions.map((condition) => this.fromUnifiedCondition(condition))
+    const hasGroups = conditions.some((c) => c.group !== undefined)
+    if (!hasGroups) {
+      const expressions = conditions.map((condition) => this.fromUnifiedCondition(condition))
+      const connector = logic === 'AND' ? ' and ' : ' or '
+      return expressions.length > 1 ? `(${expressions.join(connector)})` : expressions[0]!
+    }
 
-    const connector = logic === 'AND' ? ' and ' : ' or '
-    return expressions.length > 1 ? `(${expressions.join(connector)})` : expressions[0]!
+    const groupedConditions = new Map<number, UnifiedCondition[]>()
+    for (const condition of conditions) {
+      const groupIndex = condition.group ?? 0
+      const bucket = groupedConditions.get(groupIndex)
+      if (bucket) {
+        bucket.push(condition)
+      } else {
+        groupedConditions.set(groupIndex, [condition])
+      }
+    }
+
+    const groupExpressions = Array.from(groupedConditions.values()).map((groupConditions) =>
+      this.combineWithAnd(groupConditions.map((c) => this.fromUnifiedCondition(c))),
+    )
+
+    return groupExpressions.length > 1 ? this.combineWithOr(groupExpressions) : groupExpressions[0]!
   }
 
   /**

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -173,8 +173,14 @@ export class RuleTranslator {
     const warnings: TranslationWarning[] = []
     const conditions: UnifiedCondition[] = []
 
-    // Flatten condition groups into unified conditions
-    for (const group of rule.conditionGroup) {
+    // Flatten condition groups into a single array, but tag each condition
+    // with its source group index (`group`) so unifiedToVercel can rebuild
+    // the original AND-within/OR-across structure later. Previously this
+    // discarded which conditions were AND'd together within a group —
+    // even a single-group, multi-condition rule (meant to be AND'd) was
+    // mistranslated, since `conditionLogic` below was hardcoded to 'OR'
+    // unconditionally rather than reflecting whether groups.length > 1.
+    rule.conditionGroup.forEach((group, groupIndex) => {
       for (const condition of group.conditions) {
         const operator = this.mapVercelOperatorToUnified(condition.op)
 
@@ -198,9 +204,10 @@ export class RuleTranslator {
           value: condition.value as string | number | string[] | number[],
           negated: condition.neg,
           key: condition.key,
+          group: groupIndex,
         })
       }
-    }
+    })
 
     // Warn about complex rules with many conditions
     if (conditions.length > 10) {
@@ -242,7 +249,12 @@ export class RuleTranslator {
       description: rule.description,
       enabled: rule.active,
       conditions,
-      conditionLogic: 'OR', // Vercel uses OR between groups
+      // Informational only once `group` is set above — real join semantics
+      // for translation come from the per-condition `group` index (AND
+      // within a group, OR across groups), which a flat 'AND'|'OR' can't
+      // express for a multi-group rule. Kept accurate for any caller that
+      // still reads this field without being group-aware.
+      conditionLogic: rule.conditionGroup.length > 1 ? 'OR' : 'AND',
       action,
     }
 
@@ -338,46 +350,68 @@ export class RuleTranslator {
    */
   public static unifiedToVercel(rule: UnifiedRule): TranslationResult<VercelCustomRule> {
     const warnings: TranslationWarning[] = []
-    const conditionGroups: VercelConditionGroup[] = []
 
-    // Convert unified conditions to Vercel condition groups. A condition whose
-    // field has no Vercel equivalent (e.g. Cloudflare-only `referer`/`port`) is
-    // dropped with a critical warning rather than mistranslated — silently
-    // relabeling it (the previous behavior defaulted to `path`) rewrote what
-    // the rule actually matches with no indication anything was wrong.
-    const conditions: VercelRuleCondition[] = []
+    // Group conditions by their `group` index (set by vercelToUnified when
+    // the rule originated from Vercel's own conditionGroup[] structure) so a
+    // multi-group rule round-trips correctly instead of collapsing into one
+    // group and changing what the rule matches (AND-within/OR-across ->
+    // everything AND'd together). Conditions with no `group` (e.g. a
+    // hand-authored config) all fall into one implicit group — the same
+    // single-group behavior this function has always had.
+    const groupedConditions = new Map<number, UnifiedCondition[]>()
     for (const condition of rule.conditions) {
-      const type = this.mapUnifiedTypeToVercel(condition.field)
-      if (!type) {
-        const { TranslationWarningSystem } = require('./TranslationWarningSystem')
-        warnings.push(
-          TranslationWarningSystem.createUnsupportedFeatureWarning(
-            `condition field '${condition.field}'`,
-            'unified config',
-            'Vercel',
-            rule.id,
-            condition.field,
-          ),
-        )
-        continue
+      const groupIndex = condition.group ?? 0
+      const bucket = groupedConditions.get(groupIndex)
+      if (bucket) {
+        bucket.push(condition)
+      } else {
+        groupedConditions.set(groupIndex, [condition])
       }
-      conditions.push({
-        op: this.mapUnifiedOperatorToVercel(condition.operator),
-        neg: condition.negated,
-        type,
-        key: condition.key,
-        value: condition.value,
-      })
     }
 
-    if (conditions.length === 0) {
+    // A condition whose field has no Vercel equivalent (e.g. Cloudflare-only
+    // `referer`/`port`) is dropped with a critical warning rather than
+    // mistranslated — silently relabeling it (the previous behavior defaulted
+    // to `path`) rewrote what the rule actually matches with no indication
+    // anything was wrong. A group that ends up fully empty is dropped too —
+    // that OR-branch simply doesn't exist in the output.
+    const conditionGroups: VercelConditionGroup[] = []
+    for (const groupConditions of groupedConditions.values()) {
+      const mapped: VercelRuleCondition[] = []
+      for (const condition of groupConditions) {
+        const type = this.mapUnifiedTypeToVercel(condition.field)
+        if (!type) {
+          const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+          warnings.push(
+            TranslationWarningSystem.createUnsupportedFeatureWarning(
+              `condition field '${condition.field}'`,
+              'unified config',
+              'Vercel',
+              rule.id,
+              condition.field,
+            ),
+          )
+          continue
+        }
+        mapped.push({
+          op: this.mapUnifiedOperatorToVercel(condition.operator),
+          neg: condition.negated,
+          type,
+          key: condition.key,
+          value: condition.value,
+        })
+      }
+      if (mapped.length > 0) {
+        conditionGroups.push({ conditions: mapped })
+      }
+    }
+
+    if (conditionGroups.length === 0) {
       throw new Error(
         `Rule "${rule.name}" has no conditions Vercel can represent — every condition field is unsupported ` +
           'by Vercel (e.g. Cloudflare-only fields like referer/port). Cannot sync this rule to Vercel.',
       )
     }
-
-    conditionGroups.push({ conditions })
 
     const vercelRule: VercelCustomRule = {
       id: rule.id,

--- a/src/lib/translators/__tests__/ExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/ExpressionBuilder.test.ts
@@ -203,6 +203,33 @@ describe('ExpressionBuilder', () => {
     it('throws when conditions array is empty', () => {
       expect(() => ExpressionBuilder.fromUnifiedConditions([])).toThrow('At least one condition is required')
     })
+
+    // Regression test: conditions carrying a `group` index (set by
+    // RuleTranslator.vercelToUnified for a rule with 2+ Vercel condition
+    // groups) must be AND'd within a group and OR'd across groups, not
+    // flattened by the flat `logic` join — which would silently turn
+    // "(path=/api AND method=POST) OR (header=x)" into a single
+    // all-AND'd (or all-OR'd) expression matching different traffic.
+    it('AND-within/OR-across when conditions carry a group index', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/api', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+        { field: 'host', operator: 'eq', value: 'example.com', group: 1 },
+      ]
+      const result = ExpressionBuilder.fromUnifiedConditions(conditions)
+      expect(result).toBe(
+        '((http.request.uri.path eq "/api" and http.request.method eq "POST") or http.host eq "example.com")',
+      )
+    })
+
+    it('collapses to a single AND group when all conditions share the same group index', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/api', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+      ]
+      const result = ExpressionBuilder.fromUnifiedConditions(conditions)
+      expect(result).toBe('(http.request.uri.path eq "/api" and http.request.method eq "POST")')
+    })
   })
 
   describe('fromUnifiedCondition', () => {

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -65,8 +65,11 @@ describe('RuleTranslator', () => {
         field: 'path',
         operator: 'eq',
         value: '/api',
+        group: 0,
       })
-      expect(result.conditionLogic).toBe('OR')
+      // Regression test: a single-group rule is AND semantics (there's
+      // nothing to OR against), not the previously-hardcoded 'OR'.
+      expect(result.conditionLogic).toBe('AND')
     })
 
     it('translates all Vercel operators to unified operators', () => {
@@ -186,6 +189,34 @@ describe('RuleTranslator', () => {
       const { result } = RuleTranslator.vercelToUnified(rule)
       expect(result.conditions).toHaveLength(2)
     })
+
+    // Regression test: multi-group rules are a real, documented pattern
+    // (used throughout examples/*.json) — vercelToUnified previously
+    // flattened all conditions into one array with no way to tell which
+    // came from which group, and hardcoded conditionLogic: 'OR' regardless
+    // of actual structure (wrongly applying OR-semantics even within what
+    // should be an AND'd group). Each condition must carry its source
+    // group index so unifiedToVercel can reconstruct the original
+    // AND-within/OR-across structure.
+    it('tags each condition with its source group index', () => {
+      const rule = makeVercelRule({
+        conditionGroup: [
+          {
+            conditions: [
+              { type: 'path', op: 'eq', value: '/api' },
+              { type: 'method', op: 'eq', value: 'POST' },
+            ],
+          },
+          { conditions: [{ type: 'header', op: 'eq', value: 'x', key: 'X-Custom' }] },
+        ],
+      })
+      const { result } = RuleTranslator.vercelToUnified(rule)
+
+      expect(result.conditions[0]?.group).toBe(0)
+      expect(result.conditions[1]?.group).toBe(0)
+      expect(result.conditions[2]?.group).toBe(1)
+      expect(result.conditionLogic).toBe('OR')
+    })
   })
 
   describe('unifiedToVercel', () => {
@@ -295,6 +326,48 @@ describe('RuleTranslator', () => {
       })
 
       expect(() => RuleTranslator.unifiedToVercel(rule)).toThrow(/no conditions Vercel can represent/)
+    })
+
+    // Regression test: multi-group round-trip fidelity. A rule translated
+    // from Vercel with 2 groups (group 0: path AND method; group 1: a
+    // single header condition) must come back out as 2 distinct Vercel
+    // condition groups, not one flattened group — flattening would turn
+    // "(path=/api AND method=POST) OR (header=x)" into
+    // "path=/api AND method=POST AND header=x", a different rule.
+    it('rebuilds multiple Vercel condition groups from the group index', () => {
+      const rule = makeUnifiedRule({
+        conditions: [
+          { field: 'path', operator: 'eq', value: '/api', group: 0 },
+          { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+          { field: 'header', operator: 'eq', value: 'x', key: 'X-Custom', group: 1 },
+        ],
+      })
+
+      const { result } = RuleTranslator.unifiedToVercel(rule)
+
+      expect(result.conditionGroup).toHaveLength(2)
+      expect(result.conditionGroup[0]!.conditions).toHaveLength(2)
+      expect(result.conditionGroup[1]!.conditions).toHaveLength(1)
+      expect(result.conditionGroup[1]!.conditions[0]!.key).toBe('X-Custom')
+    })
+
+    // Regression test: if every condition in one group is unmappable but
+    // another group has representable conditions, only the empty group is
+    // dropped (that OR-branch just doesn't exist in the output) — the rule
+    // as a whole still syncs rather than throwing.
+    it('drops only the group whose conditions are all unmappable, keeping the rest', () => {
+      const rule = makeUnifiedRule({
+        conditions: [
+          { field: 'referer', operator: 'eq', value: 'https://example.com', group: 0 },
+          { field: 'path', operator: 'eq', value: '/api', group: 1 },
+        ],
+      })
+
+      const { result, warnings } = RuleTranslator.unifiedToVercel(rule)
+
+      expect(result.conditionGroup).toHaveLength(1)
+      expect(result.conditionGroup[0]!.conditions[0]!.type).toBe('path')
+      expect(warnings.some((w) => w.field === 'referer')).toBe(true)
     })
 
     it('translates rate_limit action', () => {

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -16,6 +16,15 @@ export interface UnifiedCondition {
   value: string | number | string[] | number[]
   negated?: boolean
   key?: string // For header, query, cookie conditions
+  /**
+   * Index of the AND-group this condition belongs to, for providers with a
+   * two-level condition model (AND within a group, OR across groups) — e.g.
+   * Vercel's `conditionGroup[]`. Conditions sharing a `group` index are
+   * AND'd together; distinct `group` values are OR'd against each other.
+   * Omitted (or all conditions sharing the same/no value) means a single
+   * implicit group — the flat, single-level model most providers use.
+   */
+  group?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

First PR of the [approved Vercel-migration plan](https://github.com/gfargo/doorman) — routing every CLI command's Vercel branch onto the shared `IFirewallProvider` interface, matching Cloudflare, then retiring the legacy stack. This PR is a self-contained correctness fix uncovered while designing that migration, landing independently since it's foundational: the migration's config adapter cannot safely round-trip Vercel configs without it.

**The bug**: `RuleTranslator.vercelToUnified` flattened every Vercel condition group into one flat `conditions[]` array with no way to tell which conditions came from which group, and hardcoded `conditionLogic: 'OR'` unconditionally — even for a **single-group, multi-condition rule** (meant to be AND'd within the group), which got mistranslated to OR semantics. Multi-group rules are a real, documented pattern (used throughout `examples/*.json` — 7 of the 15 shipped example configs use them), not a rare edge case.

`unifiedToVercel` then collapsed everything back into a single Vercel condition group regardless of source structure, so a rule like `(path=/api AND method=POST) OR (header=x)` would round-trip into `path=/api AND method=POST AND header=x` — a different rule with different matching behavior, silently applied on the next sync.

## Fix

`UnifiedCondition` gains an optional `group` index. `vercelToUnified` now tags each condition with its source group; `unifiedToVercel` groups by that index to rebuild the original Vercel `conditionGroup[]` structure (merged with the existing per-condition Vercel-support-check logic from an earlier fix, so a group whose conditions are all unmappable is dropped rather than the whole rule failing). `ExpressionBuilder.fromUnifiedConditions` gets the same treatment for the Cloudflare direction — wirefilter fully supports the needed nesting, and the AND/OR combinators already existed unused (`combineWithAnd`/`combineWithOr`) — so a Vercel-originated multi-group rule now round-trips correctly through Cloudflare too, closing the same gap there instead of leaving it silently unhandled.

Ungrouped conditions (no `group` set on any of them — e.g. a hand-authored unified config) fall back to the existing flat `logic`-joined behavior, unchanged.

## Why now

This bug was latent/harmless until today, because nothing in the CLI ever calls `VercelFirewallService.fetchConfig`/`syncRules` — the Vercel migration is exactly what will first make it reachable. Landing this fix first, with its own tests, keeps the migration's foundation PR smaller and this fix independently reviewable.

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green (72 suites, 1276 tests), new regression tests: single-group rule is AND (not the previous hardcoded OR), each condition tagged with its source group index, multi-group round-trip through `unifiedToVercel` produces distinct Vercel condition groups, a group whose conditions are all unmappable is dropped while others survive, `ExpressionBuilder` builds correct AND-within/OR-across wirefilter expressions from grouped conditions
- [x] `pnpm eslint` — clean