### PR TITLE
feat: parse Cloudflare wirefilter expressions back into structured conditions

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -421,10 +421,13 @@ export class CloudflareFirewallService extends BaseFirewallService {
    * Get changes between local and remote configurations.
    *
    * Diffs rules in Cloudflare's *native* space (real wirefilter expressions)
-   * rather than going through `fetchConfig()`'s lossy Unified translation —
-   * `cloudflareToUnified` always returns `conditions: []` (expression
-   * parsing isn't implemented), so a remote rule with real conditions could
-   * never diff-equal its local counterpart: every synced rule showed as
+   * rather than going through `fetchConfig()`'s Unified translation. Even
+   * though `cloudflareToUnified` now parses expressions back into real
+   * conditions (via `WirefilterParser`) for hand-authored or foreign
+   * expressions outside the grammar subset it understands, that translation
+   * still isn't guaranteed lossless — diffing in native space avoids any
+   * risk of a remote rule failing to diff-equal its local counterpart due
+   * to a translation gap, which previously showed every synced rule as
    * `toUpdate` forever, even on a no-op sync. See
    * `CloudflareOptimizer.diffCloudflareRules`.
    */
@@ -442,8 +445,8 @@ export class CloudflareFirewallService extends BaseFirewallService {
 
     const ruleDiff = this.optimizer.diffCloudflareRules(localTranslations, remoteCloudflareRules)
     // No local counterpart for a remote-only rule — best-effort translation
-    // back to Unified (still lossy on conditions) is fine for a delete
-    // preview, which only needs to identify *what* is being removed.
+    // back to Unified is fine for a delete preview, which only needs to
+    // identify *what* is being removed, not perfectly round-trip it.
     const rulesToDelete = ruleDiff.toDelete.map((r) => RuleTranslator.cloudflareToUnified(r).result)
 
     // IP diffing is unaffected by the above: it round-trips losslessly

--- a/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareWorkflowIntegration.test.ts
@@ -93,6 +93,10 @@ describe('Complete Sync Workflow Integration', () => {
     expect(remoteConfig.rules.length).toBeGreaterThanOrEqual(1)
     expect(remoteConfig.ips).toHaveLength(1)
     expect(remoteConfig.metadata?.version).toBe(3)
+    // A rule fetched straight from Cloudflare shows its real conditions —
+    // not an empty array — so `list`/`status`/`diff`/`download`/`backup`
+    // can actually display what a remote rule matches on.
+    expect(remoteConfig.rules[0]?.conditions).toEqual([{ field: 'path', operator: 'eq', value: '/admin', group: 0 }])
 
     const localConfig: UnifiedConfig = {
       version: '2.0',
@@ -361,7 +365,7 @@ describe('Rule Translation Accuracy', () => {
       expect(rl?.mitigationTimeout).toBe(600)
     })
 
-    it('should produce warnings for complex expressions', () => {
+    it('parses an expression combining multiple comparisons with "and" into real conditions', () => {
       const cfRule: CloudflareRule = {
         id: 'cf-cx',
         action: 'block',
@@ -370,6 +374,21 @@ describe('Rule Translation Accuracy', () => {
         enabled: true,
       }
       const result = RuleTranslator.cloudflareToUnified(cfRule)
+      expect(result.result.conditions).toHaveLength(2)
+      expect(result.warnings).toEqual([])
+    })
+
+    it('produces a warning and falls back to empty conditions for a structure outside what WirefilterParser understands (OR nested inside AND)', () => {
+      const cfRule: CloudflareRule = {
+        id: 'cf-cx-2',
+        action: 'block',
+        expression:
+          'http.request.uri.path eq "/api" and (http.host eq "a.example.com" or http.host eq "b.example.com")',
+        description: 'Complex',
+        enabled: true,
+      }
+      const result = RuleTranslator.cloudflareToUnified(cfRule)
+      expect(result.result.conditions).toEqual([])
       expect(result.warnings.length).toBeGreaterThan(0)
       expect(result.warnings.some((w: { category: string }) => w.category === 'lossy_conversion')).toBe(true)
     })

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -2,6 +2,7 @@ import type { VercelCustomRule, VercelIPBlockingRule, VercelConditionGroup, Verc
 import type { CloudflareRule } from '../types/cloudflare'
 import type { UnifiedRule, UnifiedIPRule, UnifiedCondition, UnifiedAction } from '../types/unified'
 import { ExpressionBuilder } from './ExpressionBuilder'
+import { parseWirefilterExpression } from './WirefilterParser'
 import { ipAddressSchema } from '../schemas/commonSchemas'
 import { logger } from '../logger'
 
@@ -132,29 +133,36 @@ export class RuleTranslator {
   public static cloudflareToVercel(rule: CloudflareRule): TranslationResult<VercelCustomRule> {
     const warnings: TranslationWarning[] = []
 
-    // Import the warning system
-    const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+    const parsed = parseWirefilterExpression(rule.expression)
 
-    warnings.push(
-      TranslationWarningSystem.createLossyConversionWarning(
-        'Cloudflare expression',
-        'Cloudflare expressions cannot be perfectly converted to Vercel structured conditions',
-        rule.id,
-        'expression',
-      ),
-    )
+    let conditionGroups: VercelConditionGroup[] = []
+    if (parsed) {
+      conditionGroups = this.buildVercelConditionGroups(parsed.conditions, rule.id, warnings)
+    }
 
-    // For now, create a basic Vercel rule
-    // Full expression parsing would require a wirefilter parser
+    // Falls back to the original "empty condition group" placeholder when
+    // the expression couldn't be parsed at all, or every parsed condition's
+    // field has no Vercel equivalent — same "never throws" contract this
+    // function has always had (unlike unifiedToVercel, which hard-fails a
+    // rule Vercel genuinely can't represent at all).
+    if (conditionGroups.length === 0) {
+      const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+      warnings.push(
+        TranslationWarningSystem.createLossyConversionWarning(
+          'Cloudflare expression',
+          'Cloudflare expression could not be converted to Vercel structured conditions',
+          rule.id,
+          'expression',
+        ),
+      )
+      conditionGroups = [{ conditions: [] }]
+    }
+
     const vercelRule: VercelCustomRule = {
       id: rule.id,
       name: rule.description || `Rule ${rule.id}`,
       description: rule.description,
-      conditionGroup: [
-        {
-          conditions: [],
-        },
-      ],
+      conditionGroup: conditionGroups,
       action: {
         mitigate: {
           action: this.translateCloudflareActionToVercel(rule.action),
@@ -267,18 +275,30 @@ export class RuleTranslator {
   public static cloudflareToUnified(rule: CloudflareRule): TranslationResult<UnifiedRule> {
     const warnings: TranslationWarning[] = []
 
-    // Import the warning system
-    const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+    // doorman only ever *writes* wirefilter expressions itself, so
+    // WirefilterParser understands exactly the grammar subset it can
+    // produce — anything else (hand-authored, or from another tool) it
+    // reports as unparseable (`null`) rather than guessing, and this falls
+    // back to the previous "empty conditions" behavior with a warning.
+    const parsed = parseWirefilterExpression(rule.expression)
 
-    warnings.push(
-      TranslationWarningSystem.createWarning(
-        'complex_expressions',
-        rule.id,
-        'expression',
-        'Expression parsing not fully implemented. Using simplified translation.',
-        'Review the translated rule and add missing conditions manually if needed.',
-      ),
-    )
+    let conditions: UnifiedRule['conditions'] = []
+    let conditionLogic: UnifiedRule['conditionLogic']
+    if (parsed) {
+      conditions = parsed.conditions
+      conditionLogic = parsed.conditionLogic
+    } else {
+      const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+      warnings.push(
+        TranslationWarningSystem.createWarning(
+          'complex_expressions',
+          rule.id,
+          'expression',
+          'Expression could not be parsed back into structured conditions — it may be hand-authored or use syntax outside what doorman itself generates.',
+          'Review the translated rule and add missing conditions manually if needed.',
+        ),
+      )
+    }
 
     const action: UnifiedAction = {
       type: this.mapCloudflareActionToUnified(rule.action),
@@ -298,7 +318,8 @@ export class RuleTranslator {
       name: rule.description || `Rule ${rule.id}`,
       description: rule.description,
       enabled: rule.enabled ?? true,
-      conditions: [], // Would need expression parser
+      conditions,
+      conditionLogic,
       action,
     }
 
@@ -351,60 +372,7 @@ export class RuleTranslator {
   public static unifiedToVercel(rule: UnifiedRule): TranslationResult<VercelCustomRule> {
     const warnings: TranslationWarning[] = []
 
-    // Group conditions by their `group` index (set by vercelToUnified when
-    // the rule originated from Vercel's own conditionGroup[] structure) so a
-    // multi-group rule round-trips correctly instead of collapsing into one
-    // group and changing what the rule matches (AND-within/OR-across ->
-    // everything AND'd together). Conditions with no `group` (e.g. a
-    // hand-authored config) all fall into one implicit group — the same
-    // single-group behavior this function has always had.
-    const groupedConditions = new Map<number, UnifiedCondition[]>()
-    for (const condition of rule.conditions) {
-      const groupIndex = condition.group ?? 0
-      const bucket = groupedConditions.get(groupIndex)
-      if (bucket) {
-        bucket.push(condition)
-      } else {
-        groupedConditions.set(groupIndex, [condition])
-      }
-    }
-
-    // A condition whose field has no Vercel equivalent (e.g. Cloudflare-only
-    // `referer`/`port`) is dropped with a critical warning rather than
-    // mistranslated — silently relabeling it (the previous behavior defaulted
-    // to `path`) rewrote what the rule actually matches with no indication
-    // anything was wrong. A group that ends up fully empty is dropped too —
-    // that OR-branch simply doesn't exist in the output.
-    const conditionGroups: VercelConditionGroup[] = []
-    for (const groupConditions of groupedConditions.values()) {
-      const mapped: VercelRuleCondition[] = []
-      for (const condition of groupConditions) {
-        const type = this.mapUnifiedTypeToVercel(condition.field)
-        if (!type) {
-          const { TranslationWarningSystem } = require('./TranslationWarningSystem')
-          warnings.push(
-            TranslationWarningSystem.createUnsupportedFeatureWarning(
-              `condition field '${condition.field}'`,
-              'unified config',
-              'Vercel',
-              rule.id,
-              condition.field,
-            ),
-          )
-          continue
-        }
-        mapped.push({
-          op: this.mapUnifiedOperatorToVercel(condition.operator),
-          neg: condition.negated,
-          type,
-          key: condition.key,
-          value: condition.value,
-        })
-      }
-      if (mapped.length > 0) {
-        conditionGroups.push({ conditions: mapped })
-      }
-    }
+    const conditionGroups = this.buildVercelConditionGroups(rule.conditions, rule.id, warnings)
 
     if (conditionGroups.length === 0) {
       throw new Error(
@@ -443,6 +411,74 @@ export class RuleTranslator {
     }
 
     return { result: vercelRule, warnings }
+  }
+
+  /**
+   * Groups unified conditions by their `group` index (set by
+   * `vercelToUnified` when the rule originated from Vercel's own
+   * `conditionGroup[]` structure, or by `WirefilterParser` when it came from
+   * a parsed Cloudflare expression) into Vercel's `conditionGroup[]` shape,
+   * so a multi-group rule round-trips correctly instead of collapsing into
+   * one group and changing what the rule matches (AND-within/OR-across ->
+   * everything AND'd together). Conditions with no `group` (e.g. a
+   * hand-authored config) all fall into one implicit group.
+   *
+   * A condition whose field has no Vercel equivalent (e.g. Cloudflare-only
+   * `referer`/`port`) is dropped with a warning pushed onto the caller's
+   * `warnings` array, rather than mistranslated — silently relabeling it
+   * would rewrite what the rule actually matches with no indication
+   * anything was wrong. A group that ends up fully empty is dropped too —
+   * that OR-branch simply doesn't exist in the output. Shared by
+   * `unifiedToVercel` and `cloudflareToVercel`.
+   */
+  private static buildVercelConditionGroups(
+    conditions: UnifiedCondition[],
+    ruleId: string | undefined,
+    warnings: TranslationWarning[],
+  ): VercelConditionGroup[] {
+    const groupedConditions = new Map<number, UnifiedCondition[]>()
+    for (const condition of conditions) {
+      const groupIndex = condition.group ?? 0
+      const bucket = groupedConditions.get(groupIndex)
+      if (bucket) {
+        bucket.push(condition)
+      } else {
+        groupedConditions.set(groupIndex, [condition])
+      }
+    }
+
+    const conditionGroups: VercelConditionGroup[] = []
+    for (const groupConditions of groupedConditions.values()) {
+      const mapped: VercelRuleCondition[] = []
+      for (const condition of groupConditions) {
+        const type = this.mapUnifiedTypeToVercel(condition.field)
+        if (!type) {
+          const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+          warnings.push(
+            TranslationWarningSystem.createUnsupportedFeatureWarning(
+              `condition field '${condition.field}'`,
+              'unified config',
+              'Vercel',
+              ruleId,
+              condition.field,
+            ),
+          )
+          continue
+        }
+        mapped.push({
+          op: this.mapUnifiedOperatorToVercel(condition.operator),
+          neg: condition.negated,
+          type,
+          key: condition.key,
+          value: condition.value,
+        })
+      }
+      if (mapped.length > 0) {
+        conditionGroups.push({ conditions: mapped })
+      }
+    }
+
+    return conditionGroups
   }
 
   /**

--- a/src/lib/translators/WirefilterParser.ts
+++ b/src/lib/translators/WirefilterParser.ts
@@ -1,0 +1,436 @@
+import type { UnifiedCondition } from '../types/unified'
+import { unescapeWirefilterString } from './wirefilterEscape'
+
+/**
+ * Parses a Cloudflare wirefilter expression back into `UnifiedCondition[]`.
+ *
+ * doorman only ever *writes* wirefilter expressions via `ExpressionBuilder`,
+ * so this is deliberately the inverse of that generator rather than a
+ * general-purpose wirefilter parser — it understands exactly the grammar
+ * subset `ExpressionBuilder` can produce (field/op/value comparisons,
+ * `exists`, `not (...)` wrapping a single comparison/exists, `and`/`or`
+ * joins, one level of AND-within-groups OR-across-groups nesting, bracket
+ * key access for header/cookie, `{...}` set values, quoted-string
+ * escaping). Anything outside that subset — a hand-authored expression, or
+ * one from another tool — is reported as unsupported (`null`) rather than
+ * guessed at, so a caller can fall back to a clearly-flagged lossy
+ * conversion instead of silently misrepresenting what the rule matches.
+ */
+
+// wirefilter field path -> unified condition field. Exact inverse of
+// ExpressionBuilder's private `mapUnifiedFieldToCloudflare` — keep in sync.
+const CLOUDFLARE_FIELD_TO_UNIFIED: Record<string, string> = {
+  'ip.src': 'ip',
+  'ip.geoip.country': 'country',
+  'ip.geoip.subdivision_1': 'region',
+  'ip.geoip.city': 'city',
+  'ip.geoip.asnum': 'asn',
+  'http.request.uri.path': 'path',
+  'http.host': 'host',
+  'http.request.method': 'method',
+  'http.request.headers': 'header',
+  'http.request.uri.query': 'query',
+  'http.cookie': 'cookie',
+  'http.user_agent': 'user_agent',
+  'http.referer': 'referer',
+  ssl: 'scheme',
+  'cf.edge.server_port': 'port',
+}
+
+const COMPARISON_OPERATORS = new Set([
+  'eq',
+  'ne',
+  'contains',
+  'starts_with',
+  'ends_with',
+  'matches',
+  'in',
+  'gt',
+  'ge',
+  'lt',
+  'le',
+])
+
+const BOOLEAN_CONNECTIVES = new Set(['and', 'or', 'not'])
+
+type TokenType = 'LPAREN' | 'RPAREN' | 'LBRACE' | 'RBRACE' | 'LBRACKET' | 'RBRACKET' | 'STRING' | 'WORD'
+
+interface Token {
+  type: TokenType
+  value: string
+}
+
+class ParseError extends Error {}
+
+function tokenize(expression: string): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+  const len = expression.length
+
+  while (i < len) {
+    const ch = expression[i]!
+
+    if (/\s/.test(ch)) {
+      i++
+      continue
+    }
+
+    if (ch === '(') {
+      tokens.push({ type: 'LPAREN', value: ch })
+      i++
+      continue
+    }
+    if (ch === ')') {
+      tokens.push({ type: 'RPAREN', value: ch })
+      i++
+      continue
+    }
+    if (ch === '{') {
+      tokens.push({ type: 'LBRACE', value: ch })
+      i++
+      continue
+    }
+    if (ch === '}') {
+      tokens.push({ type: 'RBRACE', value: ch })
+      i++
+      continue
+    }
+    if (ch === '[') {
+      tokens.push({ type: 'LBRACKET', value: ch })
+      i++
+      continue
+    }
+    if (ch === ']') {
+      tokens.push({ type: 'RBRACKET', value: ch })
+      i++
+      continue
+    }
+
+    if (ch === '"') {
+      let j = i + 1
+      let raw = ''
+      let closed = false
+      while (j < len) {
+        const current = expression[j]!
+        if (current === '\\' && j + 1 < len) {
+          raw += current + expression[j + 1]!
+          j += 2
+          continue
+        }
+        if (expression[j] === '"') {
+          closed = true
+          j++
+          break
+        }
+        raw += expression[j]
+        j++
+      }
+      if (!closed) {
+        throw new ParseError('Unterminated string literal')
+      }
+      tokens.push({ type: 'STRING', value: unescapeWirefilterString(raw) })
+      i = j
+      continue
+    }
+
+    // A maximal run of anything that isn't whitespace or a structural
+    // character — covers field paths, keywords, operators, numbers, and
+    // bare (unquoted) IP/CIDR literals uniformly.
+    let j = i
+    while (j < len && !/[\s(){}[\]"]/.test(expression[j]!)) {
+      j++
+    }
+    if (j === i) {
+      throw new ParseError(`Unexpected character '${ch}' at position ${i}`)
+    }
+    tokens.push({ type: 'WORD', value: expression.slice(i, j) })
+    i = j
+  }
+
+  return tokens
+}
+
+type WirefilterNode =
+  | { type: 'and'; children: WirefilterNode[] }
+  | { type: 'or'; children: WirefilterNode[] }
+  | { type: 'not'; child: WirefilterNode }
+  | { type: 'exists'; field: string; key?: string }
+  | { type: 'comparison'; field: string; key?: string; operator: string; value: string | number | (string | number)[] }
+
+class TokenStream {
+  private pos = 0
+  constructor(private tokens: Token[]) {}
+
+  peek(): Token | undefined {
+    return this.tokens[this.pos]
+  }
+
+  next(): Token {
+    const token = this.tokens[this.pos]
+    if (!token) {
+      throw new ParseError('Unexpected end of expression')
+    }
+    this.pos++
+    return token
+  }
+
+  expect(type: TokenType, value?: string): Token {
+    const token = this.next()
+    if (token.type !== type || (value !== undefined && token.value !== value)) {
+      throw new ParseError(`Expected ${value ?? type} but got '${token.value}'`)
+    }
+    return token
+  }
+
+  isWord(value: string): boolean {
+    const token = this.peek()
+    return !!token && token.type === 'WORD' && token.value === value
+  }
+
+  atEnd(): boolean {
+    return this.pos >= this.tokens.length
+  }
+}
+
+function parseOr(stream: TokenStream): WirefilterNode {
+  const children = [parseAnd(stream)]
+  while (stream.isWord('or')) {
+    stream.next()
+    children.push(parseAnd(stream))
+  }
+  return children.length === 1 ? children[0]! : { type: 'or', children }
+}
+
+function parseAnd(stream: TokenStream): WirefilterNode {
+  const children = [parseUnary(stream)]
+  while (stream.isWord('and')) {
+    stream.next()
+    children.push(parseUnary(stream))
+  }
+  return children.length === 1 ? children[0]! : { type: 'and', children }
+}
+
+function parseUnary(stream: TokenStream): WirefilterNode {
+  if (stream.isWord('not')) {
+    stream.next()
+    stream.expect('LPAREN')
+    const inner = parseOr(stream)
+    stream.expect('RPAREN')
+    return { type: 'not', child: inner }
+  }
+  return parsePrimary(stream)
+}
+
+function parsePrimary(stream: TokenStream): WirefilterNode {
+  const token = stream.peek()
+  if (token && token.type === 'LPAREN') {
+    stream.next()
+    const inner = parseOr(stream)
+    stream.expect('RPAREN')
+    return inner
+  }
+  return parseComparisonOrExists(stream)
+}
+
+function parseFieldRef(stream: TokenStream): { field: string; key?: string } {
+  const fieldToken = stream.expect('WORD')
+  if (BOOLEAN_CONNECTIVES.has(fieldToken.value)) {
+    throw new ParseError(`Expected a field reference but got keyword '${fieldToken.value}'`)
+  }
+
+  if (stream.peek()?.type === 'LBRACKET') {
+    stream.next()
+    const keyToken = stream.expect('STRING')
+    stream.expect('RBRACKET')
+    return { field: fieldToken.value, key: keyToken.value }
+  }
+
+  return { field: fieldToken.value }
+}
+
+function parseValueSingle(stream: TokenStream): string | number {
+  const token = stream.next()
+  if (token.type === 'STRING') {
+    return token.value
+  }
+  if (token.type === 'WORD') {
+    if (/^-?\d+(\.\d+)?$/.test(token.value)) {
+      return Number(token.value)
+    }
+    // Bare token: an unquoted IP/CIDR literal, or any other unquoted
+    // wirefilter atom (e.g. `true`/`false`) — preserved as its literal text.
+    return token.value
+  }
+  throw new ParseError(`Unexpected token '${token.value}' where a value was expected`)
+}
+
+function parseValue(stream: TokenStream): string | number | (string | number)[] {
+  if (stream.peek()?.type === 'LBRACE') {
+    stream.next()
+    const values: (string | number)[] = []
+    while (stream.peek()?.type !== 'RBRACE') {
+      values.push(parseValueSingle(stream))
+    }
+    stream.expect('RBRACE')
+    return values
+  }
+  return parseValueSingle(stream)
+}
+
+function parseComparisonOrExists(stream: TokenStream): WirefilterNode {
+  const { field, key } = parseFieldRef(stream)
+
+  if (stream.isWord('exists')) {
+    stream.next()
+    return { type: 'exists', field, key }
+  }
+
+  const opToken = stream.next()
+  if (opToken.type !== 'WORD' || !COMPARISON_OPERATORS.has(opToken.value)) {
+    throw new ParseError(`Unsupported or unrecognized operator '${opToken.value}'`)
+  }
+
+  const value = parseValue(stream)
+  return { type: 'comparison', field, key, operator: opToken.value, value }
+}
+
+function parseExpression(expression: string): WirefilterNode {
+  const stream = new TokenStream(tokenize(expression))
+  const node = parseOr(stream)
+  if (!stream.atEnd()) {
+    throw new ParseError('Unexpected trailing tokens')
+  }
+  return node
+}
+
+/** A leaf is a single condition — a comparison, an exists check, or one level of `not (...)` wrapping either. */
+function isLeaf(node: WirefilterNode): boolean {
+  if (node.type === 'comparison' || node.type === 'exists') return true
+  if (node.type === 'not') return node.child.type === 'comparison' || node.child.type === 'exists'
+  return false
+}
+
+function leafToCondition(node: WirefilterNode, group: number): UnifiedCondition | null {
+  const negated = node.type === 'not'
+  const inner = node.type === 'not' ? node.child : node
+  if (inner.type !== 'comparison' && inner.type !== 'exists') {
+    return null
+  }
+
+  const mappedField = CLOUDFLARE_FIELD_TO_UNIFIED[inner.field]
+  if (!mappedField) {
+    return null
+  }
+
+  if (inner.type === 'exists') {
+    return {
+      field: mappedField,
+      operator: negated ? 'not_exists' : 'exists',
+      value: '',
+      key: inner.key,
+      group,
+    }
+  }
+
+  // Prefer the dedicated "not_X" operator over a generic `negated` flag when
+  // one exists — `not (field contains "x")` and `not (field in {...})` are
+  // exactly what `not_contains`/`not_in` generate; every other operator has
+  // no dedicated negative form, so those fall back to `negated: true`.
+  let operator = inner.operator
+  let isNegated: boolean | undefined
+  if (negated) {
+    if (inner.operator === 'contains') {
+      operator = 'not_contains'
+    } else if (inner.operator === 'in') {
+      operator = 'not_in'
+    } else {
+      isNegated = true
+    }
+  }
+
+  return {
+    field: mappedField,
+    operator: operator as UnifiedCondition['operator'],
+    value: inner.value as UnifiedCondition['value'],
+    key: inner.key,
+    negated: isNegated,
+    group,
+  }
+}
+
+/**
+ * Converts a parsed AST into `UnifiedCondition[]`, restricted to the shapes
+ * `ExpressionBuilder` itself produces: a flat AND, a flat OR, or a top-level
+ * OR of AND-groups (Vercel's two-level condition model). Anything else
+ * (OR nested inside AND, `not` wrapping a non-leaf, an unmapped field) is
+ * outside that subset and reported as `null`.
+ */
+function astToConditions(
+  node: WirefilterNode,
+): { conditions: UnifiedCondition[]; conditionLogic: 'AND' | 'OR' } | null {
+  if (isLeaf(node)) {
+    const condition = leafToCondition(node, 0)
+    return condition ? { conditions: [condition], conditionLogic: 'AND' } : null
+  }
+
+  if (node.type === 'and') {
+    const conditions: UnifiedCondition[] = []
+    for (const child of node.children) {
+      if (!isLeaf(child)) return null
+      const condition = leafToCondition(child, 0)
+      if (!condition) return null
+      conditions.push(condition)
+    }
+    return { conditions, conditionLogic: 'AND' }
+  }
+
+  if (node.type === 'or') {
+    const conditions: UnifiedCondition[] = []
+    node.children.forEach((child, groupIndex) => {
+      if (isLeaf(child)) {
+        const condition = leafToCondition(child, groupIndex)
+        if (condition) conditions.push(condition)
+        return
+      }
+      if (child.type === 'and') {
+        for (const grandchild of child.children) {
+          if (!isLeaf(grandchild)) return
+          const condition = leafToCondition(grandchild, groupIndex)
+          if (condition) conditions.push(condition)
+        }
+      }
+    })
+    // Only succeed if every child actually contributed at least one
+    // condition — a silently-dropped OR branch would change what the rule
+    // matches, so a partial result is treated the same as total failure.
+    const expectedGroups = node.children.length
+    const actualGroups = new Set(conditions.map((c) => c.group)).size
+    if (actualGroups !== expectedGroups) return null
+    return { conditions, conditionLogic: 'OR' }
+  }
+
+  return null
+}
+
+export interface WirefilterParseResult {
+  conditions: UnifiedCondition[]
+  conditionLogic: 'AND' | 'OR'
+}
+
+/**
+ * Parses a wirefilter expression into `UnifiedCondition[]`, or returns
+ * `null` if the expression falls outside the grammar subset this parser
+ * understands (syntax error, or a structure `ExpressionBuilder` never
+ * generates). Never throws.
+ */
+export function parseWirefilterExpression(expression: string): WirefilterParseResult | null {
+  if (!expression || !expression.trim()) {
+    return null
+  }
+  try {
+    const ast = parseExpression(expression)
+    return astToConditions(ast)
+  } catch {
+    return null
+  }
+}

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -403,7 +403,7 @@ describe('RuleTranslator', () => {
   })
 
   describe('cloudflareToUnified', () => {
-    it('translates a basic block rule', () => {
+    it('translates a basic block rule, parsing the expression back into structured conditions', () => {
       const cfRule = makeCloudflareRule()
       const { result, warnings } = RuleTranslator.cloudflareToUnified(cfRule)
 
@@ -411,10 +411,20 @@ describe('RuleTranslator', () => {
       expect(result.name).toBe('A test rule')
       expect(result.enabled).toBe(true)
       expect(result.action.type).toBe('deny')
-      // Conditions are empty because expression parsing is not fully implemented
+      expect(result.conditions).toEqual([
+        { field: 'path', operator: 'eq', value: '/api', key: undefined, negated: undefined, group: 0 },
+      ])
+      // A successfully-parsed expression gets no "couldn't parse" warning.
+      expect(warnings).toEqual([])
+    })
+
+    it('falls back to empty conditions with a warning when the expression is outside what WirefilterParser understands', () => {
+      const cfRule = makeCloudflareRule({ expression: 'http.request.body.raw contains "x"' })
+      const { result, warnings } = RuleTranslator.cloudflareToUnified(cfRule)
+
       expect(result.conditions).toEqual([])
-      // Should have a warning about expression parsing
       expect(warnings.length).toBeGreaterThan(0)
+      expect(warnings.some((w) => w.field === 'expression')).toBe(true)
     })
 
     it('maps Cloudflare actions to unified actions', () => {
@@ -654,7 +664,7 @@ describe('RuleTranslator', () => {
   })
 
   describe('cloudflareToVercel', () => {
-    it('translates a basic block rule', () => {
+    it('translates a basic block rule, parsing the expression back into structured conditions', () => {
       const cfRule = makeCloudflareRule()
       const { result, warnings } = RuleTranslator.cloudflareToVercel(cfRule)
 
@@ -662,7 +672,16 @@ describe('RuleTranslator', () => {
       expect(result.name).toBe('A test rule')
       expect(result.active).toBe(true)
       expect(result.action.mitigate.action).toBe('deny')
-      // Should have lossy conversion warning
+      expect(result.conditionGroup).toEqual([{ conditions: [{ type: 'path', op: 'eq', value: '/api' }] }])
+      // A successfully-parsed expression gets no lossy-conversion warning.
+      expect(warnings).toEqual([])
+    })
+
+    it('falls back to an empty condition group with a lossy-conversion warning when the expression cannot be parsed', () => {
+      const cfRule = makeCloudflareRule({ expression: 'http.request.body.raw contains "x"' })
+      const { result, warnings } = RuleTranslator.cloudflareToVercel(cfRule)
+
+      expect(result.conditionGroup).toEqual([{ conditions: [] }])
       expect(warnings.length).toBeGreaterThan(0)
       expect(warnings.some((w) => w.category === 'lossy_conversion')).toBe(true)
     })

--- a/src/lib/translators/__tests__/WirefilterParser.test.ts
+++ b/src/lib/translators/__tests__/WirefilterParser.test.ts
@@ -1,0 +1,220 @@
+import { parseWirefilterExpression } from '../WirefilterParser'
+import { ExpressionBuilder } from '../ExpressionBuilder'
+import type { UnifiedCondition } from '../../types/unified'
+
+describe('parseWirefilterExpression', () => {
+  it('parses a single simple comparison', () => {
+    const result = parseWirefilterExpression('http.request.uri.path eq "/api"')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions).toHaveLength(1)
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api', group: 0 })
+    expect(result!.conditionLogic).toBe('AND')
+  })
+
+  it('parses a flat AND of multiple conditions into a single group', () => {
+    const result = parseWirefilterExpression('(http.request.uri.path eq "/api" and http.request.method eq "POST")')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditionLogic).toBe('AND')
+    expect(result!.conditions).toHaveLength(2)
+    expect(result!.conditions.every((c) => c.group === 0)).toBe(true)
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api' })
+    expect(result!.conditions[1]).toMatchObject({ field: 'method', operator: 'eq', value: 'POST' })
+  })
+
+  it('parses a flat OR of single-condition groups, one group per branch', () => {
+    const result = parseWirefilterExpression('(http.request.uri.path eq "/api" or http.request.uri.path eq "/admin")')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditionLogic).toBe('OR')
+    expect(result!.conditions).toHaveLength(2)
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', value: '/api', group: 0 })
+    expect(result!.conditions[1]).toMatchObject({ field: 'path', value: '/admin', group: 1 })
+  })
+
+  it('parses a top-level OR with no enclosing parens (matches ExpressionBuilder.fromVercelConditionGroups output)', () => {
+    const result = parseWirefilterExpression(
+      '(http.request.uri.path eq "/a" and http.request.method eq "POST") or http.request.uri.path eq "/b"',
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.conditionLogic).toBe('OR')
+    expect(result!.conditions).toHaveLength(3)
+    const group0 = result!.conditions.filter((c) => c.group === 0)
+    const group1 = result!.conditions.filter((c) => c.group === 1)
+    expect(group0).toHaveLength(2)
+    expect(group1).toHaveLength(1)
+    expect(group1[0]).toMatchObject({ field: 'path', value: '/b' })
+  })
+
+  it('parses negated comparisons as negated: true for operators with no dedicated "not_X" form', () => {
+    const result = parseWirefilterExpression('not (http.request.uri.path eq "/api")')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api', negated: true })
+  })
+
+  it('parses "not (field contains value)" as the dedicated not_contains operator', () => {
+    const result = parseWirefilterExpression('not (http.user_agent contains "bot")')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'user_agent', operator: 'not_contains', value: 'bot' })
+    expect(result!.conditions[0]!.negated).toBeUndefined()
+  })
+
+  it('parses "not (field in {...})" as the dedicated not_in operator', () => {
+    const result = parseWirefilterExpression('not (http.request.method in {"GET" "HEAD"})')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'method', operator: 'not_in', value: ['GET', 'HEAD'] })
+  })
+
+  it('parses "field exists" and its negation', () => {
+    const exists = parseWirefilterExpression('http.referer exists')
+    expect(exists!.conditions[0]).toMatchObject({ field: 'referer', operator: 'exists' })
+
+    const notExists = parseWirefilterExpression('not (http.referer exists)')
+    expect(notExists!.conditions[0]).toMatchObject({ field: 'referer', operator: 'not_exists' })
+  })
+
+  it('parses header bracket-key field references', () => {
+    const result = parseWirefilterExpression('http.request.headers["X-Custom"] eq "value"')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'header', key: 'X-Custom', operator: 'eq', value: 'value' })
+  })
+
+  it('parses cookie bracket-key field references', () => {
+    const result = parseWirefilterExpression('http.cookie["session"] eq "abc123"')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'cookie', key: 'session', operator: 'eq', value: 'abc123' })
+  })
+
+  it('parses a set literal into an array value', () => {
+    const result = parseWirefilterExpression('http.request.uri.path in {"/a" "/b" "/c"}')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]!.value).toEqual(['/a', '/b', '/c'])
+  })
+
+  it('parses an unquoted IP literal value', () => {
+    const result = parseWirefilterExpression('ip.src eq 1.2.3.4')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'ip', operator: 'eq', value: '1.2.3.4' })
+  })
+
+  it('parses a numeric value', () => {
+    const result = parseWirefilterExpression('cf.edge.server_port gt 1024')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]).toMatchObject({ field: 'port', operator: 'gt', value: 1024 })
+  })
+
+  it('decodes escaped quotes and backslashes inside string values', () => {
+    const result = parseWirefilterExpression('http.request.uri.path eq "/say \\"hi\\" \\\\ bye"')
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions[0]!.value).toBe('/say "hi" \\ bye')
+  })
+
+  it('returns null for an expression with an unmapped field', () => {
+    expect(parseWirefilterExpression('http.request.body.raw contains "x"')).toBeNull()
+  })
+
+  it('returns null for an OR nested inside an AND (a shape ExpressionBuilder never generates)', () => {
+    expect(
+      parseWirefilterExpression('http.request.uri.path eq "/api" and (http.host eq "a" or http.host eq "b")'),
+    ).toBeNull()
+  })
+
+  it('returns null for malformed syntax', () => {
+    expect(parseWirefilterExpression('http.request.uri.path eq')).toBeNull()
+    expect(parseWirefilterExpression('(http.request.uri.path eq "/api"')).toBeNull()
+    expect(parseWirefilterExpression('')).toBeNull()
+  })
+
+  describe('round-trip fidelity against ExpressionBuilder', () => {
+    it('round-trips a flat single condition', () => {
+      const conditions: UnifiedCondition[] = [{ field: 'path', operator: 'eq', value: '/api' }]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions, 'AND')
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions).toHaveLength(1)
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api' })
+    })
+
+    it('round-trips a flat AND of conditions', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/api' },
+        { field: 'method', operator: 'eq', value: 'POST' },
+      ]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions, 'AND')
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditionLogic).toBe('AND')
+      expect(parsed!.conditions).toHaveLength(2)
+    })
+
+    it('round-trips a multi-group (AND-within/OR-across) condition set', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/a', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+        { field: 'path', operator: 'eq', value: '/b', group: 1 },
+      ]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions)
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditionLogic).toBe('OR')
+      expect(parsed!.conditions).toHaveLength(3)
+      const group0 = parsed!.conditions.filter((c) => c.group === 0)
+      const group1 = parsed!.conditions.filter((c) => c.group === 1)
+      expect(group0).toHaveLength(2)
+      expect(group1).toHaveLength(1)
+    })
+
+    it('round-trips a negated condition', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'user_agent', operator: 'contains', value: 'bot', negated: true },
+      ]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions, 'AND')
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      // negated: true + contains generates the same wirefilter text as the
+      // dedicated not_contains operator — the parser canonicalizes to the
+      // more specific enum value, so this is an intentional, documented
+      // asymmetry rather than a bug (see leafToCondition's comment).
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'user_agent', operator: 'not_contains', value: 'bot' })
+    })
+
+    it('round-trips a header condition with a bracket key', () => {
+      const conditions: UnifiedCondition[] = [{ field: 'header', key: 'X-Custom', operator: 'eq', value: 'value' }]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions, 'AND')
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'header', key: 'X-Custom', value: 'value' })
+    })
+
+    it('round-trips an "in" condition with an array value', () => {
+      const conditions: UnifiedCondition[] = [{ field: 'method', operator: 'in', value: ['GET', 'HEAD'] }]
+      const expression = ExpressionBuilder.fromUnifiedConditions(conditions, 'AND')
+
+      const parsed = parseWirefilterExpression(expression)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'method', operator: 'in', value: ['GET', 'HEAD'] })
+    })
+  })
+})

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -14,3 +14,5 @@ export { TranslationWarningSystem } from './TranslationWarningSystem'
 
 export { ExpressionBuilder } from './ExpressionBuilder'
 export { FieldMapper } from './FieldMapper'
+export { parseWirefilterExpression } from './WirefilterParser'
+export type { WirefilterParseResult } from './WirefilterParser'

--- a/src/lib/translators/wirefilterEscape.ts
+++ b/src/lib/translators/wirefilterEscape.ts
@@ -12,3 +12,22 @@
 export function escapeWirefilterString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
+
+/**
+ * Inverse of `escapeWirefilterString` — decodes `\\` and `\"` escape
+ * sequences in the *contents* of a wirefilter double-quoted string literal
+ * (the caller strips the surrounding quotes before calling this). Any other
+ * backslash sequence is left as-is; wirefilter only defines these two.
+ */
+export function unescapeWirefilterString(value: string): string {
+  let result = ''
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === '\\' && (value[i + 1] === '\\' || value[i + 1] === '"')) {
+      result += value[i + 1]
+      i++
+    } else {
+      result += value[i]
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

Closes #153.

`RuleTranslator.cloudflareToUnified` and `cloudflareToVercel` previously always returned an empty conditions array for any rule fetched from Cloudflare — expression parsing was never implemented, only generation (`ExpressionBuilder`, the unified/Vercel -> Cloudflare direction). This meant `download`/`list`/`status`/`diff` showed no conditions for any rule sourced from a live Cloudflare zone — the user could see a rule exists, its action, and description, but not what it actually matches on.

**Approach**: adds `WirefilterParser` — a tokenizer + recursive-descent parser that inverts exactly the grammar subset `ExpressionBuilder` itself can produce (field/op/value comparisons, `exists`, one level of `not (...)` wrapping, `and`/`or` joins, one level of AND-within-groups OR-across-groups nesting matching Vercel's two-level condition model, bracket key access for header/cookie, `{...}` set values, quoted-string escaping) — deliberately **not** a general-purpose wirefilter parser, per the issue's suggested approach. An expression outside that subset (hand-authored, or from another tool) is reported as unparseable and falls back to the previous empty-conditions-plus-warning behavior, rather than guessing at its meaning and silently corrupting what a rule matches on.

`cloudflareToUnified` and `cloudflareToVercel` now call the parser first. The condition-group-building logic shared by `unifiedToVercel` and `cloudflareToVercel` is extracted into a `buildVercelConditionGroups` helper to avoid duplicating the field-mapping/warning logic between them.

`CloudflareFirewallService.getChanges` diffs in native wirefilter-string space rather than via unified conditions — a deliberate design already in place before this PR, to avoid a related diffing bug. That diffing path is untouched here; this PR only improves `fetchConfig`'s output quality for display/backup/cross-provider export.

Updates `RuleTranslator.test.ts` and `CloudflareWorkflowIntegration.test.ts`'s fixtures/assertions to reflect the fix (they previously asserted the empty-conditions bug as expected behavior), and adds dedicated `WirefilterParser` tests including round-trip fidelity checks against `ExpressionBuilder`'s actual output for every shape it generates.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` (73 suites / 1321 tests passing)
- [x] `pnpm eslint .` (0 errors, pre-existing warnings only)
- [x] Round-trip tests confirm every condition shape `ExpressionBuilder` can generate (flat AND, flat OR, multi-group AND-within/OR-across, negation incl. `not_contains`/`not_in`/`not_exists`, header/cookie bracket keys, set literals, unquoted IP values) parses back correctly
- [x] Confirmed via `CloudflareWorkflowIntegration.test.ts`'s full fetch/diff/sync cycle test that a rule fetched from a (mocked) live Cloudflare zone now shows its real parsed conditions, not an empty array