### PR TITLE
feat: lay foundation for migrating Vercel CLI onto IFirewallProvider

### DIFF
--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -38,6 +38,18 @@ export interface SyncResult {
   ipsUpdated?: number
   ipsDeleted?: number
   version?: number
+  /** Provider's post-sync timestamp, paired with `version` for local
+   * config metadata write-back. Optional — not every provider tracks one. */
+  updatedAt?: string
+  /**
+   * Rules whose provider-assigned id differs from what the local config
+   * had (or had none of) before this sync — e.g. Vercel always assigns its
+   * own id on create, regardless of what was sent. Providers that accept
+   * client-supplied ids (Cloudflare) never populate this. `oldId` is
+   * omitted when the local rule had no id at all (match callers should key
+   * on `name` in that case instead).
+   */
+  idRemappings?: { oldId?: string; newId: string; name: string }[]
   errors?: string[]
   warnings?: string[]
 }
@@ -73,6 +85,11 @@ export interface ChangeSet {
   ipsToAdd?: import('../types/unified').UnifiedIPRule[]
   ipsToUpdate?: import('../types/unified').UnifiedIPRule[]
   ipsToDelete?: import('../types/unified').UnifiedIPRule[]
+  /** The provider's current remote version, if it tracks one. Lets a caller
+   * detect version-only drift (e.g. another tool synced since the local
+   * config was last saved) even when there are no rule/IP changes to make
+   * `hasChanges` true on its own. */
+  version?: number
   hasChanges: boolean
 }
 

--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -465,6 +465,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
       ipsToAdd: ipDiff.toAdd,
       ipsToUpdate: ipDiff.toUpdate,
       ipsToDelete: ipDiff.toDelete,
+      version: parseInt(ruleset.version, 10),
       hasChanges:
         ruleDiff.toAdd.length > 0 ||
         ruleDiff.toUpdate.length > 0 ||

--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -26,7 +26,13 @@ export interface VercelConfig {
   updatedAt: string
 }
 
-export const VERCEL_API_BASE_URL = 'https://api.vercel.com/v1/security/firewall/config'
+// Overridable for testing/demos against a local mock server — never set this
+// in production. Matches src/lib/services/VercelClient.ts's (legacy) existing
+// override; demos/mock-server.mjs and the VHS demo tapes rely on this to
+// drive the real CLI/network code path against a local fixture server
+// instead of the live Vercel API.
+export const VERCEL_API_BASE_URL =
+  process.env.DOORMAN_VERCEL_API_BASE_URL || 'https://api.vercel.com/v1/security/firewall/config'
 
 export interface FetchFirewallConfigOptions {
   /**

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -57,6 +57,16 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       return {
         version: '2.0',
         provider: 'vercel',
+        // CloudflareFirewallService.fetchConfig already sets providers.cloudflare
+        // — this must match, or downstream ValidationService checks (which
+        // require providers.<provider> to be present whenever `provider` is
+        // set) throw, and ProviderDetector's round-trip auto-detection breaks.
+        providers: {
+          vercel: {
+            projectId: this.client['projectId'],
+            teamId: this.client['teamId'],
+          },
+        },
         rules,
         ips,
         metadata: {
@@ -185,6 +195,14 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       const describeError = (context: string, error: unknown): string =>
         `${context}: ${error instanceof Error ? error.message : String(error)}`
 
+      // Vercel always assigns its own id on create (createFirewallRule sends
+      // `id: null` regardless of what the local rule had, if anything) — so
+      // the local config's rule id is essentially always stale for a newly
+      // created rule. This is real reconciliation data, not a naming-
+      // convention guess: `oldId` is the local rule's id if it had one (a
+      // caller should match on it), otherwise omitted (match on `name`).
+      const idRemappings: NonNullable<SyncResult['idRemappings']> = []
+
       // Delete custom rules
       for (const rule of toDelete) {
         try {
@@ -217,6 +235,9 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
           logger.debug(`Adding new custom rule: ${rule.name}`)
           const newRule = await this.client.createFirewallRule(rule)
           addedRules.push(newRule)
+          if (newRule.id && newRule.id !== rule.id) {
+            idRemappings.push({ oldId: rule.id || undefined, newId: newRule.id, name: rule.name })
+          }
           logger.debug(`New custom rule added: ${newRule.id}`)
         } catch (error) {
           logger.error(`Failed to add custom rule "${rule.name}":`, error)
@@ -272,13 +293,17 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
           `${chalk.cyan('Updated:')} ${chalk.cyan(updatedIPRules.length)}, ${chalk.red('Deleted:')} ${chalk.red(deletedIPRules.length)}`,
       )
 
-      // Fetch updated version. Best-effort: a failure here shouldn't
-      // discard the sync results already collected above. Falls back to
-      // the pre-sync version (captured before any mutations) if it fails.
+      // Fetch updated version/timestamp. Best-effort: a failure here
+      // shouldn't discard the sync results already collected above. Falls
+      // back to the pre-sync version (captured before any mutations) if it
+      // fails — updatedAt has no equivalent pre-sync fallback, so it's left
+      // undefined in that case rather than reporting a stale timestamp.
       let finalVersion: number = version
+      let finalUpdatedAt: string | undefined
       try {
         const activeConfig = await this.client.fetchFirewallConfig()
         finalVersion = activeConfig.version
+        finalUpdatedAt = activeConfig.updatedAt
       } catch (error) {
         logger.error('Failed to fetch updated firewall configuration version after sync:', error)
         errors.push(describeError('Failed to fetch updated configuration version after sync', error))
@@ -293,6 +318,8 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
         ipsUpdated: updatedIPRules.length,
         ipsDeleted: deletedIPRules.length,
         version: finalVersion,
+        updatedAt: finalUpdatedAt,
+        idRemappings: idRemappings.length > 0 ? idRemappings : undefined,
         errors: errors.length > 0 ? errors : undefined,
       }
     } catch (error) {

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -115,6 +115,22 @@ describe('VercelFirewallService', () => {
       expect(result.metadata!.updatedAt).toBe('2024-01-01T00:00:00Z')
     })
 
+    // Regression test: fetchConfig previously set `provider: 'vercel'` with
+    // no matching `providers.vercel` block — CloudflareFirewallService
+    // already sets `providers.cloudflare` alongside `provider: 'cloudflare'`.
+    // Without it, anything running the result through ValidationService
+    // (e.g. `backup`'s config validation, `saveConfig`'s default validation)
+    // throws "Provider 'vercel' specified but no configuration found in
+    // providers section", and ProviderDetector's round-trip auto-detection
+    // (which looks for providers.vercel.projectId) silently breaks.
+    it('should set providers.vercel alongside provider', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
+
+      const result = await service.fetchConfig()
+
+      expect(result.providers?.vercel).toEqual({ projectId: 'proj_123', teamId: 'team_456' })
+    })
+
     it('should pass version parameter to client', async () => {
       const spy = jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
 
@@ -438,6 +454,88 @@ describe('VercelFirewallService', () => {
 
       expect(deleteFirewallRuleSpy).toHaveBeenCalledTimes(1)
       expect(result.success).toBe(false)
+    })
+  })
+
+  describe('idRemappings (regression: local-config write-back needs the real server-assigned id, not a naming-convention guess)', () => {
+    it('reports an id remapping when the server assigns a different id than the local rule had', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'stale_local_id',
+            name: 'My Rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({ ...mockVercelConfig, rules: [], ips: [] })
+      jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+        id: 'rule_server_assigned',
+        name: 'My Rule',
+        active: true,
+        conditionGroup: [],
+        action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+      })
+
+      const result = await service.syncRules(config)
+
+      expect(result.idRemappings).toEqual([{ oldId: 'stale_local_id', newId: 'rule_server_assigned', name: 'My Rule' }])
+    })
+
+    it('omits oldId when the local rule had no id at all', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            name: 'Brand New Rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({ ...mockVercelConfig, rules: [], ips: [] })
+      jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+        id: 'rule_server_assigned',
+        name: 'Brand New Rule',
+        active: true,
+        conditionGroup: [],
+        action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+      })
+
+      const result = await service.syncRules(config)
+
+      expect(result.idRemappings).toEqual([{ newId: 'rule_server_assigned', name: 'Brand New Rule' }])
+    })
+
+    it('leaves idRemappings undefined when no rules were created', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
+
+      const result = await service.syncRules({
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bots',
+            enabled: true,
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      })
+
+      expect(result.idRemappings).toBeUndefined()
     })
   })
 

--- a/src/lib/utils/__tests__/vercelConfigAdapter.test.ts
+++ b/src/lib/utils/__tests__/vercelConfigAdapter.test.ts
@@ -1,0 +1,224 @@
+jest.mock('../../logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+import { toUnifiedConfig, applySyncResultToConfig } from '../vercelConfigAdapter'
+import type { FirewallConfig, CustomRule, IPBlockingRule } from '../../types'
+import type { UnifiedConfig } from '../../types/unified'
+import type { SyncResult } from '../../providers/IFirewallProvider'
+
+function makeLegacyRule(overrides: Partial<CustomRule> = {}): CustomRule {
+  return {
+    id: 'rule_test',
+    name: 'Test Rule',
+    description: 'A test rule',
+    conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/api' }] }],
+    action: { mitigate: { action: 'deny' } },
+    active: true,
+    ...overrides,
+  }
+}
+
+function makeLegacyIPRule(overrides: Partial<IPBlockingRule> = {}): IPBlockingRule {
+  return {
+    id: 'ip_test',
+    ip: '10.0.0.1',
+    hostname: 'example.com',
+    notes: 'blocked',
+    action: 'deny',
+    ...overrides,
+  }
+}
+
+function makeLegacyConfig(overrides: Partial<FirewallConfig> = {}): FirewallConfig {
+  return {
+    version: 3,
+    updatedAt: '2024-01-01T00:00:00Z',
+    projectId: 'proj_123',
+    teamId: 'team_456',
+    firewallEnabled: true,
+    rules: [makeLegacyRule()],
+    ips: [makeLegacyIPRule()],
+    ...overrides,
+  }
+}
+
+describe('vercelConfigAdapter', () => {
+  describe('toUnifiedConfig', () => {
+    it('passes through a config that already has provider metadata unchanged', () => {
+      const unified: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        providers: { vercel: { projectId: 'proj_123' } },
+        rules: [],
+        ips: [],
+      }
+
+      const result = toUnifiedConfig(unified)
+
+      expect(result).toBe(unified)
+    })
+
+    it('converts a legacy config into a unified config with provider metadata set', () => {
+      const legacy = makeLegacyConfig()
+
+      const result = toUnifiedConfig(legacy)
+
+      expect(result.provider).toBe('vercel')
+      expect(result.providers?.vercel).toEqual({ projectId: 'proj_123', teamId: 'team_456' })
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0]).toMatchObject({
+        id: 'rule_test',
+        name: 'Test Rule',
+        conditions: [{ field: 'path', operator: 'eq', value: '/api', group: 0 }],
+      })
+    })
+
+    it('hoists top-level version/updatedAt into metadata', () => {
+      const legacy = makeLegacyConfig({ version: 7, updatedAt: '2024-06-01T00:00:00Z' })
+
+      const result = toUnifiedConfig(legacy)
+
+      expect(result.metadata?.version).toBe(7)
+      expect(result.metadata?.updatedAt).toBe('2024-06-01T00:00:00Z')
+      // Top-level `version` on the unified side is the config *format*
+      // string, not the remote version number — must not be conflated.
+      expect(result.version).toBe('2.0')
+    })
+
+    it('converts IP rules, preserving notes and hostname', () => {
+      const legacy = makeLegacyConfig({ ips: [makeLegacyIPRule({ notes: 'suspicious traffic' })] })
+
+      const result = toUnifiedConfig(legacy)
+
+      expect(result.ips).toHaveLength(1)
+      expect(result.ips?.[0]).toMatchObject({
+        id: 'ip_test',
+        ip: '10.0.0.1',
+        hostname: 'example.com',
+        notes: 'suspicious traffic',
+      })
+    })
+
+    it('converts an id-less rule without throwing', () => {
+      const legacy = makeLegacyConfig({ rules: [makeLegacyRule({ id: undefined })] })
+
+      const result = toUnifiedConfig(legacy)
+
+      expect(result.rules[0]?.id).toBeUndefined()
+      expect(result.rules[0]?.name).toBe('Test Rule')
+    })
+
+    // Regression coverage for the condition-group fidelity fix this adapter
+    // depends on: a legacy rule with 2+ condition groups must not collapse
+    // into a single flat group when converted.
+    it('preserves multi-group rules through the conversion', () => {
+      const legacy = makeLegacyConfig({
+        rules: [
+          makeLegacyRule({
+            conditionGroup: [
+              {
+                conditions: [
+                  { type: 'path', op: 'eq', value: '/api' },
+                  { type: 'method', op: 'eq', value: 'POST' },
+                ],
+              },
+              { conditions: [{ type: 'header', op: 'eq', value: 'x', key: 'X-Custom' }] },
+            ],
+          }),
+        ],
+      })
+
+      const result = toUnifiedConfig(legacy)
+
+      const groups = new Set(result.rules[0]?.conditions.map((c) => c.group))
+      expect(groups.size).toBe(2)
+    })
+  })
+
+  describe('applySyncResultToConfig', () => {
+    const baseResult: Pick<SyncResult, 'version' | 'updatedAt' | 'idRemappings'> = {
+      version: 5,
+      updatedAt: '2024-07-01T00:00:00Z',
+    }
+
+    it('writes version/updatedAt to the top level for a legacy-shaped config', () => {
+      const legacy = makeLegacyConfig({ version: 3, updatedAt: '2024-01-01T00:00:00Z' })
+
+      const { config, changed } = applySyncResultToConfig(legacy, baseResult)
+
+      expect(changed).toBe(true)
+      expect(config.version).toBe(5)
+      expect(config.updatedAt).toBe('2024-07-01T00:00:00Z')
+      // metadata must never appear on a legacy-shaped config — it's not
+      // part of that schema.
+      expect((config as unknown as Record<string, unknown>).metadata).toBeUndefined()
+    })
+
+    it('writes version/updatedAt to metadata for a unified config, leaving top-level version alone', () => {
+      const unified: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [],
+        ips: [],
+        metadata: { version: 3, updatedAt: '2024-01-01T00:00:00Z' },
+      }
+
+      const { config, changed } = applySyncResultToConfig(unified, baseResult)
+
+      expect(changed).toBe(true)
+      expect(config.version).toBe('2.0')
+      expect(config.metadata?.version).toBe(5)
+      expect(config.metadata?.updatedAt).toBe('2024-07-01T00:00:00Z')
+    })
+
+    it('reports unchanged when the version already matches', () => {
+      const legacy = makeLegacyConfig({ version: 5, updatedAt: '2024-07-01T00:00:00Z' })
+
+      const { changed } = applySyncResultToConfig(legacy, baseResult)
+
+      expect(changed).toBe(false)
+    })
+
+    it('remaps a rule id by matching on oldId', () => {
+      const legacy = makeLegacyConfig({ rules: [makeLegacyRule({ id: 'stale_id', name: 'My Rule' })] })
+
+      const { config, changed } = applySyncResultToConfig(legacy, {
+        idRemappings: [{ oldId: 'stale_id', newId: 'rule_abc123', name: 'My Rule' }],
+      })
+
+      expect(changed).toBe(true)
+      expect(config.rules[0]?.id).toBe('rule_abc123')
+    })
+
+    it('remaps an id-less rule by matching on name', () => {
+      const legacy = makeLegacyConfig({ rules: [makeLegacyRule({ id: undefined, name: 'Brand New Rule' })] })
+
+      const { config, changed } = applySyncResultToConfig(legacy, {
+        idRemappings: [{ newId: 'rule_xyz789', name: 'Brand New Rule' }],
+      })
+
+      expect(changed).toBe(true)
+      expect(config.rules[0]?.id).toBe('rule_xyz789')
+    })
+
+    it('does not touch rules with no matching remapping', () => {
+      const legacy = makeLegacyConfig({ rules: [makeLegacyRule({ id: 'unrelated_id', name: 'Other Rule' })] })
+
+      const { config, changed } = applySyncResultToConfig(legacy, {
+        idRemappings: [{ oldId: 'stale_id', newId: 'rule_abc123', name: 'My Rule' }],
+      })
+
+      expect(changed).toBe(false)
+      expect(config.rules[0]?.id).toBe('unrelated_id')
+    })
+
+    it('reports unchanged and returns an equivalent config when there is nothing to write back', () => {
+      const legacy = makeLegacyConfig({ version: 5 })
+
+      const { changed } = applySyncResultToConfig(legacy, { version: 5 })
+
+      expect(changed).toBe(false)
+    })
+  })
+})

--- a/src/lib/utils/vercelConfigAdapter.ts
+++ b/src/lib/utils/vercelConfigAdapter.ts
@@ -1,0 +1,151 @@
+/**
+ * Adapter between legacy (pre-multi-provider) Vercel config files and the
+ * shared `UnifiedConfig` format `VercelFirewallService`/`IFirewallProvider`
+ * consume.
+ *
+ * Every real Vercel user's `.doorman.json` today is legacy-shaped
+ * (`rule.conditionGroup`, `action.mitigate`, top-level `version`/
+ * `updatedAt`, no `provider` field). `VercelFirewallService` only knows how
+ * to consume `UnifiedConfig` (`rule.conditions`, `action.type`), and
+ * `OperationSafety` hard-fails any config with no `provider` field — so
+ * routing an unconverted legacy config through the generic provider path
+ * throws immediately. This module bridges that gap in-memory; it never
+ * silently rewrites a user's file into unified format as a side effect —
+ * that's a distinct, opt-in concern out of scope here.
+ */
+
+import { hasProviderMetadata } from '../types/unified'
+import { RuleTranslator } from '../translators/RuleTranslator'
+import type { FirewallConfig } from '../types'
+import type { UnifiedConfig, UnifiedRule, UnifiedIPRule } from '../types/unified'
+import type { VercelCustomRule, VercelIPBlockingRule } from '../types/vercel'
+import type { SyncResult } from '../providers/IFirewallProvider'
+
+/**
+ * Convert a legacy Vercel `FirewallConfig`, or an already-unified config
+ * (passed through unchanged), into a `UnifiedConfig`.
+ *
+ * Legacy `CustomRule`/`IPBlockingRule` (src/lib/types.ts) and Vercel's own
+ * `VercelCustomRule`/`VercelIPBlockingRule` (src/lib/types/vercel.ts) are
+ * structurally identical — they were modeled as parallel interfaces, not a
+ * shared one — so a legacy rule is passed to `RuleTranslator` as-is.
+ */
+export function toUnifiedConfig(config: FirewallConfig | UnifiedConfig): UnifiedConfig {
+  if (hasProviderMetadata(config)) {
+    return config as UnifiedConfig
+  }
+
+  const legacy = config as FirewallConfig
+
+  const rules: UnifiedRule[] = legacy.rules.map((rule) => {
+    const translation = RuleTranslator.vercelToUnified(rule as unknown as VercelCustomRule)
+    return translation.result
+  })
+
+  const ips: UnifiedIPRule[] = (legacy.ips ?? []).map((ip) =>
+    RuleTranslator.vercelIPToUnified(ip as unknown as VercelIPBlockingRule),
+  )
+
+  return {
+    version: '2.0',
+    provider: 'vercel',
+    providers: {
+      vercel: {
+        projectId: legacy.projectId,
+        teamId: legacy.teamId,
+      },
+    },
+    rules,
+    ips,
+    metadata: {
+      version: legacy.version,
+      updatedAt: legacy.updatedAt,
+    },
+  }
+}
+
+/**
+ * Result of applying a sync result's version/id-remapping data back onto a
+ * config object.
+ */
+export interface ConfigWriteBack<T extends FirewallConfig | UnifiedConfig> {
+  config: T
+  /** Whether anything actually changed — callers use this to decide
+   * whether a save is needed at all. */
+  changed: boolean
+}
+
+/**
+ * Format-preserving write-back of a sync result onto the *original*
+ * (pre-`toUnifiedConfig`) config object a caller loaded from disk — not the
+ * in-memory `UnifiedConfig` `toUnifiedConfig` produces for talking to the
+ * provider. A legacy-shaped config's write-back goes to its top-level
+ * `version`/`updatedAt` fields (what the legacy sync flow always wrote); an
+ * already-unified config's write-back goes to `metadata.version`/
+ * `metadata.updatedAt`, leaving the top-level `version` (the config
+ * *format* string, e.g. "2.0") untouched — the two are different concepts
+ * that happen to share a field name only on the legacy shape.
+ *
+ * Also applies any `idRemappings` from the sync result to matching
+ * `config.rules[i].id` values — a rule with an `oldId` match is updated by
+ * id; an id-less rule (no `oldId` in the remapping) is matched by `name`
+ * instead, since there was no previous id to compare against.
+ */
+export function applySyncResultToConfig<T extends FirewallConfig | UnifiedConfig>(
+  originalConfig: T,
+  result: Pick<SyncResult, 'version' | 'updatedAt' | 'idRemappings'>,
+): ConfigWriteBack<T> {
+  let changed = false
+  const isUnified = hasProviderMetadata(originalConfig)
+
+  let config: FirewallConfig | UnifiedConfig = isUnified
+    ? { ...(originalConfig as UnifiedConfig), metadata: { ...(originalConfig as UnifiedConfig).metadata } }
+    : { ...(originalConfig as FirewallConfig) }
+
+  if (result.version !== undefined) {
+    if (isUnified) {
+      const unified = config as UnifiedConfig
+      if (unified.metadata?.version !== result.version) {
+        unified.metadata = {
+          ...unified.metadata,
+          version: result.version,
+          updatedAt: result.updatedAt ?? new Date().toISOString(),
+        }
+        changed = true
+      }
+    } else {
+      const legacy = config as FirewallConfig
+      if (legacy.version !== result.version) {
+        legacy.version = result.version
+        legacy.updatedAt = result.updatedAt ?? new Date().toISOString()
+        changed = true
+      }
+    }
+  }
+
+  if (result.idRemappings && result.idRemappings.length > 0) {
+    const remapByOldId = new Map(
+      result.idRemappings.filter((r) => r.oldId).map((r) => [r.oldId, r.newId] as [string, string]),
+    )
+    const remapByName = new Map(
+      result.idRemappings.filter((r) => !r.oldId).map((r) => [r.name, r.newId] as [string, string]),
+    )
+
+    let rulesChanged = false
+    const remappedRules = (config.rules as Array<{ id?: string; name: string }>).map((rule) => {
+      const newId = rule.id ? remapByOldId.get(rule.id) : remapByName.get(rule.name)
+      if (newId && newId !== rule.id) {
+        rulesChanged = true
+        return { ...rule, id: newId }
+      }
+      return rule
+    })
+
+    if (rulesChanged) {
+      config = { ...config, rules: remappedRules } as FirewallConfig | UnifiedConfig
+      changed = true
+    }
+  }
+
+  return { config: config as T, changed }
+}


### PR DESCRIPTION
## Summary

Second PR of the approved Vercel-migration plan (see [PR #169](https://github.com/gfargo/doorman/pull/169)). No command routing changes yet — this is purely foundational, additive-only groundwork the migration's later PRs depend on.

**Config adapter** (`src/lib/utils/vercelConfigAdapter.ts`):
- `toUnifiedConfig()` converts a legacy Vercel `FirewallConfig` (`rule.conditionGroup`, top-level `version`/`updatedAt`, no `provider` field — what every real Vercel user's `.doorman.json` is today) into a `UnifiedConfig` `VercelFirewallService` can consume. Without this, routing an unconverted legacy config through the provider path throws immediately: `OperationSafety` hard-fails any config with no `provider` field, and `VercelFirewallService` reads `rule.conditions`, which a legacy rule doesn't have.
- `applySyncResultToConfig()` is a format-preserving write-back: a legacy-shaped config's sync result goes to its top-level `version`/`updatedAt` (matching what the legacy sync flow always wrote); an already-unified config's goes to `metadata.version`/`updatedAt`, leaving the top-level format-version string alone. Also applies rule-id remappings (see below) to matching `config.rules[i].id`.

**`VercelFirewallService.fetchConfig`** now sets `providers.vercel` alongside `provider: 'vercel'`, matching what `CloudflareFirewallService` already does with `providers.cloudflare`. Without it, `ValidationService` throws `"Provider 'vercel' specified but no configuration found in providers section"` the moment anything (e.g. `backup`'s config validation) runs a fetched Vercel config through it.

**`IFirewallProvider`'s shared types** get additive extensions (Cloudflare unaffected):
- `SyncResult` gains `updatedAt` and `idRemappings`. `idRemappings` replaces the old `FirewallService` convention: rather than guessing an expected `rule_<snake_case(name)>` id and comparing it to the *local* rule's id (what the legacy code did, which can point at an id that was never actually sent to Vercel), `VercelFirewallService.syncRules` now reports the real server-assigned id from each create response — Vercel always assigns its own id on create regardless of what's sent, so this is strictly more correct reconciliation data, not a guess.
- `ChangeSet` gains `version`, so a pure version-drift sync (no rule/IP changes, e.g. another tool synced since the local config was last saved) can still be detected — both providers already had the underlying remote version in hand in `getChanges`, just not on the shared type.

**Ports `DOORMAN_VERCEL_API_BASE_URL`** (the env override `demos/mock-server.mjs` and the VHS demo tapes rely on to point the CLI at a local fixture server instead of the live Vercel API) into the new `VercelClient` — previously only the legacy client honored it.

None of this is wired into any command yet (that's the next PR) — the adapter and type extensions are exercised by their own dedicated tests only.

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm jest` — full suite green (73 suites, 1293 tests), new tests: adapter round-trip (legacy->unified conversion, format-preserving write-back for both shapes, id remapping by oldId and by name, multi-group rule preservation through the adapter), `providers.vercel` set on fetch, `idRemappings` populated with the real server-assigned id
- [x] `pnpm eslint` — clean