### PR TITLE
feat: migrate backup and export onto IFirewallProvider for Vercel

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -1,14 +1,14 @@
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { VercelClient } from '../../lib/services/VercelClient'
+import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
 import { logger } from '../../lib/logger'
-import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
 import { handler } from '../backup'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
-jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/vercel/VercelClient')
 jest.mock('../../lib/providers/cloudflare/CloudflareClient')
 
 const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
@@ -73,7 +73,7 @@ describe('backup command', () => {
     // `find-up` package and doesn't play well with ts-jest's CJS transform).
     configPath = join(tempDir, '.doorman.json')
     await fs.writeFile(configPath, JSON.stringify({ rules: [], ips: [] }))
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(vercelRemoteConfig) as any
+    mockVercelClientPrototype(MockedVercelClient, { config: vercelRemoteConfig as any })
     mockCloudflareClientPrototype(MockedCloudflareClient)
   })
 
@@ -100,15 +100,21 @@ describe('backup command', () => {
     const content = JSON.parse(await fs.readFile(join(backupDir, files[0]!), 'utf8'))
     expect(content.backup.provider).toBe('vercel')
     expect(content.backup.projectId).toBe('prj')
-    // Vercel API-only fields must not leak into the saved backup — this is
-    // also what makes the sanitized config pass schema validation at all.
+    // The backup now saves the UnifiedConfig fetchConfig() returns —
+    // RuleTranslator.vercelToUnified builds it from an explicit field
+    // allowlist, so API-only fields (id, crs, projectKey, ownerId,
+    // firewallEnabled, per-rule valid/validationErrors) never survive it in
+    // the first place; no separate sanitization step needed.
     expect(content.id).toBeUndefined()
     expect(content.crs).toBeUndefined()
     expect(content.projectKey).toBeUndefined()
     expect(content.ownerId).toBeUndefined()
-    expect(content.version).toBe(5)
-    expect(content.firewallEnabled).toBe(true)
-    // Per-rule API-only fields must not leak into the saved backup either.
+    // Top-level `version` is now the unified format string; the real
+    // remote version lives under `metadata.version` (and is mirrored into
+    // `backup.originalVersion`).
+    expect(content.version).toBe('2.0')
+    expect(content.metadata.version).toBe(5)
+    expect(content.backup.originalVersion).toBe(5)
     expect(content.rules).toHaveLength(1)
     expect(content.rules[0].valid).toBeUndefined()
     expect(content.rules[0].validationErrors).toBeUndefined()

--- a/src/commands/__tests__/export.test.ts
+++ b/src/commands/__tests__/export.test.ts
@@ -1,13 +1,13 @@
 import { getConfig } from '../../lib/utils/config'
 import { logger } from '../../lib/logger'
-import { VercelClient } from '../../lib/services/VercelClient'
+import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
-import { mockCloudflareClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
 import { handler } from '../export'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
 jest.mock('../../lib/utils/config', () => ({ getConfig: jest.fn() }))
-jest.mock('../../lib/services/VercelClient')
+jest.mock('../../lib/providers/vercel/VercelClient')
 jest.mock('../../lib/providers/cloudflare/CloudflareClient')
 
 const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
@@ -32,13 +32,19 @@ describe('export command', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any)
-    MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue({
-      version: 5,
-      firewallEnabled: true,
-      rules: [],
-      ips: [],
-      updatedAt: '2024-01-01T00:00:00Z',
-    }) as any
+    mockVercelClientPrototype(MockedVercelClient, {
+      config: {
+        version: 5,
+        id: 'config_1',
+        firewallEnabled: true,
+        crs: null,
+        rules: [],
+        ips: [],
+        projectKey: 'pk_1',
+        ownerId: 'owner_1',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    })
     mockCloudflareClientPrototype(MockedCloudflareClient)
   })
 
@@ -80,7 +86,11 @@ describe('export command', () => {
     } as any)
 
     const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
-    expect(JSON.parse(logged).version).toBe(5)
+    const parsed = JSON.parse(logged)
+    // A remote export always fetches a clean UnifiedConfig now — the real
+    // remote version lives under `metadata.version`, not the top-level
+    // `version` (which is the unified format string, e.g. "2.0").
+    expect(parsed.metadata.version).toBe(5)
   })
 
   it('exports the remote config for the Cloudflare provider without crashing (regression test for #82)', async () => {
@@ -101,17 +111,49 @@ describe('export command', () => {
     expect(JSON.parse(logged).provider).toBe('cloudflare')
   })
 
-  it('refuses non-JSON export formats for a multi-provider config instead of producing garbage output', async () => {
+  it('exports markdown for a multi-provider (Cloudflare) config too, not just Vercel', async () => {
     mockedGetConfig.mockResolvedValue({
       version: '2.0',
       provider: 'cloudflare',
       providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
-      rules: [],
+      rules: [
+        {
+          name: 'Block Bad Bots',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'deny' },
+        },
+      ],
       ips: [],
     } as any)
 
     await handler({ source: 'local', format: 'markdown', output: '-', debug: false, ci: true } as any)
 
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('only supported for Vercel configurations'))
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(logged).toContain('Block Bad Bots')
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('exports terraform for a multi-provider (Cloudflare) config too', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: '2.0',
+      provider: 'cloudflare',
+      providers: { cloudflare: { zoneId: '0123456789abcdef0123456789abcdef' } },
+      rules: [
+        {
+          name: 'Block Bad Bots',
+          enabled: true,
+          conditions: [{ field: 'user_agent', operator: 'contains', value: 'badbot' }],
+          action: { type: 'deny' },
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({ source: 'local', format: 'terraform', output: '-', debug: false, ci: true } as any)
+
+    const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(logged).toContain('resource "firewall_rule" "rule_0"')
+    expect(logged).toContain('Block Bad Bots')
   })
 })

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -5,8 +5,7 @@ import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
 import { ValidationService } from '../lib/services/ValidationService'
-import type { VercelConfig } from '../lib/services/VercelClient'
-import { FirewallConfig, IPBlockingRule } from '../lib/types'
+import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
@@ -173,50 +172,25 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         ci: argv.ci,
         errorContext: 'creating backup',
       },
-      async ({ client, provider, projectId, teamId }) => {
+      async ({ provider, projectId, teamId }) => {
         logger.start('Fetching current remote configuration...')
-        const remoteConfig =
-          provider.name === 'vercel' ? await client.fetchFirewallConfig() : await provider.fetchConfig()
+        // `fetchConfig()` already returns a clean UnifiedConfig for every
+        // provider — RuleTranslator.vercelToUnified builds its result from
+        // an explicit field allowlist, so API-only fields (valid,
+        // validationErrors, id, crs, projectKey, ownerId, firewallEnabled)
+        // genuinely cannot survive it, the same guarantee Cloudflare's
+        // fetchConfig() already provided. No further sanitization needed.
+        const remoteConfig = await provider.fetchConfig()
+        const remoteVersion = remoteConfig.metadata?.version ?? remoteConfig.version
 
-        // The raw Vercel API response includes fields (id, crs, projectKey,
-        // ownerId) that aren't part of a Doorman config and would fail schema
-        // validation (additionalProperties: false) — strip them before
-        // validating/saving, the same way download.ts builds its saved config.
-        // The API also attaches valid/validationErrors to every rule object
-        // (download.ts strips these too, for the same reason — CustomRule also
-        // has additionalProperties: false). IP-blocking rules are similarly
-        // allowlist-reconstructed by known schema field names (id, ip,
-        // hostname, notes, action) rather than passed through as-is — no
-        // extra fields have been observed there yet, but IPBlockingRule also
-        // has additionalProperties: false, so this closes off the same bug
-        // class before it can trigger a third time. Cloudflare's
-        // fetchConfig() already returns a clean UnifiedConfig with no extra
-        // fields, so it's used as-is.
-        const sanitizedConfig =
-          provider.name === 'vercel'
-            ? {
-                version: remoteConfig.version,
-                firewallEnabled: (remoteConfig as VercelConfig).firewallEnabled,
-                rules: remoteConfig.rules.map(({ valid, validationErrors, ...rule }: any) => rule),
-                ips: (remoteConfig.ips as IPBlockingRule[]).map(({ id, ip, hostname, notes, action }) => ({
-                  ...(id !== undefined && { id }),
-                  ip,
-                  hostname,
-                  ...(notes !== undefined && { notes }),
-                  action,
-                })),
-                updatedAt: (remoteConfig as VercelConfig).updatedAt,
-              }
-            : remoteConfig
-
-        // Validate the sanitized config (before adding the backup metadata
+        // Validate the fetched config (before adding the backup metadata
         // wrapper below) — this catches genuine API response corruption rather
         // than trusting whatever the provider returned. It's validated here,
         // not after wrapping, because the wrapper's `backup` field isn't part of
         // the live config schema (additionalProperties: false); see the save
         // below for why that final write is unvalidated.
         const validator: ValidationService = ValidationService.getInstance()
-        validator.validateConfig(sanitizedConfig)
+        validator.validateConfig(remoteConfig)
 
         if (!existsSync(backupDir)) {
           mkdirSync(backupDir, { recursive: true })
@@ -230,13 +204,13 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         const backupPath = join(backupDir, backupFilename)
 
         const backupConfig = {
-          ...sanitizedConfig,
+          ...remoteConfig,
           backup: {
             createdAt: new Date().toISOString(),
             source: 'remote',
             provider: provider.name,
             ...(provider.name === 'vercel' ? { projectId, teamId } : {}),
-            originalVersion: remoteConfig.version,
+            originalVersion: remoteVersion,
           },
         }
 
@@ -249,7 +223,7 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
         logger.success(chalk.green(`✅ Backup created: ${backupPath}`))
         logger.log('')
         logger.log(chalk.bold('Backup Details:'))
-        logger.log(`${chalk.dim('Version:')} ${remoteConfig.version}`)
+        logger.log(`${chalk.dim('Version:')} ${remoteVersion ?? 'unknown'}`)
         logger.log(
           `${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips?.length ?? 0} IP blocking`,
         )

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -2,9 +2,11 @@ import chalk from 'chalk'
 import { writeFileSync } from 'fs'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
-import { CustomRule, FirewallConfig, IPBlockingRule, hasProviderMetadata } from '../lib/types'
+import type { FirewallConfig } from '../lib/types'
+import type { UnifiedConfig, UnifiedIPRule, UnifiedRule } from '../lib/types/unified'
 import { getConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
+import { toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface ExportOptions {
@@ -77,32 +79,55 @@ export const builder = {
   ci: { type: 'boolean', description: 'Run in CI mode (non-interactive)', default: false },
 }
 
-const generateMarkdownReport = (config: FirewallConfig): string => {
-  const { rules, ips = [], version, updatedAt } = config
+/**
+ * Groups a rule's flat `conditions[]` by `.group` (defaulting ungrouped
+ * conditions to a single implicit group 0) — reconstructs the AND-within/
+ * OR-across structure providers like Vercel model as nested condition
+ * groups, for display purposes.
+ */
+function groupConditions(conditions: UnifiedRule['conditions']): UnifiedRule['conditions'][] {
+  const groups = new Map<number, UnifiedRule['conditions']>()
+  for (const condition of conditions) {
+    const index = condition.group ?? 0
+    const bucket = groups.get(index)
+    if (bucket) {
+      bucket.push(condition)
+    } else {
+      groups.set(index, [condition])
+    }
+  }
+  return [...groups.values()]
+}
 
-  let markdown = `# Vercel Firewall Configuration Report\n\n`
-  markdown += `**Version:** ${version}\n`
+const generateMarkdownReport = (config: UnifiedConfig): string => {
+  const { rules, ips = [] } = config
+  const version = config.metadata?.version
+  const updatedAt = config.metadata?.updatedAt
+
+  let markdown = `# Firewall Configuration Report\n\n`
+  markdown += `**Provider:** ${config.provider ?? 'unknown'}\n`
+  markdown += `**Version:** ${version ?? 'unknown'}\n`
   markdown += `**Last Updated:** ${updatedAt ? new Date(updatedAt).toLocaleString() : 'Unknown'}\n`
   markdown += `**Generated:** ${new Date().toLocaleString()}\n\n`
 
   markdown += `## Custom Rules (${rules.length})\n\n`
   if (rules.length > 0) {
-    rules.forEach((rule: CustomRule, index: number) => {
+    rules.forEach((rule: UnifiedRule, index: number) => {
       markdown += `### ${index + 1}. ${rule.name}\n\n`
-      markdown += `- **ID:** \`${rule.id}\`\n`
+      markdown += `- **ID:** \`${rule.id ?? 'unassigned'}\`\n`
       markdown += `- **Description:** ${rule.description || 'No description'}\n`
-      markdown += `- **Action:** ${rule.action.mitigate.action}\n`
-      markdown += `- **Active:** ${rule.active ? '✅ Yes' : '❌ No'}\n`
+      markdown += `- **Action:** ${rule.action.type}\n`
+      markdown += `- **Enabled:** ${rule.enabled ? '✅ Yes' : '❌ No'}\n`
 
-      if (rule.action.mitigate.rateLimit) {
-        markdown += `- **Rate Limit:** ${rule.action.mitigate.rateLimit.requests} requests per ${rule.action.mitigate.rateLimit.window}\n`
+      if (rule.action.rateLimit) {
+        markdown += `- **Rate Limit:** ${rule.action.rateLimit.requests} requests per ${rule.action.rateLimit.window}\n`
       }
 
       markdown += `- **Conditions:**\n`
-      rule.conditionGroup.forEach((group, groupIndex) => {
+      groupConditions(rule.conditions).forEach((group, groupIndex) => {
         markdown += `  - Group ${groupIndex + 1}:\n`
-        group.conditions.forEach((condition) => {
-          markdown += `    - ${condition.type} ${condition.op} \`${condition.value}\`\n`
+        group.forEach((condition) => {
+          markdown += `    - ${condition.field} ${condition.operator} \`${condition.value}\`\n`
         })
       })
       markdown += `\n`
@@ -115,7 +140,7 @@ const generateMarkdownReport = (config: FirewallConfig): string => {
   if (ips.length > 0) {
     markdown += `| IP Address | Hostname | Action |\n`
     markdown += `|------------|----------|--------|\n`
-    ips.forEach((ip: IPBlockingRule) => {
+    ips.forEach((ip: UnifiedIPRule) => {
       markdown += `| \`${ip.ip}\` | ${ip.hostname || 'N/A'} | ${ip.action} |\n`
     })
   } else {
@@ -125,33 +150,33 @@ const generateMarkdownReport = (config: FirewallConfig): string => {
   return markdown
 }
 
-const generateTerraformConfig = (config: FirewallConfig): string => {
+const generateTerraformConfig = (config: UnifiedConfig): string => {
   const { rules, ips = [] } = config
 
-  let terraform = `# Vercel Firewall Configuration\n`
+  let terraform = `# Firewall Configuration (${config.provider ?? 'unknown'})\n`
   terraform += `# Generated on ${new Date().toISOString()}\n\n`
   terraform += `# Note: This is a conceptual Terraform configuration\n`
-  terraform += `# A Vercel Terraform provider would need to be implemented for actual use\n\n`
+  terraform += `# A provider-specific Terraform provider would need to be implemented for actual use\n\n`
 
-  rules.forEach((rule: CustomRule, index: number) => {
-    terraform += `resource "vercel_firewall_rule" "rule_${index}" {\n`
+  rules.forEach((rule: UnifiedRule, index: number) => {
+    terraform += `resource "firewall_rule" "rule_${index}" {\n`
     terraform += `  name        = "${rule.name}"\n`
     terraform += `  description = "${rule.description || ''}"\n`
-    terraform += `  active      = ${rule.active}\n`
-    terraform += `  action      = "${rule.action.mitigate.action}"\n`
+    terraform += `  enabled     = ${rule.enabled}\n`
+    terraform += `  action      = "${rule.action.type}"\n`
 
-    if (rule.action.mitigate.rateLimit) {
+    if (rule.action.rateLimit) {
       terraform += `  rate_limit {\n`
-      terraform += `    requests = ${rule.action.mitigate.rateLimit.requests}\n`
-      terraform += `    window   = "${rule.action.mitigate.rateLimit.window}"\n`
+      terraform += `    requests = ${rule.action.rateLimit.requests}\n`
+      terraform += `    window   = "${rule.action.rateLimit.window}"\n`
       terraform += `  }\n`
     }
 
     terraform += `}\n\n`
   })
 
-  ips.forEach((ip: IPBlockingRule, index: number) => {
-    terraform += `resource "vercel_ip_blocking_rule" "ip_${index}" {\n`
+  ips.forEach((ip: UnifiedIPRule, index: number) => {
+    terraform += `resource "firewall_ip_blocking_rule" "ip_${index}" {\n`
     terraform += `  ip       = "${ip.ip}"\n`
     terraform += `  hostname = "${ip.hostname || ''}"\n`
     terraform += `  action   = "${ip.action}"\n`
@@ -163,7 +188,14 @@ const generateTerraformConfig = (config: FirewallConfig): string => {
 
 export const handler = async (argv: Arguments<ExportOptions>) => {
   try {
-    let config: FirewallConfig
+    // The raw config as loaded/fetched, in whatever shape it's already in
+    // (legacy or unified) — JSON export serializes this as-is, matching the
+    // pre-migration behavior of round-tripping the on-disk file unchanged.
+    // `provider.fetchConfig()` always returns a clean UnifiedConfig now
+    // (for every provider), so a remote JSON export no longer leaks
+    // API-only fields (id, crs, projectKey, ownerId, valid,
+    // validationErrors) the way a raw Vercel API response used to.
+    let config: FirewallConfig | UnifiedConfig
 
     if (argv.source === 'remote') {
       // Remote export needs credentials
@@ -181,12 +213,9 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
           ci: argv.ci,
           errorContext: 'exporting configuration',
         },
-        async ({ client, provider }) => {
+        async ({ provider }) => {
           logger.start('Fetching remote configuration...')
-          config =
-            provider.name === 'vercel'
-              ? await client.fetchFirewallConfig()
-              : ((await provider.fetchConfig()) as unknown as FirewallConfig)
+          config = await provider.fetchConfig()
         },
       )
     } else {
@@ -194,17 +223,6 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
     }
 
     logger.start(`Exporting configuration in ${argv.format} format...`)
-
-    // The yaml/terraform/markdown generators below assume the legacy Vercel rule
-    // shape (conditionGroup/action.mitigate). A multi-provider (Cloudflare) config
-    // uses a different rule shape and would otherwise silently produce garbage
-    // output, so only json export is supported for those until dedicated generators
-    // exist.
-    if (argv.format !== 'json' && hasProviderMetadata(config!)) {
-      throw new Error(
-        `The '${argv.format}' export format is currently only supported for Vercel configurations. Use --format json instead.`,
-      )
-    }
 
     let output: string
     let defaultExtension: string
@@ -215,27 +233,29 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
         defaultExtension = 'json'
         break
 
-      case 'yaml':
-        output = `# Vercel Firewall Configuration\n`
-        output += `version: ${config!.version}\n`
-        output += `updatedAt: "${config!.updatedAt}"\n`
+      case 'yaml': {
+        const unified = toUnifiedConfig(config!)
+        output = `# Firewall Configuration (${unified.provider ?? 'unknown'})\n`
+        output += `version: ${unified.metadata?.version ?? 'unknown'}\n`
+        output += `updatedAt: "${unified.metadata?.updatedAt ?? ''}"\n`
         output += `rules:\n`
-        config!.rules.forEach((rule: CustomRule) => {
+        unified.rules.forEach((rule: UnifiedRule) => {
           output += `  - name: "${rule.name}"\n`
-          output += `    id: "${rule.id}"\n`
-          output += `    active: ${rule.active}\n`
-          output += `    action: "${rule.action.mitigate.action}"\n`
+          output += `    id: "${rule.id ?? ''}"\n`
+          output += `    enabled: ${rule.enabled}\n`
+          output += `    action: "${rule.action.type}"\n`
         })
         defaultExtension = 'yaml'
         break
+      }
 
       case 'terraform':
-        output = generateTerraformConfig(config!)
+        output = generateTerraformConfig(toUnifiedConfig(config!))
         defaultExtension = 'tf'
         break
 
       case 'markdown':
-        output = generateMarkdownReport(config!)
+        output = generateMarkdownReport(toUnifiedConfig(config!))
         defaultExtension = 'md'
         break
 


### PR DESCRIPTION
## Summary

PR4 of the Vercel-CLI-onto-`IFirewallProvider` migration (see plan; follows #174).

- **`backup.ts`**: drops the Vercel-specific manual sanitization block and calls `provider.fetchConfig()` directly for every provider, like Cloudflare already did — `RuleTranslator.vercelToUnified` builds its result from an explicit field allowlist, so API-only fields (`id`, `crs`, `projectKey`, `ownerId`, per-rule `valid`/`validationErrors`) can't survive it. Incidentally fixes the version display/`originalVersion` metadata to read `metadata.version` instead of the unified format string (`"2.0"`) — a bug that already existed for Cloudflare backups before this PR. `firewallEnabled` is no longer captured in backups (small, real capability loss — not threaded into `metadata`, out of scope here per the plan).
- **`export.ts`**: rewrites the yaml/terraform/markdown generators to consume `UnifiedRule`/`UnifiedConfig` (`action.type`, flat `conditions[]` regrouped by `.group` index for display, `rule.enabled`) instead of the legacy Vercel shape, and drops the `hasProviderMetadata` gate that restricted those formats to Vercel only — **they now work for Cloudflare too**. JSON export still serializes the raw loaded/fetched config as-is (no forced normalization), preserving exact round-trip behavior for `--source local`; `--source remote` now always fetches a clean `UnifiedConfig`, so a remote JSON export no longer leaks raw Vercel API-only fields the way it used to.

Updated `backup.test.ts` and `export.test.ts` to mock the new `providers/vercel/VercelClient` and reflect the new output shapes.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` (74 suites / 1307 tests passing)
- [x] `pnpm eslint .` (0 errors, pre-existing warnings only)
- [x] Manually exercised `backup` and all four `export` formats (json/yaml/terraform/markdown, both local and remote source) against `demos/mock-server.mjs` — confirmed correct version/metadata display and confirmed markdown/terraform export now works for a Cloudflare-shaped local config