### PR TITLE
fix: resolve Vercel projectId/teamId from config in both legacy and unified shapes

### DIFF
--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -10,6 +10,10 @@ jest.mock('../../ui/promptSecret', () => ({
   promptSecret: jest.fn(),
 }))
 
+jest.mock('../../ui/promptForCredentials', () => ({
+  promptForCredentials: jest.fn(),
+}))
+
 // Mock the providers
 jest.mock('../../providers/vercel', () => ({
   VercelProvider: {
@@ -35,6 +39,7 @@ import { CloudflareProvider } from '../../providers/cloudflare'
 import { ProviderDetector } from '../../providers/ProviderDetector'
 import { prompt } from '../../ui/prompt'
 import { promptSecret } from '../../ui/promptSecret'
+import { promptForCredentials } from '../../ui/promptForCredentials'
 import type { IFirewallProvider } from '../../providers/IFirewallProvider'
 
 describe('providerHelper', () => {
@@ -167,6 +172,60 @@ describe('providerHelper', () => {
           accountId: 'cf-account',
         }),
       )
+    })
+
+    it('resolves projectId/teamId from a legacy config file without prompting (regression test)', async () => {
+      const legacyConfig = {
+        rules: [],
+        projectId: 'legacy-project',
+        teamId: 'legacy-team',
+      }
+
+      const { provider } = await getProviderInstance({
+        provider: 'vercel',
+        token: 'my-token',
+        config: legacyConfig,
+        interactive: true,
+      })
+
+      expect(provider.name).toBe('vercel')
+      expect(VercelProvider.fromConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'my-token',
+          projectId: 'legacy-project',
+          teamId: 'legacy-team',
+        }),
+      )
+      expect(promptForCredentials).not.toHaveBeenCalled()
+    })
+
+    it('resolves projectId/teamId from a unified config file without prompting (regression test)', async () => {
+      const unifiedConfig = {
+        rules: [],
+        providers: {
+          vercel: {
+            projectId: 'unified-project',
+            teamId: 'unified-team',
+          },
+        },
+      }
+
+      const { provider } = await getProviderInstance({
+        provider: 'vercel',
+        token: 'my-token',
+        config: unifiedConfig,
+        interactive: true,
+      })
+
+      expect(provider.name).toBe('vercel')
+      expect(VercelProvider.fromConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'my-token',
+          projectId: 'unified-project',
+          teamId: 'unified-team',
+        }),
+      )
+      expect(promptForCredentials).not.toHaveBeenCalled()
     })
 
     it('throws for Vercel when credentials missing and non-interactive', async () => {

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -7,7 +7,6 @@ import { VercelProvider } from '../providers/vercel'
 import { CloudflareProvider } from '../providers/cloudflare'
 import type { IFirewallProvider, ProviderType } from '../providers/IFirewallProvider'
 import type { FirewallConfig, UnifiedConfig } from '../types'
-import { isUnifiedConfig } from '../types'
 
 export interface ProviderOptions {
   // Common options
@@ -94,11 +93,13 @@ export async function getProviderInstance(options: ProviderOptions): Promise<Pro
 async function getVercelProvider(options: ProviderOptions): Promise<ProviderInstanceResult> {
   const token = options.token || process.env.VERCEL_TOKEN
 
-  // Type guard for accessing Vercel-specific properties
-  const vercelConfig =
-    options.config && !isUnifiedConfig(options.config) ? (options.config as Partial<FirewallConfig>) : undefined
-  const configProjectId = vercelConfig?.projectId
-  const configTeamId = vercelConfig?.teamId
+  // Vercel credentials may live directly on the config (legacy `.doorman.json`
+  // shape) or under `providers.vercel` (unified config shape). Both are
+  // checked since a config's shape can't be reliably inferred from `rules`
+  // alone (both legacy and unified configs have a top-level `rules` array).
+  const config = options.config as (Partial<FirewallConfig> & Partial<UnifiedConfig>) | undefined
+  const configProjectId = config?.providers?.vercel?.projectId ?? config?.projectId
+  const configTeamId = config?.providers?.vercel?.teamId ?? config?.teamId
 
   const projectId = options.projectId || configProjectId || process.env.VERCEL_PROJECT_ID
   const teamId = options.teamId || configTeamId || process.env.VERCEL_TEAM_ID


### PR DESCRIPTION
## Summary
- `getVercelProvider` gated config-sourced credentials on `!isUnifiedConfig(options.config)`, but `isUnifiedConfig` only checks for a top-level `rules` array — true for both legacy Vercel configs and unified configs. As a result `vercelConfig` was always `undefined` and `projectId`/`teamId` saved in `.doorman.json` were silently ignored, falling through to env vars or an interactive prompt.
- Unified-format configs also weren't supported at all: `getVercelProvider` never read `config.providers?.vercel?.projectId` / `.teamId`.
- Resolves `projectId`/`teamId` from both `config.providers?.vercel` (unified) and the legacy top-level fields, dropping the `isUnifiedConfig` gate at this call site.

## Test plan
- [x] Added regression tests in `src/lib/utils/__tests__/providerHelper.test.ts` asserting no prompt occurs when the config carries the IDs, for both legacy and unified config shapes
- [x] `pnpm exec jest src/lib/utils/__tests__/providerHelper.test.ts src/tests/version-sync-fix.test.ts` — 22 passed
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint src/lib/utils/providerHelper.ts src/lib/utils/__tests__/providerHelper.test.ts` — clean