### PR TITLE
fix: restore upfront config validation and add post-sync verification

### DIFF
--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -6,6 +6,7 @@ import { RuleTranslator } from '../../translators'
 import { isDeepEqual } from '../../utils/isDeepEqual'
 import { omitId } from '../../utils/omitId'
 import { firewallConfigSchema } from '../../schemas/firewallSchemas'
+import { unifiedConfigSchema } from '../../schemas/unifiedSchemas'
 import type {
   IFirewallProvider,
   ProviderType,
@@ -293,17 +294,52 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
           `${chalk.cyan('Updated:')} ${chalk.cyan(updatedIPRules.length)}, ${chalk.red('Deleted:')} ${chalk.red(deletedIPRules.length)}`,
       )
 
-      // Fetch updated version/timestamp. Best-effort: a failure here
-      // shouldn't discard the sync results already collected above. Falls
-      // back to the pre-sync version (captured before any mutations) if it
-      // fails — updatedAt has no equivalent pre-sync fallback, so it's left
-      // undefined in that case rather than reporting a stale timestamp.
+      // Fetch updated version/timestamp, and use the same re-fetch to
+      // spot-check that the mutations above actually landed. This is
+      // deliberately lightweight (presence/absence by id, not a full
+      // content comparison) — it's meant to catch a create/update/delete
+      // that silently didn't take effect (API eventual consistency, a
+      // partial failure not caught by the per-item try/catch above, etc),
+      // not to replace the per-item error handling. Mismatches are
+      // reported as warnings, not failures — the sync itself already
+      // succeeded from the API's point of view.
       let finalVersion: number = version
       let finalUpdatedAt: string | undefined
+      const warnings: string[] = []
       try {
         const activeConfig = await this.client.fetchFirewallConfig()
         finalVersion = activeConfig.version
         finalUpdatedAt = activeConfig.updatedAt
+
+        const remoteRuleIds = new Set(activeConfig.rules.map((r) => r.id))
+        const remoteIPIds = new Set(activeConfig.ips.map((r) => r.id))
+
+        for (const rule of [...addedRules, ...updatedRules]) {
+          if (rule.id && !remoteRuleIds.has(rule.id)) {
+            warnings.push(
+              `Rule "${rule.name}" (${rule.id}) was synced but is missing from the post-sync remote config — a subsequent sync may re-create or misdiff it.`,
+            )
+          }
+        }
+        for (const rule of deletedRules) {
+          if (rule.id && remoteRuleIds.has(rule.id)) {
+            warnings.push(
+              `Rule "${rule.name}" (${rule.id}) was deleted but still appears in the post-sync remote config.`,
+            )
+          }
+        }
+        for (const ip of [...addedIPRules, ...updatedIPRules]) {
+          if (ip.id && !remoteIPIds.has(ip.id)) {
+            warnings.push(
+              `IP rule "${ip.ip}" (${ip.id}) was synced but is missing from the post-sync remote config — a subsequent sync may re-create or misdiff it.`,
+            )
+          }
+        }
+        for (const ip of deletedIPRules) {
+          if (ip.id && remoteIPIds.has(ip.id)) {
+            warnings.push(`IP rule "${ip.ip}" (${ip.id}) was deleted but still appears in the post-sync remote config.`)
+          }
+        }
       } catch (error) {
         logger.error('Failed to fetch updated firewall configuration version after sync:', error)
         errors.push(describeError('Failed to fetch updated configuration version after sync', error))
@@ -321,6 +357,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
         updatedAt: finalUpdatedAt,
         idRemappings: idRemappings.length > 0 ? idRemappings : undefined,
         errors: errors.length > 0 ? errors : undefined,
+        warnings: warnings.length > 0 ? warnings : undefined,
       }
     } catch (error) {
       logger.error('Error during sync:', error)
@@ -341,6 +378,21 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
     config: UnifiedConfig,
     options?: { allowCreate?: boolean },
   ): Promise<ChangeSet & { version: number }> {
+    // Reject a structurally invalid config up front — before ever diffing
+    // or contacting the API — rather than letting a rule with no
+    // conditions, or an IP rule with a malformed address, silently reach
+    // Vercel. Uses the schema directly rather than `validateUnifiedConfig`,
+    // which also asserts `providers.<provider>` is present — a routing
+    // concern already enforced earlier in the command pipeline, not
+    // something a diff/sync call needs to re-check on every invocation.
+    // Deliberately outside the try/catch below so this specific failure
+    // surfaces with its own message instead of being flattened into the
+    // generic "failed to fetch" one.
+    const configValidation = unifiedConfigSchema.safeParse(config)
+    if (!configValidation.success) {
+      throw new Error(`Invalid firewall configuration: ${configValidation.error.message}`)
+    }
+
     try {
       logger.debug('Fetching existing firewall configuration')
       // `allowCreate: false` is threaded down from syncRules' dry-run path

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -573,6 +573,88 @@ describe('VercelFirewallService', () => {
     })
   })
 
+  describe('post-sync verification (regression: a create/update/delete that silently did not take effect used to go unreported)', () => {
+    it('warns when a created rule is missing from the post-sync remote config', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            name: 'New Rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/new' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest
+        .spyOn(client, 'fetchFirewallConfig')
+        // Pre-sync diff: nothing exists yet.
+        .mockResolvedValueOnce({ ...mockVercelConfig, rules: [], ips: [] })
+        // Post-sync re-fetch: the just-created rule isn't there — e.g. an
+        // eventual-consistency lag, or a create that silently no-op'd.
+        .mockResolvedValueOnce({ ...mockVercelConfig, rules: [], ips: [] })
+      jest.spyOn(client, 'createFirewallRule').mockResolvedValue({
+        id: 'new_rule_1',
+        name: 'New Rule',
+        active: true,
+        conditionGroup: [],
+        action: { mitigate: { action: 'deny', rateLimit: null, redirect: null, actionDuration: null } },
+      })
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings!.some((w) => w.includes('New Rule') && w.includes('missing from the post-sync'))).toBe(
+        true,
+      )
+    })
+
+    it('warns when a deleted rule still appears in the post-sync remote config', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [],
+        ips: [],
+      }
+
+      jest
+        .spyOn(client, 'fetchFirewallConfig')
+        // Pre-sync diff: the remote rule exists, gets marked for deletion.
+        .mockResolvedValueOnce(mockVercelConfig)
+        // Post-sync re-fetch: the "deleted" rule is still there.
+        .mockResolvedValueOnce(mockVercelConfig)
+      jest.spyOn(client, 'deleteFirewallRule').mockResolvedValue(undefined)
+      // mockVercelConfig also has an IP rule not present in `config.ips`,
+      // so it's marked for deletion too — mock it out so it doesn't fail
+      // as a real (unmocked-fetch) API call and pollute `result.success`.
+      jest.spyOn(client, 'deleteIPBlockingRule').mockResolvedValue(undefined)
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings!.some((w) => w.includes('rule_1') && w.includes('still appears in the post-sync'))).toBe(
+        true,
+      )
+    })
+
+    it('leaves warnings undefined when nothing needed to change (no mutations, nothing to verify)', async () => {
+      const config: UnifiedConfig = { version: '2.0', provider: 'vercel', rules: [], ips: [] }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({ ...mockVercelConfig, rules: [], ips: [] })
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(true)
+      expect(result.rulesAdded + result.rulesUpdated + result.rulesDeleted).toBe(0)
+      expect(result.warnings).toBeUndefined()
+    })
+  })
+
   describe('getChanges', () => {
     const unifiedConfig: UnifiedConfig = {
       version: '2.0',
@@ -719,6 +801,39 @@ describe('VercelFirewallService', () => {
 
       expect(changes.rulesToAdd).toHaveLength(1)
       expect(changes.rulesToAdd[0]?.name).toBe('Rule Without ID')
+    })
+
+    it('rejects a rule with no conditions before ever contacting the API', async () => {
+      const configWithEmptyConditions: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            name: 'Malformed Rule',
+            enabled: true,
+            conditions: [],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+      const fetchSpy = jest.spyOn(client, 'fetchFirewallConfig')
+
+      await expect(service.getChanges(configWithEmptyConditions)).rejects.toThrow('Invalid firewall configuration')
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects an IP rule with a malformed address before ever contacting the API', async () => {
+      const configWithBadIP: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [],
+        ips: [{ ip: 'not-an-ip-address', hostname: 'test-host', action: 'deny' }],
+      }
+      const fetchSpy = jest.spyOn(client, 'fetchFirewallConfig')
+
+      await expect(service.getChanges(configWithBadIP)).rejects.toThrow('Invalid firewall configuration')
+      expect(fetchSpy).not.toHaveBeenCalled()
     })
 
     it('should throw on error', async () => {


### PR DESCRIPTION
## Summary

Closes the two follow-up gaps flagged when the legacy Vercel `FirewallService`/`VercelClient` stack was removed (#176).

**1. Upfront config validation restored.** `VercelFirewallService.getChanges` now rejects a structurally invalid `UnifiedConfig` (a rule with no conditions, an IP rule with a malformed address, etc.) up front via `unifiedConfigSchema`, before ever diffing or contacting the API — restoring the pre-diff validation the legacy `FirewallService.getChanges` did via `firewallConfigSchema`. In practice most CLI callers already get this for free from `getConfig`'s own schema validation at file-load time (confirmed manually — see test plan); this closes the gap for callers that build or pass a `UnifiedConfig` directly (embedded/library usage, and the service's own test suite), matching the legacy service's defense-in-depth. Deliberately uses the schema directly rather than the stricter `validateUnifiedConfig` helper, which also asserts `providers.<provider>` is present — a routing concern already enforced earlier in the pipeline, not something a diff/sync call needs to re-check.

**2. Post-sync verification added.** `syncRules`'s existing post-sync re-fetch (used to compute the final version/updatedAt) now also spot-checks that mutations actually landed: every added/updated rule and IP should be present in the re-fetched remote config, every deleted one should be absent. Mismatches are surfaced as `SyncResult.warnings` (already displayed by `sync.ts`/`watch.ts`) rather than treated as failures, since the sync itself already succeeded from the API's point of view — this is meant to catch a create/update/delete that silently didn't take effect (eventual consistency, an API quirk), not to replace the existing per-item error handling.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` (72 suites / 1295 tests passing — 5 new tests)
- [x] `pnpm eslint .` (0 errors, pre-existing warnings only)
- [x] Manually verified against `demos/mock-server.mjs`:
  - A local config with an empty-conditions rule is rejected before sync (confirmed this is actually caught earlier, at config-load time, for the CLI path — the new `getChanges`-level check is defense-in-depth for direct/library callers)
  - A local config with a malformed IP address is rejected the same way
  - A normal valid sync still completes cleanly with no spurious warnings