### PR TITLE
feat: migrate sync and watch onto IFirewallProvider for Vercel

### DIFF
--- a/src/commands/__tests__/sync.test.ts
+++ b/src/commands/__tests__/sync.test.ts
@@ -1,27 +1,28 @@
 import { getConfig, saveConfig } from '../../lib/utils/config'
 import { logger } from '../../lib/logger'
 import { prompt } from '../../lib/ui/prompt'
-import { VercelClient } from '../../lib/services/VercelClient'
+import { VercelClient } from '../../lib/providers/vercel/VercelClient'
+import { mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
 import { handler } from '../sync'
 
 /**
- * Characterization tests for the CURRENT (pre-migration) legacy Vercel sync
- * path in sync.ts. These pin down existing behavior — including known quirks
- * — as a regression baseline before the Vercel CLI migrates onto
- * IFirewallProvider. See the migration plan for context; do not "fix" a
- * failing assertion here without updating the plan's characterization first.
+ * Tests for `sync.ts`'s Vercel path now that it's migrated onto the generic
+ * IFirewallProvider interface (same path as Cloudflare) — see the
+ * Vercel-CLI-onto-IFirewallProvider migration plan. Supersedes the
+ * characterization tests written against the legacy `services/VercelClient`
+ * path in #172; several behaviors changed deliberately as part of the
+ * migration (see individual test comments below).
  *
- * Note: a confirmed sync fetches the remote Vercel config THREE times —
- * sync.ts's own pre-sync `getChanges` call (for the confirmation display),
- * `FirewallService.syncRules`'s own internal `getChanges` re-diff, and
- * `validateAndUpdateConfig`'s post-sync verification re-fetch — so mocks
- * below queue three `fetchFirewallConfig` responses for any test that
- * confirms the initial prompt.
+ * A confirmed sync fetches the remote Vercel config THREE times — sync.ts's
+ * own pre-sync `getChanges` call (for the confirmation display),
+ * `VercelFirewallService.syncRules`'s own internal `getChanges` re-diff, and
+ * its post-sync re-fetch for the final version/updatedAt — so mocks below
+ * queue three `fetchFirewallConfig` responses for any test that confirms.
  */
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
 jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn(), saveConfig: jest.fn() }))
-jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/vercel/VercelClient')
 jest.mock('../../lib/ui/prompt', () => ({ prompt: jest.fn() }))
 
 const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
@@ -63,7 +64,7 @@ function remoteConfig(overrides: Partial<Record<string, unknown>> = {}) {
   }
 }
 
-describe('sync command (legacy Vercel path)', () => {
+describe('sync command (Vercel via IFirewallProvider)', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
@@ -73,47 +74,41 @@ describe('sync command (legacy Vercel path)', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-    jest.useRealTimers()
   })
 
   it('reports no changes and does nothing when local and remote are identical', async () => {
     mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(remoteConfig()) as any
+    mockVercelClientPrototype(MockedVercelClient, { config: remoteConfig() })
 
     await handler(baseArgv as any)
 
     expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('No changes detected'))
     expect(mockedPrompt).not.toHaveBeenCalled()
     expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(MockedVercelClient.prototype.fetchFirewallConfig).toHaveBeenCalledTimes(1)
   })
 
-  it('does not sync anything when the user declines the initial confirmation', async () => {
+  it('cancels the sync and exits non-zero when the user declines confirmation (unified with Cloudflare)', async () => {
+    // Behavior change from the legacy path: declining now surfaces as a
+    // hard failure (matching Cloudflare's existing confirm/cancel
+    // semantics) instead of a clean "Sync cancelled." return.
     mockedGetConfig.mockResolvedValue({ version: 5, rules: [blockBadBotsRule], ips: [] } as any)
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(remoteConfig()) as any
-    MockedVercelClient.prototype.createFirewallRule = jest.fn()
-    mockedPrompt.mockResolvedValueOnce(false)
+    mockVercelClientPrototype(MockedVercelClient, { config: remoteConfig() })
+    mockedPrompt.mockResolvedValue(false)
 
-    await handler(baseArgv as any)
+    await expect(handler(baseArgv as any)).rejects.toThrow('process.exit called with "1"')
 
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Sync cancelled'))
     expect(MockedVercelClient.prototype.createFirewallRule).not.toHaveBeenCalled()
     expect(mockedSaveConfig).not.toHaveBeenCalled()
   })
 
   it('writes back version-only drift with no rule/IP changes', async () => {
-    jest.useFakeTimers()
     mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
     const postSync = remoteConfig({ version: 6, updatedAt: 'remote-updated-1' })
-    MockedVercelClient.prototype.fetchFirewallConfig = jest
-      .fn()
-      .mockResolvedValueOnce(postSync) // sync.ts's pre-sync getChanges
-      .mockResolvedValueOnce(postSync) // syncRules' internal getChanges
-      .mockResolvedValueOnce(postSync) // validateAndUpdateConfig's re-fetch
-    mockedPrompt.mockResolvedValueOnce(true)
+    mockVercelClientPrototype(MockedVercelClient, { config: postSync })
+    mockedPrompt.mockResolvedValue(true)
 
-    const handlerPromise = handler(baseArgv as any)
-    await jest.advanceTimersByTimeAsync(3000)
-    await handlerPromise
+    await handler(baseArgv as any)
 
     expect(mockedPrompt).toHaveBeenCalledTimes(1)
     expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
@@ -123,137 +118,55 @@ describe('sync command (legacy Vercel path)', () => {
     )
   })
 
-  it('prompts to update local rule IDs when the create leaves a guessed-id mismatch, and applies it on confirmation', async () => {
-    jest.useFakeTimers()
-    mockedGetConfig.mockResolvedValue({ version: 5, rules: [blockBadBotsRule], ips: [] } as any)
-    const preSync = remoteConfig({ version: 5 })
-    // Post-sync verification re-fetch reports the rule back under the SAME
-    // id the local config already had, which does not match
-    // createFirewallRule's returned id below. This is what lets
-    // FirewallService's snake_case "guessed id" survive
-    // validateAndUpdateConfig's own (unrelated) content-based id remap.
-    const postSync = remoteConfig({
-      version: 6,
-      updatedAt: 'remote-updated-2',
-      rules: [{ ...blockBadBotsRule, id: 'custom-id-1' }],
-    })
-    MockedVercelClient.prototype.fetchFirewallConfig = jest
-      .fn()
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(postSync)
+  it('writes back the provider-assigned rule ID unconditionally after create, with no separate prompt', async () => {
+    // Behavior change from the legacy path: the old "guessed snake_case id"
+    // reconciliation prompt is gone. The provider's actually-returned id is
+    // authoritative and gets written back automatically, logged (not
+    // prompted) — see VercelFirewallService.syncRules's idRemappings.
+    const localRuleNoId = { ...blockBadBotsRule, id: undefined }
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [localRuleNoId], ips: [] } as any)
+    mockVercelClientPrototype(MockedVercelClient, { config: remoteConfig({ version: 5 }) })
     MockedVercelClient.prototype.createFirewallRule = jest
       .fn()
       .mockResolvedValue({ ...blockBadBotsRule, id: 'server-assigned-id' })
-    mockedPrompt
-      .mockResolvedValueOnce(true) // apply changes
-      .mockResolvedValueOnce(true) // update local config with new IDs
+    mockedPrompt.mockResolvedValue(true)
 
-    const handlerPromise = handler(baseArgv as any)
-    await jest.advanceTimersByTimeAsync(3000)
-    await handlerPromise
+    await handler(baseArgv as any)
 
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('do not match their expected snake_case name'))
-    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Updated local config with new rule IDs'))
-
-    // Written back twice: once for the ID update, once more for the
-    // version/updatedAt metadata update at the end of the handler — these
-    // are two independent conditions in sync.ts, not a single write.
-    expect(mockedSaveConfig).toHaveBeenCalledTimes(2)
-    expect(mockedSaveConfig).toHaveBeenLastCalledWith(
+    expect(mockedPrompt).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Rule IDs were reassigned by the provider and written back'),
+    )
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    expect(mockedSaveConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        version: 6,
-        updatedAt: 'remote-updated-2',
-        rules: [expect.objectContaining({ id: 'rule_block_bad_bots' })],
+        rules: [expect.objectContaining({ id: 'server-assigned-id' })],
       }),
       '.doorman.json',
     )
   })
 
-  it('leaves the local rule ID untouched when the user declines the ID-update prompt, but still writes back version metadata', async () => {
-    jest.useFakeTimers()
+  it('exits non-zero and does not write back when the sync reports failure', async () => {
     mockedGetConfig.mockResolvedValue({ version: 5, rules: [blockBadBotsRule], ips: [] } as any)
-    const preSync = remoteConfig({ version: 5 })
-    const postSync = remoteConfig({
-      version: 6,
-      updatedAt: 'remote-updated-3',
-      rules: [{ ...blockBadBotsRule, id: 'custom-id-1' }],
-    })
-    MockedVercelClient.prototype.fetchFirewallConfig = jest
-      .fn()
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(postSync)
+    mockVercelClientPrototype(MockedVercelClient, { config: remoteConfig() })
+    MockedVercelClient.prototype.createFirewallRule = jest.fn().mockRejectedValue(new Error('rate limited'))
+    mockedPrompt.mockResolvedValue(true)
+
+    await expect(handler(baseArgv as any)).rejects.toThrow('process.exit called with "1"')
+
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+  })
+
+  it('bypasses the confirmation prompt with --ci (unlike the legacy Vercel path, which always prompted)', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [blockBadBotsRule], ips: [] } as any)
+    mockVercelClientPrototype(MockedVercelClient, { config: remoteConfig() })
     MockedVercelClient.prototype.createFirewallRule = jest
       .fn()
-      .mockResolvedValue({ ...blockBadBotsRule, id: 'server-assigned-id' })
-    mockedPrompt
-      .mockResolvedValueOnce(true) // apply changes
-      .mockResolvedValueOnce(false) // decline updating local IDs
-
-    const handlerPromise = handler(baseArgv as any)
-    await jest.advanceTimersByTimeAsync(3000)
-    await handlerPromise
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Local config not updated. Remember to update rule IDs manually'),
-    )
-
-    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
-    expect(mockedSaveConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        version: 6,
-        updatedAt: 'remote-updated-3',
-        rules: [expect.objectContaining({ id: 'custom-id-1' })],
-      }),
-      '.doorman.json',
-    )
-  })
-
-  it('restores the original config and exits non-zero when post-sync validation finds unexpected remote state', async () => {
-    jest.useFakeTimers()
-    const localIpRule = { ip: '1.2.3.4', hostname: 'example.com', action: 'deny' as const }
-    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [localIpRule] } as any)
-    const preSync = remoteConfig({ version: 5, ips: [] })
-    const postSync = remoteConfig({
-      version: 6,
-      ips: [{ id: 'unexpected-ip-id', ip: '9.9.9.9', hostname: 'other.com', action: 'deny' }],
-    })
-    MockedVercelClient.prototype.fetchFirewallConfig = jest
-      .fn()
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(preSync)
-      .mockResolvedValueOnce(postSync)
-    MockedVercelClient.prototype.createIPBlockingRule = jest
-      .fn()
-      .mockResolvedValue({ ...localIpRule, id: 'ip-created-id' })
-    mockedPrompt.mockResolvedValueOnce(true) // apply changes
-
-    const handlerPromise = handler(baseArgv as any)
-    // Attach the rejection expectation before advancing fake timers so the
-    // rejection that fires during advanceTimersByTimeAsync is never
-    // observed as unhandled. It's awaited below, just not at this call site.
-    // eslint-disable-next-line jest/valid-expect
-    const expectation = expect(handlerPromise).rejects.toThrow('process.exit called with "1"')
-    await jest.advanceTimersByTimeAsync(3000)
-    await expectation
-
-    expect(logger.error).toHaveBeenCalledWith('Failed to validate sync result or update config metadata')
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Restored original config'))
-    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
-    expect(mockedSaveConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ version: 5, rules: [], ips: [localIpRule] }),
-      '.doorman.json',
-    )
-  })
-
-  it('still prompts interactively for Vercel sync even when --ci is set (no CI bypass in the legacy path)', async () => {
-    mockedGetConfig.mockResolvedValue({ version: 5, rules: [blockBadBotsRule], ips: [] } as any)
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(remoteConfig()) as any
-    mockedPrompt.mockResolvedValueOnce(false)
+      .mockResolvedValue({ ...blockBadBotsRule, id: 'custom-id-1' })
 
     await handler({ ...baseArgv, ci: true } as any)
 
-    expect(mockedPrompt).toHaveBeenCalledWith('Do you want to apply these changes?', { type: 'confirm' })
+    expect(mockedPrompt).not.toHaveBeenCalled()
+    expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('Firewall rules sync completed successfully'))
   })
 })

--- a/src/commands/__tests__/watch.test.ts
+++ b/src/commands/__tests__/watch.test.ts
@@ -1,14 +1,14 @@
 import type { Stats } from 'fs'
 import { getConfig } from '../../lib/utils/config'
 import { logger } from '../../lib/logger'
-import { VercelClient } from '../../lib/services/VercelClient'
+import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
-import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
 import { handler } from '../watch'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
 jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn(), saveConfig: jest.fn() }))
-jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/vercel/VercelClient')
 jest.mock('../../lib/providers/cloudflare/CloudflareClient')
 
 let capturedWatchListener: ((curr: Stats, prev: Stats) => void) | undefined
@@ -37,13 +37,19 @@ describe('watch command', () => {
     jest.clearAllMocks()
     jest.useFakeTimers()
     capturedWatchListener = undefined
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue({
-      version: 5,
-      firewallEnabled: true,
-      rules: [],
-      ips: [],
-      updatedAt: '2024-01-01T00:00:00Z',
-    }) as any
+    mockVercelClientPrototype(MockedVercelClient, {
+      config: {
+        version: 5,
+        id: 'config_1',
+        firewallEnabled: true,
+        crs: null,
+        rules: [],
+        ips: [],
+        projectKey: 'pk_1',
+        ownerId: 'owner_1',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    })
     mockCloudflareClientPrototype(MockedCloudflareClient)
   })
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,11 +2,10 @@ import chalk from 'chalk'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
-import { CustomRule, FirewallConfig } from '../lib/types'
-import type { UnifiedConfig } from '../lib/types/unified'
-import { prompt } from '../lib/ui/prompt'
-import { displayIPBlockingTable, displayRulesTable, RULE_STATUS_MAP } from '../lib/ui/table'
+import type { UnifiedIPRule, UnifiedRule } from '../lib/types/unified'
+import { FirewallConfig } from '../lib/types'
 import { saveConfig } from '../lib/utils/config'
+import { applySyncResultToConfig, toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface SyncOptions {
@@ -80,180 +79,67 @@ export const handler = async (argv: Arguments<SyncOptions>) => {
       errorContext: 'syncing firewall rules',
     },
     async (ctx) => {
-      if (ctx.provider.name !== 'vercel') {
-        await syncWithProvider(ctx.provider, ctx.config, argv)
-        return
-      }
-
-      let config = ctx.config
-      const service = ctx.service
-
-      logger.start(chalk.magenta('Calculating firewall configuration changes...'))
-      const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
-        await service.getChanges(config)
-
-      const hasCustomRuleChanges = toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0
-      const hasIPRuleChanges = ipsToAdd.length > 0 || ipsToUpdate.length > 0 || ipsToDelete.length > 0
-      const hasVersionChange = config.version !== version
-
-      if (!hasCustomRuleChanges && !hasIPRuleChanges && !hasVersionChange) {
-        logger.success(chalk.green('No changes detected. Firewall rules are in sync.'))
-        return
-      }
-
-      if (hasCustomRuleChanges) {
-        logger.log(chalk.bold('\nProposed Custom Rule Changes:\n'))
-        displayRulesTable(
-          [
-            ...toAdd.map((rule: any) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id as string })),
-            ...toUpdate.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.modified, id: rule.id as string })),
-            ...toDelete.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.deleted, id: rule.id as string })),
-          ],
-          { showStatus: true },
-        )
-      }
-
-      if (hasIPRuleChanges) {
-        logger.log(chalk.bold('\nProposed IP Blocking Rule Changes:\n'))
-        displayIPBlockingTable(
-          [
-            ...ipsToAdd.map((rule) => ({ ...rule, changeStatus: RULE_STATUS_MAP.new, id: rule.id || undefined })),
-            ...ipsToUpdate.map((rule) => ({
-              ...rule,
-              changeStatus: RULE_STATUS_MAP.modified,
-              id: rule.id || undefined,
-            })),
-            ...ipsToDelete.map((rule) => ({
-              ...rule,
-              changeStatus: RULE_STATUS_MAP.deleted,
-              id: rule.id || undefined,
-            })),
-          ],
-          { showStatus: true },
-        )
-      }
-
-      if (hasVersionChange) {
-        logger.log(chalk.bold('\nProposed Metadata Changes:\n'))
-        logger.log(`  - Version: ${chalk.red(config.version)} ${chalk.dim('->')} ${chalk.green(version)}`)
-      }
-
-      const confirmed = await prompt('Do you want to apply these changes?', { type: 'confirm' })
-      if (!confirmed) {
-        logger.info(chalk.yellow('Sync cancelled.'))
-        return
-      }
-
-      logger.start('Starting firewall rules sync...')
-
-      const backupConfig = JSON.parse(JSON.stringify(config)) as FirewallConfig
-
-      const syncResult = await service.syncRules(config, {
-        debug: argv.debug,
-      })
-      const { rulesToUpdateLocally } = syncResult
-      logger.success(chalk.green('Firewall rules sync completed successfully'))
-
-      try {
-        const updatedConfig = await service.validateAndUpdateConfig(config, syncResult, { dryRun: false })
-        config = updatedConfig
-      } catch (error) {
-        logger.error('Failed to validate sync result or update config metadata')
-        logger.error(error instanceof Error ? error.message : String(error))
-
-        await saveConfig(backupConfig, argv.config)
-
-        logger.info(chalk.yellow('Restored original config due to validation failure'))
-        throw new Error('Sync validation failed - original config restored')
-      }
-
-      // Filter rulesToUpdateLocally to only include entries whose oldId still
-      // exists in the current config. validateAndUpdateConfig may have already
-      // updated some rule IDs to match remote-assigned IDs.
-      const pendingIdUpdates = rulesToUpdateLocally.filter((r) =>
-        config.rules.some((rule) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name)),
-      )
-
-      if (pendingIdUpdates.length > 0) {
-        logger.log('')
-        logger.info(chalk.yellow('Some rules have IDs that do not match their expected snake_case name:'))
-        pendingIdUpdates.forEach((rule) => {
-          logger.log(
-            `  - Rule "${rule.name}": ${chalk.red(rule.oldId || 'empty')} ${chalk.dim('->')} ${chalk.green(rule.newId)}`,
-          )
-        })
-
-        const updateConfirmed = await prompt('Do you want to update the local config with the new IDs?', {
-          type: 'confirm',
-        })
-
-        if (updateConfirmed) {
-          config = {
-            ...config,
-            rules: config.rules.map((rule: CustomRule) => {
-              const ruleToUpdate = pendingIdUpdates.find(
-                (r) => r.oldId === rule.id || (r.oldId === '' && r.name === rule.name),
-              )
-              return ruleToUpdate ? { ...rule, id: ruleToUpdate.newId } : rule
-            }),
-            ips: config.ips || [],
-          }
-
-          await saveConfig(config, argv.config)
-          logger.success(chalk.green('Updated local config with new rule IDs'))
-        } else {
-          logger.warn(chalk.yellow('Local config not updated. Remember to update rule IDs manually if needed.'))
-        }
-      }
-
-      if (backupConfig.version !== config.version || backupConfig.updatedAt !== config.updatedAt) {
-        await saveConfig(config, argv.config)
-        logger.success(
-          chalk.green(`Updated version ${chalk.dim(`(v${config.version})`)} and metadata in local config file`),
-        )
-      }
+      await syncWithProvider(ctx.provider, ctx.config, argv)
     },
   )
 }
 
 /**
- * Sync using the generic IFirewallProvider interface (Cloudflare and any future
- * non-Vercel provider). Simpler than the Vercel flow above: providers implementing
- * this interface handle their own diff/risk-assessment/confirmation internally, and
- * the interface has no equivalent of Vercel's remote-assigned-ID reconciliation, so
- * there's nothing to write back to the local config file after a successful sync.
+ * Sync using the generic IFirewallProvider interface — the same path for
+ * every provider (Vercel included). A local legacy-shaped Vercel config is
+ * converted to `UnifiedConfig` in-memory via `toUnifiedConfig` before being
+ * handed to the provider; the file on disk is never rewritten into unified
+ * format as a side effect of this.
+ *
+ * Providers implementing `IFirewallProvider` handle their own diff/risk-
+ * assessment/confirmation internally (`syncRules` -> `OperationSafety`), so
+ * there's a single confirmation UX across providers rather than Vercel
+ * having its own separate prompt. After a successful sync, any
+ * provider-assigned rule ID changes and version/metadata drift are written
+ * back to the local config file in its original format (legacy or unified)
+ * via `applySyncResultToConfig` — unconditionally, not behind a prompt: the
+ * provider's returned ID is authoritative, so declining the write-back
+ * would just leave the config permanently desynced.
  */
 async function syncWithProvider(
   provider: IFirewallProvider,
   config: FirewallConfig,
   argv: Arguments<SyncOptions>,
 ): Promise<void> {
-  const unifiedConfig = config as unknown as UnifiedConfig
+  const unifiedConfig = toUnifiedConfig(config)
 
   logger.start(chalk.magenta(`Calculating ${provider.name} firewall configuration changes...`))
   const changes = await provider.getChanges(unifiedConfig)
 
-  if (!changes.hasChanges) {
+  const localVersion = unifiedConfig.metadata?.version
+  const hasVersionChange = changes.version !== undefined && localVersion !== changes.version
+
+  if (!changes.hasChanges && !hasVersionChange) {
     logger.success(chalk.green('No changes detected. Firewall rules are in sync.'))
     return
   }
 
   logger.log(chalk.bold('\nProposed Changes:\n'))
-  logger.log(`  ${chalk.green('+')} ${changes.rulesToAdd.length} rules to add`)
-  logger.log(`  ${chalk.cyan('~')} ${changes.rulesToUpdate.length} rules to update`)
-  logger.log(`  ${chalk.red('-')} ${changes.rulesToDelete.length} rules to delete`)
+  logRuleNames('Rules to add', changes.rulesToAdd, chalk.green('+'))
+  logRuleNames('Rules to update', changes.rulesToUpdate, chalk.cyan('~'))
+  logRuleNames('Rules to delete', changes.rulesToDelete, chalk.red('-'))
   const ipsToAdd = changes.ipsToAdd ?? []
   const ipsToUpdate = changes.ipsToUpdate ?? []
   const ipsToDelete = changes.ipsToDelete ?? []
   if (ipsToAdd.length || ipsToUpdate.length || ipsToDelete.length) {
-    logger.log(`  ${chalk.green('+')} ${ipsToAdd.length} IPs to add`)
-    logger.log(`  ${chalk.cyan('~')} ${ipsToUpdate.length} IPs to update`)
-    logger.log(`  ${chalk.red('-')} ${ipsToDelete.length} IPs to delete`)
+    logIPNames('IPs to add', ipsToAdd, chalk.green('+'))
+    logIPNames('IPs to update', ipsToUpdate, chalk.cyan('~'))
+    logIPNames('IPs to delete', ipsToDelete, chalk.red('-'))
+  }
+  if (hasVersionChange) {
+    logger.log(
+      `  Remote config version: ${chalk.red(localVersion ?? 'unknown')} ${chalk.dim('->')} ${chalk.green(changes.version)}`,
+    )
   }
 
   logger.start('Starting firewall rules sync...')
-  // Non-vercel providers prompt for confirmation internally (unless --ci); no need
-  // to prompt again here. In --ci mode, a sync that would delete anything still
+  // Providers prompt for confirmation internally (unless --ci); no need to
+  // prompt again here. In --ci mode, a sync that would delete anything still
   // requires --allow-deletions — see OperationSafety.confirmDestructiveOperation.
   const result = await provider.syncRules(unifiedConfig, { force: argv.ci, allowDeletions: argv.allowDeletions })
 
@@ -269,4 +155,29 @@ async function syncWithProvider(
     )
   }
   result.warnings?.forEach((w) => logger.warn(w))
+
+  if (result.idRemappings?.length) {
+    logger.info(chalk.yellow('Rule IDs were reassigned by the provider and written back to the local config:'))
+    result.idRemappings.forEach((r) => {
+      logger.log(`  - ${r.name}: ${chalk.red(r.oldId || 'none')} ${chalk.dim('->')} ${chalk.green(r.newId)}`)
+    })
+  }
+
+  const writeBack = applySyncResultToConfig(config, result)
+  if (writeBack.changed) {
+    await saveConfig(writeBack.config, argv.config)
+    logger.success(chalk.green('Updated local config with new version/metadata'))
+  }
+}
+
+function logRuleNames(label: string, rules: UnifiedRule[], marker: string): void {
+  if (rules.length === 0) return
+  logger.log(`  ${marker} ${label} (${rules.length}):`)
+  rules.forEach((rule) => logger.log(`      - ${rule.name}`))
+}
+
+function logIPNames(label: string, ips: UnifiedIPRule[], marker: string): void {
+  if (ips.length === 0) return
+  logger.log(`  ${marker} ${label} (${ips.length}):`)
+  ips.forEach((ip) => logger.log(`      - ${ip.ip}${ip.hostname ? ` (${ip.hostname})` : ''}`))
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -3,8 +3,9 @@ import { Stats, watchFile, unwatchFile } from 'fs'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
-import type { UnifiedConfig } from '../lib/types/unified'
+import type { FirewallConfig } from '../lib/types'
 import { getConfig, saveConfig } from '../lib/utils/config'
+import { applySyncResultToConfig, toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface WatchOptions {
@@ -79,7 +80,7 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
       ci: argv.ci,
       errorContext: 'setting up watch mode',
     },
-    async ({ service, provider }) => {
+    async ({ provider }) => {
       let isProcessing = false
       let lastModified = 0
 
@@ -100,48 +101,7 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
           logger.start('Validating and syncing changes...')
 
           const updatedConfig = await getConfig(configPath)
-
-          if (provider.name !== 'vercel') {
-            await syncChangesWithProvider(provider, updatedConfig as unknown as UnifiedConfig)
-            logger.log(chalk.dim('Watching for more changes...'))
-            return
-          }
-
-          const { toAdd, toUpdate, toDelete, ipsToAdd, ipsToUpdate, ipsToDelete, version } =
-            await service.getChanges(updatedConfig)
-
-          const hasChanges =
-            toAdd.length > 0 ||
-            toUpdate.length > 0 ||
-            toDelete.length > 0 ||
-            ipsToAdd.length > 0 ||
-            ipsToUpdate.length > 0 ||
-            ipsToDelete.length > 0 ||
-            updatedConfig.version !== version
-
-          if (!hasChanges) {
-            logger.info(chalk.blue('No changes detected, skipping sync'))
-            return
-          }
-
-          const totalChanges =
-            toAdd.length + toUpdate.length + toDelete.length + ipsToAdd.length + ipsToUpdate.length + ipsToDelete.length
-          logger.log(chalk.cyan(`Syncing ${totalChanges} changes...`))
-
-          const syncResult = await service.syncRules(updatedConfig, { debug: argv.debug })
-
-          try {
-            const validatedConfig = await service.validateAndUpdateConfig(updatedConfig, syncResult, { dryRun: false })
-            await saveConfig(validatedConfig, configPath)
-            logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
-          } catch (validationError) {
-            logger.warn(
-              chalk.yellow(
-                `⚠️ Sync applied but validation failed: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
-              ),
-            )
-            logger.info(chalk.dim('Run `download` to reconcile local config with remote state'))
-          }
+          await syncChangesWithProvider(provider, updatedConfig, configPath)
 
           logger.log(chalk.dim('Watching for more changes...'))
         } catch (error) {
@@ -173,18 +133,32 @@ export const handler = async (argv: Arguments<WatchOptions>) => {
 }
 
 /**
- * Mirrors the Vercel branch above but via the generic IFirewallProvider interface.
- * Always applies changes without prompting (force: true) — same as the Vercel path,
- * which goes straight from diff to sync without a confirmation prompt, since watch
- * mode is opt-in unattended auto-sync. `allowDeletions: true` is likewise deliberate
- * here (unlike plain `doorman sync --ci`): a `watch` session is opted into by an
- * actively-present developer editing the local config file, not a headless CI job,
- * so a deletion driven by their own edit is exactly what they asked for.
+ * Syncs a changed config file to the provider via the generic
+ * IFirewallProvider interface — the same path for every provider (Vercel
+ * included; a legacy-shaped local config is converted in-memory via
+ * `toUnifiedConfig`). Always applies changes without prompting (force:
+ * true), since watch mode is opt-in unattended auto-sync. `allowDeletions:
+ * true` is likewise deliberate here (unlike plain `doorman sync --ci`): a
+ * `watch` session is opted into by an actively-present developer editing the
+ * local config file, not a headless CI job, so a deletion driven by their
+ * own edit is exactly what they asked for.
+ *
+ * After a successful sync, provider-assigned rule ID changes and version/
+ * metadata drift are written back to the local config file unconditionally
+ * (no prompt, matching watch mode's unattended design).
  */
-async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfig: UnifiedConfig): Promise<void> {
+async function syncChangesWithProvider(
+  provider: IFirewallProvider,
+  originalConfig: FirewallConfig,
+  configPath: string,
+): Promise<void> {
+  const updatedConfig = toUnifiedConfig(originalConfig)
   const changes = await provider.getChanges(updatedConfig)
 
-  if (!changes.hasChanges) {
+  const localVersion = updatedConfig.metadata?.version
+  const hasVersionChange = changes.version !== undefined && localVersion !== changes.version
+
+  if (!changes.hasChanges && !hasVersionChange) {
     logger.info(chalk.blue('No changes detected, skipping sync'))
     return
   }
@@ -206,4 +180,15 @@ async function syncChangesWithProvider(provider: IFirewallProvider, updatedConfi
 
   logger.success(chalk.green(`✅ Sync completed at ${new Date().toLocaleTimeString()}`))
   result.warnings?.forEach((w) => logger.warn(w))
+
+  if (result.idRemappings?.length) {
+    result.idRemappings.forEach((r) => {
+      logger.info(chalk.dim(`  Rule "${r.name}" ID updated: ${r.oldId || 'none'} -> ${r.newId}`))
+    })
+  }
+
+  const writeBack = applySyncResultToConfig(originalConfig, result)
+  if (writeBack.changed) {
+    await saveConfig(writeBack.config, configPath)
+  }
 }

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -353,9 +353,17 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       })
       logger.debug(`Fetched ${activeConfig.rules.length} custom rules and ${activeConfig.ips.length} IP blocking rules`)
 
-      // Convert unified rules back to Vercel format for comparison
-      const configRules: CustomRule[] = config.rules.map((rule) => {
-        const translation = RuleTranslator.unifiedToVercel(rule)
+      // Diff in unified space, normalizing BOTH sides through
+      // `vercelToUnified` rather than translating only the local config to
+      // Vercel shape and comparing it against the raw remote response.
+      // Translating one side but not the other is asymmetric: `unifiedToVercel`
+      // fills in fields a minimal on-disk config never had (e.g.
+      // action.mitigate.rateLimit/redirect/actionDuration defaulting to
+      // null), which then never structurally matches a remote rule that
+      // omits them — producing a spurious "update" on every sync even when
+      // nothing actually changed.
+      const remoteRules: UnifiedRule[] = activeConfig.rules.map((rule) => {
+        const translation = RuleTranslator.vercelToUnified(rule)
         if (translation.warnings.length > 0) {
           translation.warnings.forEach((w) => {
             const { TranslationWarningSystem } = require('../../translators/TranslationWarningSystem')
@@ -367,36 +375,21 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       })
 
       // Handle custom rules
-      const { toAdd, toUpdate, toDelete } = this.diffRules(configRules, activeConfig.rules)
+      const { toAdd, toUpdate, toDelete } = this.diffRules(config.rules, remoteRules)
 
-      // Convert unified IP rules back to Vercel format
-      const configIPs: IPBlockingRule[] = (config.ips || []).map((ip) => ({
-        id: ip.id || '',
-        ip: ip.ip,
-        hostname: ip.hostname || '',
-        action: ip.action as 'deny',
-        notes: ip.notes,
-      }))
+      const remoteIPs: UnifiedIPRule[] = activeConfig.ips.map((ip) => RuleTranslator.vercelIPToUnified(ip))
 
       // Handle IP blocking rules
-      const { ipsToAdd, ipsToUpdate, ipsToDelete } = this.diffIPRules(configIPs, activeConfig.ips)
-
-      // Convert to unified format for ChangeSet compatibility
-      const unifiedRulesToAdd = toAdd.map((r) => RuleTranslator.vercelToUnified(r).result)
-      const unifiedRulesToUpdate = toUpdate.map((r) => RuleTranslator.vercelToUnified(r).result)
-      const unifiedRulesToDelete = toDelete.map((r) => RuleTranslator.vercelToUnified(r).result)
-      const unifiedIPsToAdd = ipsToAdd.map((ip) => RuleTranslator.vercelIPToUnified(ip))
-      const unifiedIPsToUpdate = ipsToUpdate.map((ip) => RuleTranslator.vercelIPToUnified(ip))
-      const unifiedIPsToDelete = ipsToDelete.map((ip) => RuleTranslator.vercelIPToUnified(ip))
+      const { ipsToAdd, ipsToUpdate, ipsToDelete } = this.diffIPRules(config.ips || [], remoteIPs)
 
       return {
         version: activeConfig.version,
-        rulesToAdd: unifiedRulesToAdd,
-        rulesToUpdate: unifiedRulesToUpdate,
-        rulesToDelete: unifiedRulesToDelete,
-        ipsToAdd: unifiedIPsToAdd,
-        ipsToUpdate: unifiedIPsToUpdate,
-        ipsToDelete: unifiedIPsToDelete,
+        rulesToAdd: toAdd,
+        rulesToUpdate: toUpdate,
+        rulesToDelete: toDelete,
+        ipsToAdd,
+        ipsToUpdate,
+        ipsToDelete,
         hasChanges:
           toAdd.length > 0 ||
           toUpdate.length > 0 ||
@@ -515,18 +508,20 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
   }
 
   /**
-   * Diff custom rules
+   * Diff custom rules. Both arguments must already be normalized into
+   * `UnifiedRule` — see the comment in `getChanges` for why comparing an
+   * unnormalized side against a normalized one produces false diffs.
    */
   private diffRules(
-    configRules: CustomRule[],
-    existingRules: CustomRule[],
+    configRules: UnifiedRule[],
+    existingRules: UnifiedRule[],
   ): {
-    toAdd: CustomRule[]
-    toUpdate: CustomRule[]
-    toDelete: CustomRule[]
+    toAdd: UnifiedRule[]
+    toUpdate: UnifiedRule[]
+    toDelete: UnifiedRule[]
   } {
-    const toAdd: CustomRule[] = []
-    const toUpdate: CustomRule[] = []
+    const toAdd: UnifiedRule[] = []
+    const toUpdate: UnifiedRule[] = []
     const toDelete = [...existingRules]
 
     for (const configRule of configRules) {
@@ -548,18 +543,19 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
   }
 
   /**
-   * Diff IP blocking rules
+   * Diff IP blocking rules. Both arguments must already be normalized into
+   * `UnifiedIPRule` — see the comment in `getChanges`.
    */
   private diffIPRules(
-    configRules: IPBlockingRule[],
-    existingRules: IPBlockingRule[],
+    configRules: UnifiedIPRule[],
+    existingRules: UnifiedIPRule[],
   ): {
-    ipsToAdd: IPBlockingRule[]
-    ipsToUpdate: IPBlockingRule[]
-    ipsToDelete: IPBlockingRule[]
+    ipsToAdd: UnifiedIPRule[]
+    ipsToUpdate: UnifiedIPRule[]
+    ipsToDelete: UnifiedIPRule[]
   } {
-    const ipsToAdd: IPBlockingRule[] = []
-    const ipsToUpdate: IPBlockingRule[] = []
+    const ipsToAdd: UnifiedIPRule[] = []
+    const ipsToUpdate: UnifiedIPRule[] = []
     const ipsToDelete = [...existingRules]
 
     for (const configRule of configRules) {

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { logger } from '../logger'
 import { prompt } from '../ui/prompt'
 import type { UnifiedConfig } from '../types/unified'
@@ -368,8 +369,6 @@ export class OperationSafety {
    * Format risk level with appropriate styling
    */
   private static formatRiskLevel(riskLevel: 'low' | 'medium' | 'high'): string {
-    const chalk = require('chalk')
-
     switch (riskLevel) {
       case 'low':
         return chalk.green('LOW')

--- a/src/tests/commands.integration.test.ts
+++ b/src/tests/commands.integration.test.ts
@@ -6,8 +6,12 @@ import { handler as syncHandler } from '../commands/sync'
 import { handler as downloadHandler } from '../commands/download'
 import { FirewallConfig } from '../lib/types'
 
-// Mock external dependencies
+// Mock external dependencies. `download` still uses the legacy
+// `services/VercelClient`; `sync` has been migrated onto the generic
+// IFirewallProvider path, which resolves the NEW `providers/vercel/VercelClient`
+// — both are mocked so each command's tests hit their respective client.
 jest.mock('../lib/services/VercelClient')
+jest.mock('../lib/providers/vercel/VercelClient')
 jest.mock('../lib/ui/prompt')
 jest.mock('../lib/ui/promptForCredentials')
 
@@ -104,6 +108,32 @@ describe('Command Integration Tests', () => {
       .mockImplementation((rule: any) => Promise.resolve(rule)) as any
     // @ts-expect-error - Mock type compatibility
     MockedVercelClient.prototype.deleteIPBlockingRule = jest.fn().mockResolvedValue(undefined)
+
+    // Mock the NEW providers/vercel/VercelClient with the same defaults —
+    // used by `sync` (and `watch`) via the generic IFirewallProvider path.
+    const { VercelClient: NewVercelClient } = await import('../lib/providers/vercel/VercelClient')
+    const MockedNewVercelClient = NewVercelClient as jest.MockedClass<typeof NewVercelClient>
+
+    // @ts-expect-error - Mock type compatibility
+    MockedNewVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(mockRemoteConfig)
+    MockedNewVercelClient.prototype.createFirewallRule = jest
+      .fn()
+      .mockImplementation((rule: any) =>
+        Promise.resolve({ ...rule, id: `rule_${rule.name.toLowerCase().replace(/\s+/g, '_')}` }),
+      ) as any
+    MockedNewVercelClient.prototype.updateFirewallRule = jest
+      .fn()
+      .mockImplementation((rule: any) => Promise.resolve(rule)) as any
+    // @ts-expect-error - Mock type compatibility
+    MockedNewVercelClient.prototype.deleteFirewallRule = jest.fn().mockResolvedValue(undefined)
+    MockedNewVercelClient.prototype.createIPBlockingRule = jest
+      .fn()
+      .mockImplementation((rule: any) => Promise.resolve({ ...rule, id: 'ip-new-1' })) as any
+    MockedNewVercelClient.prototype.updateIPBlockingRule = jest
+      .fn()
+      .mockImplementation((rule: any) => Promise.resolve(rule)) as any
+    // @ts-expect-error - Mock type compatibility
+    MockedNewVercelClient.prototype.deleteIPBlockingRule = jest.fn().mockResolvedValue(undefined)
   })
 
   afterEach(async () => {
@@ -342,7 +372,7 @@ describe('Command Integration Tests', () => {
       } as any)
 
       // Then
-      const { VercelClient } = await import('../lib/services/VercelClient')
+      const { VercelClient } = await import('../lib/providers/vercel/VercelClient')
       const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
       // Should not call any modification methods
@@ -518,10 +548,17 @@ describe('Command Integration Tests', () => {
       const { prompt } = await import('../lib/ui/prompt')
       ;(prompt as jest.MockedFunction<typeof prompt>).mockResolvedValue(true)
 
+      // `sync` goes through the NEW providers/vercel/VercelClient (generic
+      // IFirewallProvider path); `download` still uses the legacy client.
+      const { VercelClient: NewVercelClient } = await import('../lib/providers/vercel/VercelClient')
+      const MockedNewVercelClient = NewVercelClient as jest.MockedClass<typeof NewVercelClient>
       const { VercelClient } = await import('../lib/services/VercelClient')
       const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
-      // Step 1: Sync the initial config
+      // Step 1: Sync the initial config. `sync.ts`'s pre-sync diff, syncRules'
+      // internal re-diff, and syncRules' post-sync re-fetch each call
+      // fetchFirewallConfig — the first two see an empty remote (so the
+      // local rule is a create), the rest see the post-sync state.
       const firstSyncPostConfig = {
         // Post-sync state
         ...mockRemoteConfig,
@@ -530,12 +567,14 @@ describe('Command Integration Tests', () => {
         ips: [],
       }
       // @ts-expect-error - Mock type compatibility
-      MockedVercelClient.prototype.fetchFirewallConfig = jest
+      MockedNewVercelClient.prototype.fetchFirewallConfig = jest
         .fn()
         // @ts-expect-error - Mock type compatibility
-        .mockResolvedValueOnce({ ...mockRemoteConfig, rules: [], ips: [] }) // For getChanges
+        .mockResolvedValueOnce({ ...mockRemoteConfig, rules: [], ips: [] })
         // @ts-expect-error - Mock type compatibility
-        .mockResolvedValue(firstSyncPostConfig) // For all validation retry attempts
+        .mockResolvedValueOnce({ ...mockRemoteConfig, rules: [], ips: [] })
+        // @ts-expect-error - Mock type compatibility
+        .mockResolvedValue(firstSyncPostConfig)
 
       await syncHandler({
         config: configPath,

--- a/src/tests/testHelpers/providerMocks.ts
+++ b/src/tests/testHelpers/providerMocks.ts
@@ -1,6 +1,7 @@
 import type { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
 import { CloudflareOptimizer } from '../../lib/providers/cloudflare/CloudflareOptimizer'
 import type { CloudflareRuleset } from '../../lib/types/cloudflare'
+import type { VercelClient, VercelConfig } from '../../lib/providers/vercel/VercelClient'
 
 /**
  * Default empty Cloudflare ruleset used by tests that don't care about its contents.
@@ -51,4 +52,57 @@ export function mockCloudflareClientPrototype(
   MockedCloudflareClient.prototype.addListItems = jest.fn().mockResolvedValue([]) as any
   MockedCloudflareClient.prototype.removeListItems = jest.fn().mockResolvedValue(undefined) as any
   MockedCloudflareClient.prototype.verifyCredentials = jest.fn().mockResolvedValue(true) as any
+}
+
+/**
+ * Default empty Vercel firewall config used by tests that don't care about its contents.
+ */
+export function emptyVercelConfig(overrides: Partial<VercelConfig> = {}): VercelConfig {
+  return {
+    version: 1,
+    id: 'config_1',
+    firewallEnabled: true,
+    crs: null,
+    rules: [],
+    ips: [],
+    projectKey: 'pk_1',
+    ownerId: 'owner_1',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * Wires up a mocked `VercelClient` class (from `jest.mock('.../providers/vercel/VercelClient')`)
+ * with sensible defaults so commands that resolve a Vercel provider (via
+ * `withCredentials` -> `getProviderInstance` -> `VercelProvider.fromConfig`) don't
+ * make real network calls. Call this after `jest.mock('.../providers/vercel/VercelClient')`
+ * in the test file; pass the mocked class itself.
+ *
+ * Note: this mocks the NEW `src/lib/providers/vercel/VercelClient`, which is what
+ * `IFirewallProvider`-based command paths use — not the legacy
+ * `src/lib/services/VercelClient`.
+ */
+export function mockVercelClientPrototype(
+  MockedVercelClient: jest.MockedClass<typeof VercelClient>,
+  options: { config?: VercelConfig } = {},
+): void {
+  const config = options.config ?? emptyVercelConfig()
+
+  MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(config) as any
+  MockedVercelClient.prototype.createFirewallRule = jest
+    .fn()
+    .mockImplementation((rule) =>
+      Promise.resolve({ ...rule, id: `rule_${Math.random().toString(36).slice(2)}` }),
+    ) as any
+  MockedVercelClient.prototype.updateFirewallRule = jest.fn().mockImplementation((rule) => Promise.resolve(rule)) as any
+  MockedVercelClient.prototype.deleteFirewallRule = jest.fn().mockResolvedValue(undefined) as any
+  MockedVercelClient.prototype.createIPBlockingRule = jest
+    .fn()
+    .mockImplementation((rule) => Promise.resolve({ ...rule, id: `ip_${Math.random().toString(36).slice(2)}` })) as any
+  MockedVercelClient.prototype.updateIPBlockingRule = jest
+    .fn()
+    .mockImplementation((rule) => Promise.resolve(rule)) as any
+  MockedVercelClient.prototype.deleteIPBlockingRule = jest.fn().mockResolvedValue(undefined) as any
+  MockedVercelClient.prototype.verifyCredentials = jest.fn().mockResolvedValue(true) as any
 }

--- a/src/tests/version-sync-fix.test.ts
+++ b/src/tests/version-sync-fix.test.ts
@@ -5,8 +5,10 @@ import { tmpdir } from 'os'
 import { handler as syncHandler } from '../commands/sync'
 import { FirewallConfig } from '../lib/types'
 
-// Mock external dependencies
-jest.mock('../lib/services/VercelClient')
+// Mock external dependencies. Mocks the NEW `providers/vercel/VercelClient`
+// (what the generic IFirewallProvider-based sync path uses) — not the
+// legacy `services/VercelClient`, which sync.ts no longer touches.
+jest.mock('../lib/providers/vercel/VercelClient')
 jest.mock('../lib/ui/prompt')
 jest.mock('../lib/ui/promptForCredentials')
 
@@ -74,7 +76,7 @@ describe('Version Sync Fix', () => {
     await fs.writeFile(configPath, JSON.stringify(localConfig, null, 2))
 
     // Mock VercelClient to return same rules but newer version
-    const { VercelClient } = await import('../lib/services/VercelClient')
+    const { VercelClient } = await import('../lib/providers/vercel/VercelClient')
     const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
     const remoteConfig = {
@@ -122,7 +124,7 @@ describe('Version Sync Fix', () => {
 
     await fs.writeFile(configPath, JSON.stringify(localConfig, null, 2))
 
-    const { VercelClient } = await import('../lib/services/VercelClient')
+    const { VercelClient } = await import('../lib/providers/vercel/VercelClient')
     const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
     const remoteConfig = {
@@ -165,7 +167,7 @@ describe('Version Sync Fix', () => {
 
     await fs.writeFile(configPath, JSON.stringify(localConfig, null, 2))
 
-    const { VercelClient } = await import('../lib/services/VercelClient')
+    const { VercelClient } = await import('../lib/providers/vercel/VercelClient')
     const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
     const remoteConfig = {
@@ -209,7 +211,7 @@ describe('Version Sync Fix', () => {
     await fs.writeFile(configPath, JSON.stringify(localConfig, null, 2))
     const originalStats = await fs.stat(configPath)
 
-    const { VercelClient } = await import('../lib/services/VercelClient')
+    const { VercelClient } = await import('../lib/providers/vercel/VercelClient')
     const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 
     const remoteConfig = {


### PR DESCRIPTION
## Summary

PR2 of the Vercel-CLI-onto-`IFirewallProvider` migration (see plan). `sync.ts` and `watch.ts` now route Vercel through the same generic provider path Cloudflare already uses, instead of the separate legacy `FirewallService`/`VercelClient` stack — using the config adapter (`toUnifiedConfig`/`applySyncResultToConfig`) and `idRemappings`/`version`/`updatedAt` plumbing laid down in #169/#170/#171.

**Two real bugs found and fixed while migrating** (both pre-existing in code this PR is the first to actually exercise end-to-end):
- `VercelFirewallService.getChanges` diffed a translated-to-Vercel-shape local config against the *raw* remote response — asymmetric, since the translator fills in `action.mitigate.rateLimit/redirect/actionDuration: null` that a minimal on-disk config never had, causing a spurious "update" on **every** sync even when nothing changed. Fixed by diffing both sides in normalized unified space instead.
- `OperationSafety.formatRiskLevel` used `const chalk = require('chalk')` instead of a top-level import, which breaks under the test chalk mock (`chalk.yellow is not a function`) — silently unexercised until now because no earlier caller of `confirmDestructiveOperation` reached the non-`skipConfirmation` branch. Fixed to a normal top-level `import chalk from 'chalk'`.

**Disclosed behavior changes** (Vercel now matches Cloudflare's existing semantics, rather than a Vercel-specific regression):
- A single risk-tiered confirmation prompt (via `OperationSafety`) replaces the two separate legacy prompts.
- Declining now exits non-zero instead of a clean "Sync cancelled." return.
- `--ci` now bypasses the confirmation prompt — the legacy Vercel path never respected `--ci` at all.
- Provider-assigned rule IDs are written back to the local config **unconditionally** (logged, not prompted) instead of guessed via a snake-case naming convention and re-confirmed.

Rewrote `sync.test.ts` (superseding #172's legacy-path characterization) and updated `watch.test.ts`, `commands.integration.test.ts`, and `version-sync-fix.test.ts` to mock the new `providers/vercel/VercelClient` instead of the legacy one. Added a `mockVercelClientPrototype` test helper mirroring the existing Cloudflare one.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` (74 suites / 1301 tests passing)
- [x] `pnpm eslint .` (0 errors, pre-existing warnings only)
- [x] Manually exercised `sync` and `watch` against `demos/mock-server.mjs` (real HTTP, not mocks) with a minimal legacy-shaped fixture: confirmed no spurious diff on an unchanged rule, correct create + ID-remap write-back, and idempotent no-op on a second run