### PR TITLE
refactor: derive the provider list from one constant instead of 12 sites

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -9,11 +9,13 @@ import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface BackupOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -36,7 +38,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -4,11 +4,13 @@ import { logger } from '../lib/logger'
 import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import type { UnifiedConfig } from '../lib/types/unified'
 import { toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface DiffOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -25,7 +27,7 @@ export const desc = 'Show detailed differences between local and remote firewall
 
 export const builder = {
   config: { alias: 'c', type: 'string', description: 'Path to firewall config file' },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: { alias: 'p', type: 'string', description: 'Vercel Project ID' },
   teamId: { alias: 't', type: 'string', description: 'Vercel Team ID' },
   token: { type: 'string', description: 'Vercel API token (defaults to VERCEL_TOKEN env var)' },

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -8,11 +8,13 @@ import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { saveConfig } from '../lib/utils/config'
 import { fromUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface DownloadOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -39,7 +41,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -7,11 +7,13 @@ import type { UnifiedConfig, UnifiedIPRule, UnifiedRule } from '../lib/types/uni
 import { getConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
 import { toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface ExportOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -34,7 +36,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,10 +4,12 @@ import { z } from 'zod'
 import { logger } from '../lib/logger'
 import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import { configVersionSchema } from '../lib/schemas/firewallSchemas'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface ListOptions {
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId: string
   teamId: string
   token?: string
@@ -28,7 +30,7 @@ export const builder = {
     type: 'number',
     description: 'Specific configuration version to fetch (defaults to latest)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,11 +4,13 @@ import { logger } from '../lib/logger'
 import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import type { UnifiedConfig } from '../lib/types/unified'
 import { toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface StatusOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -28,7 +30,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,11 +6,13 @@ import type { UnifiedIPRule, UnifiedRule } from '../lib/types/unified'
 import { FirewallConfig } from '../lib/types'
 import { saveConfig } from '../lib/utils/config'
 import { applySyncResultToConfig, toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface SyncOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -31,7 +33,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -6,11 +6,13 @@ import type { IFirewallProvider } from '../lib/providers/IFirewallProvider'
 import type { FirewallConfig } from '../lib/types'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { applySyncResultToConfig, toUnifiedConfig } from '../lib/utils/vercelConfigAdapter'
+import type { ProviderType } from '../lib/providers/IFirewallProvider'
+import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
 
 interface WatchOptions {
   config?: string
-  provider?: 'vercel' | 'cloudflare'
+  provider?: ProviderType | 'cloudflare'
   projectId?: string
   teamId?: string
   token?: string
@@ -31,7 +33,7 @@ export const builder = {
     type: 'string',
     description: 'Path to firewall config file (defaults to .doorman.json)',
   },
-  provider: { type: 'string', choices: ['vercel', 'cloudflare'], description: 'Firewall provider (auto-detected)' },
+  provider: providerOption,
   projectId: {
     alias: 'p',
     type: 'string',

--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -4,9 +4,24 @@
  */
 
 /**
+ * Every provider doorman knows about. **This is the single place to add a
+ * new one** — `ProviderType` derives from it, and everything that needs a
+ * runtime list (CLI `--provider` choices, the interactive picker, provider-
+ * string validation) reads this rather than repeating the literals.
+ *
+ * Deliberately a const array rather than the `ProviderRegistry`'s runtime
+ * membership: yargs builds `--provider`'s `choices` synchronously at
+ * CLI-construction time, before any provider factory has been registered,
+ * so a registry-driven list would be empty exactly when the CLI needs it.
+ * The registry remains the source of truth for provider *instances*; this
+ * is the source of truth for the closed set of known provider *types*.
+ */
+export const PROVIDER_TYPES = ['vercel', 'cloudflare'] as const
+
+/**
  * Provider type discriminator
  */
-export type ProviderType = 'vercel' | 'cloudflare'
+export type ProviderType = (typeof PROVIDER_TYPES)[number]
 
 /**
  * Sync operation options

--- a/src/lib/providers/ProviderDetector.ts
+++ b/src/lib/providers/ProviderDetector.ts
@@ -1,5 +1,5 @@
 import { logger } from '../logger'
-import type { ProviderType } from './IFirewallProvider'
+import { PROVIDER_TYPES, type ProviderType } from './IFirewallProvider'
 
 /**
  * Provider detection result
@@ -155,7 +155,7 @@ export class ProviderDetector {
    * Validate provider type string
    */
   private static isValidProvider(provider: string): boolean {
-    return provider === 'vercel' || provider === 'cloudflare'
+    return (PROVIDER_TYPES as readonly string[]).includes(provider)
   }
 
   /**

--- a/src/lib/providers/initProviders.ts
+++ b/src/lib/providers/initProviders.ts
@@ -2,6 +2,7 @@ import { getProviderRegistry } from './ProviderRegistry'
 import { CloudflareProvider } from './cloudflare'
 import { VercelProvider } from './vercel'
 import { logger } from '../logger'
+import type { ProviderType } from './IFirewallProvider'
 
 /**
  * Initialize and register all available providers
@@ -29,7 +30,7 @@ export function initProviders(): void {
  * Get a provider instance with automatic initialization
  */
 export async function getProvider(
-  providerType: 'vercel' | 'cloudflare',
+  providerType: ProviderType,
   config?: Record<string, unknown>,
 ): Promise<import('./IFirewallProvider').IFirewallProvider> {
   const registry = getProviderRegistry()

--- a/src/lib/utils/__tests__/providerOption.test.ts
+++ b/src/lib/utils/__tests__/providerOption.test.ts
@@ -1,0 +1,30 @@
+import { providerOption } from '../providerOption'
+import { PROVIDER_TYPES } from '../../providers/IFirewallProvider'
+
+// Regression coverage for #181: `choices: ['vercel', 'cloudflare']` used to
+// be duplicated verbatim across all eight command builders, so adding a
+// provider meant eight mechanical edits to files that are otherwise entirely
+// provider-agnostic — with a real chance of missing one.
+describe('providerOption', () => {
+  it('derives its choices from PROVIDER_TYPES rather than a hardcoded list', () => {
+    expect(providerOption.choices).toEqual([...PROVIDER_TYPES])
+  })
+
+  it('is a string option', () => {
+    expect(providerOption.type).toBe('string')
+  })
+
+  it('has a description', () => {
+    expect(providerOption.description).toBeTruthy()
+  })
+})
+
+describe('every command builder uses the shared provider option', () => {
+  const commands = ['sync', 'diff', 'download', 'list', 'status', 'watch', 'backup', 'export']
+
+  it.each(commands)('%s exposes the shared providerOption', (name) => {
+    const mod = require(`../../../commands/${name}`) as { builder: Record<string, unknown> }
+
+    expect(mod.builder.provider).toBe(providerOption)
+  })
+})

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -5,7 +5,7 @@ import { promptSecret } from '../ui/promptSecret'
 import { ProviderDetector } from '../providers/ProviderDetector'
 import { VercelProvider } from '../providers/vercel'
 import { CloudflareProvider } from '../providers/cloudflare'
-import type { IFirewallProvider, ProviderType } from '../providers/IFirewallProvider'
+import { PROVIDER_TYPES, type IFirewallProvider, type ProviderType } from '../providers/IFirewallProvider'
 import type { FirewallConfig, UnifiedConfig } from '../types'
 
 export interface ProviderOptions {
@@ -184,24 +184,35 @@ async function getCloudflareProvider(options: ProviderOptions): Promise<IFirewal
  * Prompt user to select provider
  */
 async function promptForProvider(): Promise<ProviderType> {
+  // Enumerated from PROVIDER_TYPES rather than hardcoded, so a new provider
+  // shows up in the picker automatically instead of needing this menu (and
+  // its numeric mapping, and its range prompt) edited by hand.
   logger.info(chalk.yellow('Unable to auto-detect firewall provider.'))
   logger.info('Please select a provider:\n')
-  logger.info('  1. Vercel Firewall')
-  logger.info('  2. Cloudflare WAF\n')
+  PROVIDER_TYPES.forEach((type, index) => {
+    logger.info(`  ${index + 1}. ${getProviderDisplayName(type)}`)
+  })
+  logger.info('')
 
-  const choice = await prompt('Select provider (1 or 2):', {
+  const choice = await prompt(`Select provider (1-${PROVIDER_TYPES.length}):`, {
     type: 'text',
   })
 
-  const choiceStr = String(choice).toLowerCase()
-  if (choiceStr === '1' || choiceStr === 'vercel') {
-    return 'vercel'
-  } else if (choiceStr === '2' || choiceStr === 'cloudflare') {
-    return 'cloudflare'
-  } else {
-    logger.warn(`Invalid choice: ${choice}, defaulting to Vercel`)
-    return 'vercel'
+  const choiceStr = String(choice).trim().toLowerCase()
+
+  const byName = PROVIDER_TYPES.find((type) => type === choiceStr)
+  if (byName) {
+    return byName
   }
+
+  const index = Number(choiceStr)
+  if (Number.isInteger(index) && index >= 1 && index <= PROVIDER_TYPES.length) {
+    return PROVIDER_TYPES[index - 1]!
+  }
+
+  const fallback = PROVIDER_TYPES[0]!
+  logger.warn(`Invalid choice: ${choice}, defaulting to ${getProviderDisplayName(fallback)}`)
+  return fallback
 }
 
 /**

--- a/src/lib/utils/providerOption.ts
+++ b/src/lib/utils/providerOption.ts
@@ -1,0 +1,26 @@
+import { PROVIDER_TYPES } from '../providers/IFirewallProvider'
+
+/**
+ * The shared `--provider` yargs option, so the list of valid providers lives
+ * in exactly one place (`PROVIDER_TYPES`) rather than being repeated as a
+ * `choices: ['vercel', 'cloudflare']` literal in every command's builder.
+ *
+ * Before this, adding a provider meant a mechanical edit to eight command
+ * files that were otherwise entirely provider-agnostic — pure duplication
+ * with a real chance of one being missed.
+ *
+ * Spread into a builder rather than assigned, so a command can still
+ * override any individual field:
+ *
+ * ```ts
+ * export const builder = {
+ *   provider: providerOption,
+ *   // …
+ * }
+ * ```
+ */
+export const providerOption = {
+  type: 'string' as const,
+  choices: PROVIDER_TYPES as unknown as string[],
+  description: 'Firewall provider (auto-detected)',
+}


### PR DESCRIPTION
Closes #181.

## Problem

`ProviderType` was a closed union hardcoded across ~12 places. Most egregiously, **eight command builders** each carried a byte-identical `choices: ['vercel', 'cloudflare']` — in files that have been entirely provider-agnostic since the #176 migration. Adding a provider meant eight mechanical edits with a real chance of missing one.

## Approach

`PROVIDER_TYPES` as the single source of truth, with `ProviderType` derived from it:

```ts
export const PROVIDER_TYPES = ['vercel', 'cloudflare'] as const
export type ProviderType = (typeof PROVIDER_TYPES)[number]
```

Deliberately a **const array rather than the `ProviderRegistry`'s runtime membership** — yargs builds `--provider`'s `choices` synchronously at CLI-construction time, before any provider factory has been registered, so a registry-driven list would be empty exactly when the CLI needs it. The registry stays the source of truth for provider *instances*; this is the source of truth for the closed set of known provider *types*. (The issue suggested registry-driven; this is the same outcome without the init-order fragility.)

Everything needing a runtime list now derives it:
- a shared **`providerOption`** yargs fragment replaces all eight inline copies
- `ProviderDetector.isValidProvider` → membership check
- `promptForProvider` enumerates providers with display names, deriving both the menu and its numeric range instead of hardcoding two entries — and now also accepts the provider name typed directly (`vercel`), which previously only worked by coincidence of the hand-written branches
- `initProviders.getProvider` and the eight command option interfaces take `ProviderType` instead of repeating the inline union

## Verification of the acceptance criterion

Temporarily added a third entry to `PROVIDER_TYPES` and rebuilt:

- `--provider fastly` → **accepted** with zero other edits (failed later on config-not-found, not on choice validation)
- after restoring, `--provider bogus` → still rejected: `Invalid values: Argument: provider, Given: "bogus", Choices: "vercel", "cloudflare"`

So adding a provider now requires touching only `PROVIDER_TYPES`, the provider's own adapter directory, and its `initProviders` registration — exactly what the issue asked for.

## Out of scope

The per-provider credential branching in `providerHelper`/`initProviders` is untouched — those branches differ by credential *shape*, not just name, and generalizing them is #182.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 75 suites / 1352 tests (11 new, including a parametrised check that all eight command builders reference the shared option object rather than a structural copy)
- [x] `pnpm eslint .` — 0 errors
- [x] Manual CLI verification of both the accept and reject paths described above