### PR TITLE
test: pin credential precedence (flag > config > env) before refactoring it

### DIFF
--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -268,6 +268,163 @@ describe('providerHelper', () => {
     })
   })
 
+  // Characterization tests pinning the credential *precedence* chain, which
+  // nothing asserted before: CLI flag > config file > environment variable,
+  // independently for every credential. These are the subtleties a
+  // credential-resolution refactor (#182) would break silently — a wrong
+  // precedence still resolves *a* credential, so the suite would stay green
+  // while users authenticated as the wrong project/zone. Written against
+  // current behaviour first, as a regression baseline.
+  describe('credential precedence (flag > config > env)', () => {
+    const mockedVercelFromConfig = VercelProvider.fromConfig as jest.MockedFunction<typeof VercelProvider.fromConfig>
+    const mockedCloudflareFromConfig = CloudflareProvider.fromConfig as jest.MockedFunction<
+      typeof CloudflareProvider.fromConfig
+    >
+
+    describe('vercel', () => {
+      it('prefers the CLI flag over both config and env for every credential', async () => {
+        process.env.VERCEL_TOKEN = 'env-token'
+        process.env.VERCEL_PROJECT_ID = 'env-project'
+        process.env.VERCEL_TEAM_ID = 'env-team'
+
+        await getProviderInstance({
+          provider: 'vercel',
+          token: 'flag-token',
+          projectId: 'flag-project',
+          teamId: 'flag-team',
+          config: { projectId: 'config-project', teamId: 'config-team' } as never,
+          interactive: false,
+        })
+
+        expect(mockedVercelFromConfig).toHaveBeenCalledWith({
+          token: 'flag-token',
+          projectId: 'flag-project',
+          teamId: 'flag-team',
+        })
+      })
+
+      it('prefers the config file over env for projectId/teamId', async () => {
+        process.env.VERCEL_TOKEN = 'env-token'
+        process.env.VERCEL_PROJECT_ID = 'env-project'
+        process.env.VERCEL_TEAM_ID = 'env-team'
+
+        await getProviderInstance({
+          provider: 'vercel',
+          config: { projectId: 'config-project', teamId: 'config-team' } as never,
+          interactive: false,
+        })
+
+        expect(mockedVercelFromConfig).toHaveBeenCalledWith({
+          // token has no config-file home on the legacy shape, so it still
+          // comes from env — that asymmetry is intentional and pinned here.
+          token: 'env-token',
+          projectId: 'config-project',
+          teamId: 'config-team',
+        })
+      })
+
+      it('falls back to env when neither flag nor config supplies a value', async () => {
+        process.env.VERCEL_TOKEN = 'env-token'
+        process.env.VERCEL_PROJECT_ID = 'env-project'
+        process.env.VERCEL_TEAM_ID = 'env-team'
+
+        await getProviderInstance({ provider: 'vercel', interactive: false })
+
+        expect(mockedVercelFromConfig).toHaveBeenCalledWith({
+          token: 'env-token',
+          projectId: 'env-project',
+          teamId: 'env-team',
+        })
+      })
+
+      it('resolves each credential independently rather than all-or-nothing', async () => {
+        process.env.VERCEL_TOKEN = 'env-token'
+        process.env.VERCEL_TEAM_ID = 'env-team'
+
+        await getProviderInstance({
+          provider: 'vercel',
+          projectId: 'flag-project',
+          interactive: false,
+        })
+
+        expect(mockedVercelFromConfig).toHaveBeenCalledWith({
+          token: 'env-token',
+          projectId: 'flag-project',
+          teamId: 'env-team',
+        })
+      })
+
+      it('reads projectId/teamId from providers.vercel on a unified config', async () => {
+        process.env.VERCEL_TOKEN = 'env-token'
+
+        await getProviderInstance({
+          provider: 'vercel',
+          config: { providers: { vercel: { projectId: 'unified-project', teamId: 'unified-team' } } } as never,
+          interactive: false,
+        })
+
+        expect(mockedVercelFromConfig).toHaveBeenCalledWith({
+          token: 'env-token',
+          projectId: 'unified-project',
+          teamId: 'unified-team',
+        })
+      })
+    })
+
+    describe('cloudflare', () => {
+      it('prefers the CLI flag over env for every credential', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+        process.env.CLOUDFLARE_ZONE_ID = 'env-zone'
+        process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account'
+
+        await getProviderInstance({
+          provider: 'cloudflare',
+          apiToken: 'flag-api-token',
+          zoneId: 'flag-zone',
+          accountId: 'flag-account',
+          interactive: false,
+        })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith({
+          apiToken: 'flag-api-token',
+          zoneId: 'flag-zone',
+          accountId: 'flag-account',
+        })
+      })
+
+      it('falls back to env for each credential independently', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+        process.env.CLOUDFLARE_ZONE_ID = 'env-zone'
+        process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account'
+
+        await getProviderInstance({
+          provider: 'cloudflare',
+          zoneId: 'flag-zone',
+          interactive: false,
+        })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith({
+          apiToken: 'env-api-token',
+          zoneId: 'flag-zone',
+          accountId: 'env-account',
+        })
+      })
+
+      it('passes accountId through as undefined when nothing supplies it (it is optional)', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+        process.env.CLOUDFLARE_ZONE_ID = 'env-zone'
+
+        await getProviderInstance({ provider: 'cloudflare', interactive: false })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith({
+          apiToken: 'env-api-token',
+          zoneId: 'env-zone',
+          accountId: undefined,
+        })
+      })
+    })
+  })
+
   describe('verifyProviderCredentials', () => {
     it('returns true when credentials are valid', async () => {
       const mockProvider: IFirewallProvider = {


### PR DESCRIPTION
Groundwork for #182 — landing the safety net before touching any resolution code.

## Why separately

Credential resolution has good coverage of *whether* a credential resolves, but **nothing asserted the precedence chain** — CLI flag over config file over environment variable, independently per credential.

That's precisely the class of subtlety a credential-resolution refactor breaks silently: a wrong precedence still resolves *a* credential, so the suite stays green while users authenticate against the wrong project or zone. Landing it as its own PR, before the refactor, means it can't be quietly rewritten to match whatever the refactor happens to do. (Same pattern as #172 before the Vercel migration.)

## Coverage

For both providers:
- flag beats config **and** env
- config beats env
- env as last resort
- **per-credential independent resolution** — a flag for one credential doesn't stop others falling back
- unified-config `providers.<name>` paths
- Cloudflare's optional `accountId` staying `undefined` when nothing supplies it

Also pins the deliberate asymmetry that Vercel's `token` has no legacy-config home, so it always comes from flag or env even when `projectId`/`teamId` come from the config file.

## Mutation-verified

Not assumed — checked. Inverting flag/env precedence in `getVercelProvider`:

```
const token = process.env.VERCEL_TOKEN || options.token   // deliberately wrong
```

fails with a clear diff on `prefers the CLI flag over both config and env for every credential`, and restoring it passes. So these assert real behaviour rather than passing regardless.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 75 suites / 1369 tests (9 new)
- [x] `pnpm eslint .` — 0 errors
- [x] Mutation check described above