### PR TITLE
feat: implement UnifiedAction.response and mark supportsManagedRules reserved

### DIFF
--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -100,6 +100,17 @@ export interface FeatureSet {
   supportsCustomRules: boolean
   supportsIPBlocking: boolean
   supportsRateLimiting: boolean
+  /**
+   * Whether the provider offers vendor-managed rule groups (Cloudflare
+   * Managed Rulesets, AWS Managed Rules, GCP preconfigured WAF, …).
+   *
+   * **Reserved — declared but not yet actionable.** Nothing consumes this
+   * today because `UnifiedConfig` has no surface for declaring *which*
+   * managed rulesets to enable or how to override individual rules within
+   * them. Kept as the capability signal the config surface will gate on
+   * once that lands; see the managed-rule-groups issue. Do not treat a
+   * `true` here as meaning doorman can currently manage those rules.
+   */
   supportsManagedRules: boolean
   supportsGeoBlocking: boolean
   supportsRedirect: boolean

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -470,6 +470,54 @@ describe('CloudflareFirewallService', () => {
   // Regression coverage for #179: `UnifiedRule.priority` used to feed the
   // dedup/diff hash while never affecting the order rules were written, so
   // setting it changed nothing about actual firewall evaluation order.
+  // Regression coverage for #180 at the service level — the translator
+  // tests cover the mapping itself, this asserts it survives all the way to
+  // the ruleset write rather than being dropped somewhere in syncRules.
+  describe('custom response body reaches the ruleset write', () => {
+    it('includes action_parameters.response in the synced rule', async () => {
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+      const updateSpy = jest.spyOn(mockClient, 'updateRuleset').mockResolvedValue({
+        id: 'ruleset-1',
+        name: 'rs',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '2',
+        last_updated: '2024-01-01T00:00:00Z',
+        rules: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [
+          {
+            id: 'r1',
+            name: 'Blocked',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/api' }],
+            action: { type: 'deny', response: { statusCode: 429, content: 'Slow down', contentType: 'text/html' } },
+          },
+        ],
+        ips: [],
+      }
+
+      await service.syncRules(config, { force: true })
+
+      const [, payload] = updateSpy.mock.calls[0]!
+      expect(payload.rules![0]!.action_parameters).toEqual({
+        response: { status_code: 429, content: 'Slow down', content_type: 'text/html' },
+      })
+    })
+  })
+
   describe('rule priority ordering', () => {
     const ruleWith = (name: string, priority?: number): UnifiedRule => ({
       id: name,

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -300,6 +300,12 @@ export class RuleTranslator {
       )
     }
 
+    // Custom block-response body, if this rule carries one. Recovered so
+    // `download`/`backup` capture it and a Cloudflare→unified→Cloudflare
+    // round trip doesn't silently drop the user's custom block page.
+    const blockResponse =
+      rule.action_parameters && 'response' in rule.action_parameters ? rule.action_parameters.response : undefined
+
     const action: UnifiedAction = {
       type: this.mapCloudflareActionToUnified(rule.action),
       rateLimit: rule.ratelimit
@@ -309,6 +315,13 @@ export class RuleTranslator {
             characteristics: rule.ratelimit.characteristics,
             mitigationTimeout: rule.ratelimit.mitigation_timeout,
             countingExpression: rule.ratelimit.counting_expression,
+          }
+        : undefined,
+      response: blockResponse
+        ? {
+            statusCode: blockResponse.status_code,
+            content: blockResponse.content,
+            contentType: blockResponse.content_type,
           }
         : undefined,
     }
@@ -363,6 +376,44 @@ export class RuleTranslator {
       }
     }
 
+    // Custom response body. Cloudflare only accepts this on `block` actions,
+    // and requires all three fields together — so `content` is the trigger
+    // (there's no custom response without a body) and the other two get
+    // Cloudflare's own defaults when omitted.
+    if (rule.action.response) {
+      const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+
+      if (cloudflareRule.action !== 'block') {
+        warnings.push(
+          TranslationWarningSystem.createUnsupportedFeatureWarning(
+            `custom response on a '${cloudflareRule.action}' action`,
+            'unified config',
+            'Cloudflare',
+            rule.id,
+            'action.response',
+          ),
+        )
+      } else if (!rule.action.response.content) {
+        warnings.push(
+          TranslationWarningSystem.createWarning(
+            'lossy_conversion',
+            rule.id,
+            'action.response',
+            'Custom response declared without `content`; Cloudflare requires a response body, so it was dropped.',
+            'Set action.response.content to the body you want returned.',
+          ),
+        )
+      } else {
+        cloudflareRule.action_parameters = {
+          response: {
+            status_code: rule.action.response.statusCode ?? 403,
+            content: rule.action.response.content,
+            content_type: rule.action.response.contentType ?? 'text/plain',
+          },
+        }
+      }
+    }
+
     return { result: cloudflareRule, warnings }
   }
 
@@ -373,6 +424,22 @@ export class RuleTranslator {
     const warnings: TranslationWarning[] = []
 
     const conditionGroups = this.buildVercelConditionGroups(rule.conditions, rule.id, warnings)
+
+    // Vercel's mitigate action has no custom-response-body concept, so a
+    // rule carrying one loses it here. Warn rather than drop silently —
+    // same contract as an unmappable condition field above.
+    if (rule.action.response) {
+      const { TranslationWarningSystem } = require('./TranslationWarningSystem')
+      warnings.push(
+        TranslationWarningSystem.createUnsupportedFeatureWarning(
+          'custom response body',
+          'unified config',
+          'Vercel',
+          rule.id,
+          'action.response',
+        ),
+      )
+    }
 
     if (conditionGroups.length === 0) {
       throw new Error(

--- a/src/lib/translators/__tests__/RuleTranslator.test.ts
+++ b/src/lib/translators/__tests__/RuleTranslator.test.ts
@@ -480,6 +480,94 @@ describe('RuleTranslator', () => {
     })
   })
 
+  // Regression coverage for #180: UnifiedAction.response was declared in the
+  // public type and unified schema but had zero consumers anywhere — a user
+  // could set a custom block page, pass validation, sync cleanly, and get
+  // nothing.
+  describe('custom response body (UnifiedAction.response)', () => {
+    const denyRuleWithResponse = (response: UnifiedRule['action']['response']): UnifiedRule => ({
+      id: 'r1',
+      name: 'Blocked',
+      enabled: true,
+      conditions: [{ field: 'path', operator: 'eq', value: '/api' }],
+      action: { type: 'deny', response },
+    })
+
+    it('emits action_parameters.response for a block action', () => {
+      const { result, warnings } = RuleTranslator.unifiedToCloudflare(
+        denyRuleWithResponse({ statusCode: 429, content: 'Slow down', contentType: 'text/plain' }),
+      )
+
+      expect(result.action_parameters).toEqual({
+        response: { status_code: 429, content: 'Slow down', content_type: 'text/plain' },
+      })
+      expect(warnings).toEqual([])
+    })
+
+    it('defaults statusCode to 403 and contentType to text/plain when only content is given', () => {
+      const { result } = RuleTranslator.unifiedToCloudflare(denyRuleWithResponse({ content: 'Denied' }))
+
+      expect(result.action_parameters).toEqual({
+        response: { status_code: 403, content: 'Denied', content_type: 'text/plain' },
+      })
+    })
+
+    it('warns and drops the response when content is missing (Cloudflare requires a body)', () => {
+      const { result, warnings } = RuleTranslator.unifiedToCloudflare(denyRuleWithResponse({ statusCode: 418 }))
+
+      expect(result.action_parameters).toBeUndefined()
+      expect(warnings.length).toBeGreaterThan(0)
+      expect(warnings.some((w) => w.field === 'action.response')).toBe(true)
+    })
+
+    it('warns when a custom response is set on a non-block action', () => {
+      const rule: UnifiedRule = {
+        id: 'r2',
+        name: 'Challenged',
+        enabled: true,
+        conditions: [{ field: 'path', operator: 'eq', value: '/api' }],
+        action: { type: 'challenge', response: { content: 'nope' } },
+      }
+
+      const { result, warnings } = RuleTranslator.unifiedToCloudflare(rule)
+
+      expect(result.action_parameters).toBeUndefined()
+      expect(warnings.some((w) => w.field === 'action.response')).toBe(true)
+    })
+
+    it('recovers the response when translating a Cloudflare rule back to unified', () => {
+      const cfRule = makeCloudflareRule({
+        action: 'block',
+        action_parameters: { response: { status_code: 429, content: 'Slow down', content_type: 'text/html' } },
+      })
+
+      const { result } = RuleTranslator.cloudflareToUnified(cfRule)
+
+      expect(result.action.response).toEqual({ statusCode: 429, content: 'Slow down', contentType: 'text/html' })
+    })
+
+    it('round-trips a custom response through unified -> Cloudflare -> unified', () => {
+      const original = denyRuleWithResponse({ statusCode: 429, content: 'Slow down', contentType: 'text/html' })
+
+      const cf = RuleTranslator.unifiedToCloudflare(original).result
+      const back = RuleTranslator.cloudflareToUnified(cf).result
+
+      expect(back.action.response).toEqual(original.action.response)
+    })
+
+    it('leaves action.response undefined for a Cloudflare rule that has none', () => {
+      const { result } = RuleTranslator.cloudflareToUnified(makeCloudflareRule())
+
+      expect(result.action.response).toBeUndefined()
+    })
+
+    it('warns that a custom response is unsupported when translating to Vercel', () => {
+      const { warnings } = RuleTranslator.unifiedToVercel(denyRuleWithResponse({ content: 'Denied' }))
+
+      expect(warnings.some((w) => w.field === 'action.response')).toBe(true)
+    })
+  })
+
   describe('unifiedToCloudflare', () => {
     it('translates a basic deny rule', () => {
       const unified = makeUnifiedRule()

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -46,6 +46,20 @@ export interface UnifiedAction {
     permanent?: boolean
     preserveQueryString?: boolean
   }
+  /**
+   * Custom response body returned when the rule matches.
+   *
+   * Only meaningful on a **deny/block** action, and only on providers that
+   * support it — currently Cloudflare, which requires all three fields
+   * together. `content` is therefore the trigger: without a body there's no
+   * custom response to send, and `statusCode`/`contentType` fall back to
+   * Cloudflare's defaults (403, `text/plain`) when omitted.
+   *
+   * Translating a rule that carries this to Vercel emits an
+   * unsupported-feature warning — Vercel's mitigate action has no
+   * equivalent, so the custom response is dropped rather than silently
+   * pretended-at.
+   */
   response?: {
     statusCode?: number
     content?: string


### PR DESCRIPTION
Closes #180.

Two pieces of public type surface advertised capabilities with no implementation and no consumer.

## 1. `UnifiedAction.response` — implemented

It had **zero** consumers anywhere in `src/`. A user could set a custom block-page body in `.doorman.json`, have it pass schema validation, sync successfully, and get no custom response at all — silently.

Implemented for Cloudflare, whose `CloudflareBlockActionParameters` type already had exactly the right shape (`response: { status_code, content, content_type }`):

- **`unifiedToCloudflare`** emits `action_parameters.response` for block actions. Cloudflare requires all three fields together, so `content` is the trigger (no body means no custom response) and `statusCode`/`contentType` fall back to Cloudflare's own defaults (403, `text/plain`) when omitted.
- **Setting a response on a non-block action, or without `content`**, warns and drops it rather than emitting something Cloudflare's API would reject.
- **`cloudflareToUnified`** recovers it — so `download`/`backup` capture custom block pages, and a Cloudflare → unified → Cloudflare round trip is lossless (same concern as #178).
- **`unifiedToVercel`** warns that it's unsupported. Vercel's mitigate action has no equivalent, so this follows the existing contract for unmappable condition fields rather than dropping it silently.

## 2. `FeatureSet.supportsManagedRules` — documented as reserved

Set by both adapters (`cloudflare: true`, `vercel: false`) and read by nothing. There's also no `UnifiedConfig` surface to declare *which* managed rulesets to enable, so a `true` is unactionable regardless.

Left in place but documented as reserved, pointing at #183. Removing it would just mean re-adding it when that lands — the honest fix is the config surface, not the flag, and #183 tracks that.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 74 suites / 1350 tests (9 new: 8 translator-level covering both directions, defaults, both warning paths, and round-trip fidelity; 1 service-level asserting the response survives all the way to the `updateRuleset` call rather than being dropped inside `syncRules`)
- [x] `pnpm eslint .` — 0 errors