### PR TITLE
fix: make UnifiedRule.priority actually control rule evaluation order

### DIFF
--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -6,6 +6,7 @@ import { RuleTranslator } from '../../translators/RuleTranslator'
 import { logger } from '../../logger'
 import { CloudflareErrorHandler } from './CloudflareErrorHandler'
 import { cloudflareErrors } from '../../errors'
+import { sortRulesByPriority } from '../../utils/sortRulesByPriority'
 import type { ProviderType, SyncOptions, SyncResult, ChangeSet, FeatureSet, HealthScore } from '../IFirewallProvider'
 import type { UnifiedConfig, UnifiedRule, UnifiedIPRule } from '../../types/unified'
 import type { CloudflareRule } from '../../types/cloudflare'
@@ -261,8 +262,13 @@ export class CloudflareFirewallService extends BaseFirewallService {
     // Translate all rules to Cloudflare format
     const cloudflareRules: CloudflareRule[] = []
 
-    // Add regular rules
-    for (const rule of config.rules) {
+    // Cloudflare has no per-rule priority field — position in the ruleset
+    // array *is* precedence, and this write is a full-array replace, so
+    // ordering here is exactly the resulting evaluation order. Sorting by
+    // `UnifiedRule.priority` is what actually gives that field meaning; see
+    // sortRulesByPriority for the semantics. IP rules are appended after
+    // custom rules below, which is pre-existing behaviour and unchanged.
+    for (const rule of sortRulesByPriority(config.rules)) {
       const translation = RuleTranslator.unifiedToCloudflare(rule)
       cloudflareRules.push(translation.result)
 
@@ -438,7 +444,12 @@ export class CloudflareFirewallService extends BaseFirewallService {
       (r) => r && r.id && r.expression && r.action && !this.isListBasedIPRule(r) && !this.isIPBlockingRule(r),
     )
 
-    const localTranslations = config.rules.map((rule) => ({
+    // Sorted the same way `syncRules` sorts before writing, so the diff
+    // reflects the order a sync would actually produce. Without this, a
+    // priority-only change (no rule content edited) would report "no
+    // changes" while `sync` silently rewrote the ruleset into a new
+    // evaluation order — see diffCloudflareRules' position-drift check.
+    const localTranslations = sortRulesByPriority(config.rules).map((rule) => ({
       rule,
       translated: RuleTranslator.unifiedToCloudflare(rule).result,
     }))

--- a/src/lib/providers/cloudflare/CloudflareOptimizer.ts
+++ b/src/lib/providers/cloudflare/CloudflareOptimizer.ts
@@ -263,6 +263,33 @@ export class CloudflareOptimizer {
       }
     }
 
+    // Position drift. Cloudflare has no per-rule priority field — a rule's
+    // index in the ruleset array *is* its precedence — and `local` arrives
+    // already sorted by `UnifiedRule.priority`. So a config whose only
+    // change is a reordering produces identical rule *content* on both
+    // sides and would otherwise diff clean, even though syncing it would
+    // rewrite the live evaluation order (a security-relevant change: a
+    // broad `allow` moving ahead of a narrow `block` inverts the policy).
+    //
+    // Compared over the rules common to both sides, in their respective
+    // orders — rules being added or deleted are excluded, since their
+    // arrival/removal shifts indices without anything having been
+    // deliberately reordered.
+    const alreadyUpdating = new Set(toUpdate.map((r) => r.id || r.name))
+    const desiredCommonOrder = local.map(({ rule }) => rule.id || rule.name).filter((key) => remoteById.has(key))
+    const remoteCommonOrder = remote.map((r) => r.id).filter((key) => localKeys.has(key))
+
+    desiredCommonOrder.forEach((key, index) => {
+      if (remoteCommonOrder[index] === key || alreadyUpdating.has(key)) {
+        return
+      }
+      const moved = local.find(({ rule }) => (rule.id || rule.name) === key)
+      if (moved) {
+        toUpdate.push(moved.rule)
+        alreadyUpdating.add(key)
+      }
+    })
+
     return { toAdd, toUpdate, toDelete }
   }
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -467,6 +467,133 @@ describe('CloudflareFirewallService', () => {
     })
   })
 
+  // Regression coverage for #179: `UnifiedRule.priority` used to feed the
+  // dedup/diff hash while never affecting the order rules were written, so
+  // setting it changed nothing about actual firewall evaluation order.
+  describe('rule priority ordering', () => {
+    const ruleWith = (name: string, priority?: number): UnifiedRule => ({
+      id: name,
+      name,
+      enabled: true,
+      action: { type: 'deny' },
+      conditions: [{ field: 'path', operator: 'eq', value: `/${name}` }],
+      ...(priority !== undefined ? { priority } : {}),
+    })
+
+    const configWith = (rules: UnifiedRule[]): UnifiedConfig => ({
+      version: '2.0',
+      provider: 'cloudflare',
+      rules,
+      ips: [],
+    })
+
+    it('writes rules to the ruleset in priority order, lowest number first', async () => {
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+      const updateSpy = jest.spyOn(mockClient, 'updateRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '2',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+
+      // Deliberately declared out of order in the config.
+      await service.syncRules(configWith([ruleWith('c', 30), ruleWith('a', 10), ruleWith('b', 20)]), { force: true })
+
+      const [, payload] = updateSpy.mock.calls[0]!
+      const written = payload.rules!.map((r) => r.description)
+      expect(written).toEqual(['a', 'b', 'c'])
+    })
+
+    it('places unprioritised rules after prioritised ones, preserving their config order', async () => {
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+      const updateSpy = jest.spyOn(mockClient, 'updateRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '2',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+
+      await service.syncRules(configWith([ruleWith('plain-1'), ruleWith('promoted', 1), ruleWith('plain-2')]), {
+        force: true,
+      })
+
+      const [, payload] = updateSpy.mock.calls[0]!
+      const written = payload.rules!.map((r) => r.description)
+      expect(written).toEqual(['promoted', 'plain-1', 'plain-2'])
+    })
+
+    // Without this, `diff`/`status` would report "in sync" while `sync`
+    // silently rewrote the live evaluation order — the ruleset write is a
+    // full-array replace, so reordering takes effect regardless of whether
+    // the diff noticed.
+    it('reports a priority-only reorder as a change rather than showing clean', async () => {
+      // Remote currently has a, b (in that order) with matching content.
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [
+          { id: 'a', action: 'block', expression: 'http.request.uri.path eq "/a"', description: 'a', enabled: true },
+          { id: 'b', action: 'block', expression: 'http.request.uri.path eq "/b"', description: 'b', enabled: true },
+        ],
+      })
+
+      // Same two rules, same content — only the priorities invert the order.
+      const changes = await service.getChanges(configWith([ruleWith('a', 20), ruleWith('b', 10)]))
+
+      expect(changes.hasChanges).toBe(true)
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToDelete).toHaveLength(0)
+      expect(changes.rulesToUpdate.length).toBeGreaterThan(0)
+    })
+
+    it('still reports clean when order and content both match remote', async () => {
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [
+          { id: 'a', action: 'block', expression: 'http.request.uri.path eq "/a"', description: 'a', enabled: true },
+          { id: 'b', action: 'block', expression: 'http.request.uri.path eq "/b"', description: 'b', enabled: true },
+        ],
+      })
+
+      const changes = await service.getChanges(configWith([ruleWith('a', 10), ruleWith('b', 20)]))
+
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.rulesToDelete).toHaveLength(0)
+    })
+  })
+
   describe('syncRules', () => {
     it('should sync rules in dry run mode', async () => {
       const mockConfig: UnifiedConfig = {

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -7,6 +7,7 @@ import { isDeepEqual } from '../../utils/isDeepEqual'
 import { omitId } from '../../utils/omitId'
 import { firewallConfigSchema } from '../../schemas/firewallSchemas'
 import { unifiedConfigSchema } from '../../schemas/unifiedSchemas'
+import { hasExplicitPriorities, sortRulesByPriority } from '../../utils/sortRulesByPriority'
 import type {
   IFirewallProvider,
   ProviderType,
@@ -196,6 +197,27 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       const describeError = (context: string, error: unknown): string =>
         `${context}: ${error instanceof Error ? error.message : String(error)}`
 
+      // Ordering on Vercel is best-effort. Rules are written individually
+      // (`rules.insert`/`rules.update`), not as one ordered array like
+      // Cloudflare's ruleset replace — so doorman controls the order new
+      // rules are appended in, but cannot move a rule that already exists
+      // remotely. A config that declares priorities and still has surviving
+      // pre-existing rules therefore won't end up in exactly the declared
+      // order, and saying so is better than letting the user assume it did.
+      // `config.rules.length > rulesToAdd.length` means at least one rule
+      // already exists remotely (being updated, or unchanged) — those are
+      // the ones whose position is fixed. When every rule is a fresh create,
+      // insertion order fully determines evaluation order and there's
+      // nothing to warn about.
+      const orderingWarnings: string[] = []
+      if (hasExplicitPriorities(config.rules) && config.rules.length > rulesToAdd.length) {
+        orderingWarnings.push(
+          'Rule `priority` is best-effort on Vercel: new rules are created in priority order, but rules that already ' +
+            'exist remotely cannot be repositioned via the Vercel API. Recreate them (remove and re-add) if exact ' +
+            'evaluation order matters.',
+        )
+      }
+
       // Vercel always assigns its own id on create (createFirewallRule sends
       // `id: null` regardless of what the local rule had, if anything) — so
       // the local config's rule id is essentially always stale for a newly
@@ -305,7 +327,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       // succeeded from the API's point of view.
       let finalVersion: number = version
       let finalUpdatedAt: string | undefined
-      const warnings: string[] = []
+      const warnings: string[] = [...orderingWarnings]
       try {
         const activeConfig = await this.client.fetchFirewallConfig()
         finalVersion = activeConfig.version
@@ -426,8 +448,12 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
         return translation.result
       })
 
-      // Handle custom rules
-      const { toAdd, toUpdate, toDelete } = this.diffRules(config.rules, remoteRules)
+      // Handle custom rules. Sorted by `priority` first so `toAdd` comes out
+      // in the intended evaluation order — Vercel creates rules one at a
+      // time via `rules.insert`, so insertion order is the only ordering
+      // lever available here. See syncRules for why that's best-effort
+      // rather than a guarantee.
+      const { toAdd, toUpdate, toDelete } = this.diffRules(sortRulesByPriority(config.rules), remoteRules)
 
       const remoteIPs: UnifiedIPRule[] = activeConfig.ips.map((ip) => RuleTranslator.vercelIPToUnified(ip))
 

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -573,6 +573,130 @@ describe('VercelFirewallService', () => {
     })
   })
 
+  // Regression coverage for #179. Vercel writes rules one at a time
+  // (rules.insert/rules.update), so unlike Cloudflare's full-array ruleset
+  // replace, doorman can order newly-created rules but cannot reposition a
+  // rule that already exists remotely — that limitation has to be stated,
+  // not silently papered over.
+  describe('rule priority ordering (best-effort on Vercel)', () => {
+    it('creates new rules in priority order', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            name: 'third',
+            enabled: true,
+            priority: 30,
+            conditions: [{ field: 'path', operator: 'eq', value: '/c' }],
+            action: { type: 'deny' },
+          },
+          {
+            name: 'first',
+            enabled: true,
+            priority: 10,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+          {
+            name: 'second',
+            enabled: true,
+            priority: 20,
+            conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({ ...mockVercelConfig, rules: [], ips: [] })
+      const createSpy = jest
+        .spyOn(client, 'createFirewallRule')
+        .mockImplementation((rule) => Promise.resolve({ ...rule, id: `id_${rule.name}` } as never))
+
+      await service.syncRules(config)
+
+      const createdOrder = createSpy.mock.calls.map(([rule]) => rule.name)
+      expect(createdOrder).toEqual(['first', 'second', 'third'])
+    })
+
+    it('does not warn about ordering when every rule is a fresh create (insertion order fully determines it)', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            name: 'brand new',
+            enabled: true,
+            priority: 1,
+            conditions: [{ field: 'path', operator: 'eq', value: '/new' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({ ...mockVercelConfig, rules: [], ips: [] })
+      jest
+        .spyOn(client, 'createFirewallRule')
+        .mockImplementation((rule) => Promise.resolve({ ...rule, id: 'id_new' } as never))
+
+      const result = await service.syncRules(config)
+
+      expect(result.warnings?.some((w) => w.includes('best-effort on Vercel'))).toBeFalsy()
+    })
+
+    it('warns that ordering is best-effort when prioritised rules already exist remotely', async () => {
+      // rule_1 already exists in mockVercelConfig, so it can't be repositioned.
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bots',
+            description: 'Block bad bots',
+            enabled: true,
+            priority: 20,
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [{ id: 'ip_1', ip: '1.2.3.4', hostname: 'example.com', action: 'deny', notes: 'Blocked IP' }],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
+
+      const result = await service.syncRules(config)
+
+      expect(result.warnings?.some((w) => w.includes('best-effort on Vercel'))).toBe(true)
+    })
+
+    it('does not warn when no rule declares a priority', async () => {
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bots',
+            description: 'Block bad bots',
+            enabled: true,
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot' }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [{ id: 'ip_1', ip: '1.2.3.4', hostname: 'example.com', action: 'deny', notes: 'Blocked IP' }],
+      }
+
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
+
+      const result = await service.syncRules(config)
+
+      expect(result.warnings?.some((w) => w.includes('best-effort on Vercel'))).toBeFalsy()
+    })
+  })
+
   describe('post-sync verification (regression: a create/update/delete that silently did not take effect used to go unreported)', () => {
     it('warns when a created rule is missing from the post-sync remote config', async () => {
       const config: UnifiedConfig = {

--- a/src/lib/schemas/unifiedSchemas.ts
+++ b/src/lib/schemas/unifiedSchemas.ts
@@ -50,7 +50,15 @@ export const unifiedRuleSchema = z.object({
   conditions: z.array(unifiedConditionSchema).min(1, 'At least one condition is required'),
   conditionLogic: z.enum(['AND', 'OR']).optional().default('AND'),
   action: unifiedActionSchema,
-  priority: z.number().int().optional(),
+  priority: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Rule evaluation order. Lower numbers are evaluated first. Rules without a priority keep their config order ' +
+        'and run after all prioritised rules. Fully honoured on Cloudflare; best-effort on Vercel, which cannot ' +
+        'reposition rules that already exist remotely.',
+    ),
   categories: z.array(z.string()).optional(),
 }) satisfies z.ZodType<UnifiedRule>
 

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -66,7 +66,26 @@ export interface UnifiedRule {
   conditions: UnifiedCondition[]
   conditionLogic?: 'AND' | 'OR' // How to combine conditions (default: AND)
   action: UnifiedAction
-  priority?: number // Rule execution order
+  /**
+   * Rule evaluation order. **Lower numbers are evaluated first**, matching
+   * the convention of every provider that exposes an explicit numeric
+   * priority. Rules without a priority keep their config-file order and are
+   * evaluated *after* all prioritised rules, so adding `priority` to one
+   * rule promotes it rather than demoting it. Equal priorities keep their
+   * config-file order.
+   *
+   * Fully honoured on Cloudflare (the ruleset write is an ordered replace).
+   * Best-effort on Vercel, which creates rules individually and cannot
+   * reposition one that already exists — `syncRules` warns when that
+   * applies. See `sortRulesByPriority`.
+   *
+   * Note this field only exists on the unified config format. The legacy
+   * Vercel-only format (`FirewallConfig`/`CustomRule`, `additionalProperties:
+   * false`) has no `priority`, so a legacy-shaped config cannot declare one —
+   * deliberately, since ordering is best-effort on Vercel regardless and the
+   * legacy schema isn't the place to add new capability surface.
+   */
+  priority?: number
   categories?: string[] // Tags for organization
 }
 

--- a/src/lib/utils/__tests__/sortRulesByPriority.test.ts
+++ b/src/lib/utils/__tests__/sortRulesByPriority.test.ts
@@ -1,0 +1,87 @@
+import { sortRulesByPriority, hasExplicitPriorities } from '../sortRulesByPriority'
+
+type R = { name: string; priority?: number }
+
+const names = (rules: R[]) => rules.map((r) => r.name)
+
+describe('sortRulesByPriority', () => {
+  it('orders lower priority numbers first', () => {
+    const rules: R[] = [
+      { name: 'c', priority: 30 },
+      { name: 'a', priority: 10 },
+      { name: 'b', priority: 20 },
+    ]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('sorts unprioritised rules after every prioritised one', () => {
+    const rules: R[] = [{ name: 'no-priority-1' }, { name: 'explicit', priority: 5 }, { name: 'no-priority-2' }]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['explicit', 'no-priority-1', 'no-priority-2'])
+  })
+
+  it('preserves config order among unprioritised rules', () => {
+    const rules: R[] = [{ name: 'x' }, { name: 'y' }, { name: 'z' }]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['x', 'y', 'z'])
+  })
+
+  it('preserves config order among equal priorities (stable sort)', () => {
+    const rules: R[] = [
+      { name: 'first', priority: 1 },
+      { name: 'second', priority: 1 },
+      { name: 'third', priority: 1 },
+    ]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['first', 'second', 'third'])
+  })
+
+  it('handles priority 0 as a real value rather than falsy-absent', () => {
+    const rules: R[] = [{ name: 'ten', priority: 10 }, { name: 'zero', priority: 0 }, { name: 'none' }]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['zero', 'ten', 'none'])
+  })
+
+  it('handles negative priorities', () => {
+    const rules: R[] = [
+      { name: 'zero', priority: 0 },
+      { name: 'negative', priority: -5 },
+    ]
+
+    expect(names(sortRulesByPriority(rules))).toEqual(['negative', 'zero'])
+  })
+
+  it('does not mutate the input array', () => {
+    const rules: R[] = [
+      { name: 'b', priority: 20 },
+      { name: 'a', priority: 10 },
+    ]
+
+    sortRulesByPriority(rules)
+
+    expect(names(rules)).toEqual(['b', 'a'])
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(sortRulesByPriority([])).toEqual([])
+  })
+})
+
+describe('hasExplicitPriorities', () => {
+  it('is false when no rule declares a priority', () => {
+    expect(hasExplicitPriorities([{ priority: undefined }, {}])).toBe(false)
+  })
+
+  it('is true when at least one rule declares a priority', () => {
+    expect(hasExplicitPriorities([{}, { priority: 3 }])).toBe(true)
+  })
+
+  it('treats priority 0 as explicit', () => {
+    expect(hasExplicitPriorities([{ priority: 0 }])).toBe(true)
+  })
+
+  it('is false for an empty set', () => {
+    expect(hasExplicitPriorities([])).toBe(false)
+  })
+})

--- a/src/lib/utils/sortRulesByPriority.ts
+++ b/src/lib/utils/sortRulesByPriority.ts
@@ -1,0 +1,40 @@
+import type { UnifiedRule } from '../types/unified'
+
+/**
+ * Orders rules for submission to a provider, honouring `UnifiedRule.priority`.
+ *
+ * Semantics (documented in the JSON schema and README):
+ *   - **Lower number wins** — `priority: 1` is evaluated before `priority: 10`.
+ *     This matches every provider that exposes an explicit numeric priority
+ *     (AWS WAF `Priority`, GCP Cloud Armor `priority`), so a config written
+ *     against one provider's convention keeps its meaning on another.
+ *   - Rules **without** a priority keep their original config-file order and
+ *     sort *after* every prioritised rule. Adding `priority: 1` to one rule in
+ *     an otherwise unprioritised config therefore promotes it to the front,
+ *     which is the intent that action almost always expresses.
+ *   - Equal priorities keep their relative config-file order (the sort is
+ *     stable, per ES2019+).
+ *
+ * Returns a new array; the input is not mutated.
+ */
+export function sortRulesByPriority<T extends Pick<UnifiedRule, 'priority'>>(rules: T[]): T[] {
+  return [...rules].sort((a, b) => {
+    const aHas = a.priority !== undefined
+    const bHas = b.priority !== undefined
+
+    if (!aHas && !bHas) return 0
+    if (!aHas) return 1
+    if (!bHas) return -1
+    return a.priority! - b.priority!
+  })
+}
+
+/**
+ * Whether any rule in the set declares an explicit priority. Used to decide
+ * whether to surface a warning on providers that can't fully honour ordering
+ * (see `VercelFirewallService.syncRules`) — a config that never sets
+ * `priority` shouldn't be nagged about ordering it never asked for.
+ */
+export function hasExplicitPriorities(rules: Pick<UnifiedRule, 'priority'>[]): boolean {
+  return rules.some((rule) => rule.priority !== undefined)
+}


### PR DESCRIPTION
Closes #179.

## The bug

`UnifiedRule.priority` was read in exactly one place — `CloudflareOptimizer.canonicalizeRule()`, feeding the dedup/diff hash — while rules were written to providers in **config-array order**. Setting it perturbed doorman's internal rule identity (so it could register as a change needing sync) without changing anything about actual firewall evaluation order.

Rule order is security-relevant — a broad `allow` ahead of a narrow `block` inverts the intended policy — so a field that's in the public type, passes validation, and produces a visible diff, but does nothing, is a real footgun.

## Semantics chosen

Implemented rather than removed (option (a) in the issue), since every provider in the #156 roadmap has an explicit priority concept and GCP Cloud Armor *requires* one:

- **Lower numbers first** — matches AWS WAF `Priority` and GCP Cloud Armor `priority`, so a config keeps its meaning across providers
- **Unprioritised rules keep config order and sort after all prioritised ones** — adding `priority: 1` to one rule in an otherwise unprioritised config promotes it, which is what that action almost always means
- **Equal priorities keep config order** (stable sort)

## Per-provider honesty

| | |
|---|---|
| **Cloudflare** | Fully honoured. The ruleset write is an ordered full-array replace, so position *is* precedence. |
| **Vercel** | Best-effort. Rules are written individually via `rules.insert`/`rules.update` with no bulk ordered write — doorman can order *new* rules but cannot reposition one that already exists. `syncRules` now reports this via `SyncResult.warnings`, but only when priorities are declared **and** some rule already exists remotely; a fresh sync where insertion order fully determines evaluation order stays quiet. |

## Second bug found while fixing the first

`diffCloudflareRules` compares in native Cloudflare space via `cloudflareRulesEqual`, which has no priority field (native CF rules don't have one — position is priority). So once sorting was in place, a **priority-only reorder** would produce identical rule content on both sides and diff clean — meaning `diff`/`status` would report "in sync" while `sync` silently rewrote the live evaluation order.

Fixed by making the diff order-aware: position drift among the rules common to both sides is reported as an update. Rules being added/deleted are excluded from that comparison, since their arrival/removal shifts indices without anything having been deliberately reordered.

## Scope note

`priority` is **unified-format-only**. The legacy Vercel schema (`FirewallConfig`/`CustomRule`) is `additionalProperties: false` with no such field, so a legacy-shaped config can't declare one. Left that way deliberately — ordering is best-effort on Vercel regardless, and the legacy format isn't where new capability surface belongs. Happy to add it if you'd rather have parity.

Related: `schema/firewall-config.schema.json` is generated by `ts-json-schema-generator` from the **legacy** `FirewallConfig` type, so it only ever describes the legacy format — unified-format configs get no editor autocomplete from the published schema at all. Pre-existing, out of scope here, but worth its own issue if you want it tracked.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 74 suites / 1341 tests (20 new: 12 for `sortRulesByPriority`, 4 Cloudflare ordering/diff, 4 Vercel best-effort warning)
- [x] `pnpm eslint .` — 0 errors
- [x] End-to-end against `demos/mock-server.mjs`: a unified Vercel config declaring `Z last` (priority 30) before `A first` (priority 10) synced in the corrected order — confirmed via the resulting remote rule list *and* the ID-remap output (`A first → rule_1`, `Z last → rule_2`)
- [x] Confirmed the deletion safety gate still fires correctly during that run (it blocked the first attempt until `--allow-deletions`)