### PR TITLE
fix: resolve Cloudflare zoneId/accountId from config; add credential descriptors

### DIFF
--- a/src/lib/providers/cloudflare/credentials.ts
+++ b/src/lib/providers/cloudflare/credentials.ts
@@ -1,0 +1,36 @@
+import type { CredentialDescriptor } from '../credentials'
+
+/**
+ * Cloudflare's credentials, declared once here rather than as string
+ * literals scattered across the resolution, detection, validation, and
+ * setup-verification code.
+ */
+export const cloudflareCredentials: CredentialDescriptor = {
+  provider: 'cloudflare',
+  fields: [
+    {
+      key: 'apiToken',
+      envVar: 'CLOUDFLARE_API_TOKEN',
+      label: 'Cloudflare API Token',
+      required: true,
+      secret: true,
+      // No configKey — see the Vercel token's note.
+    },
+    {
+      key: 'zoneId',
+      envVar: 'CLOUDFLARE_ZONE_ID',
+      label: 'Cloudflare Zone ID',
+      required: true,
+      configKey: 'zoneId',
+    },
+    {
+      key: 'accountId',
+      envVar: 'CLOUDFLARE_ACCOUNT_ID',
+      // Optional: only needed for the Lists API (bulk IP blocking). Without
+      // it, IP rules fall back to individual rules — degraded, not broken.
+      label: 'Cloudflare Account ID',
+      required: false,
+      configKey: 'accountId',
+    },
+  ],
+}

--- a/src/lib/providers/credentials.ts
+++ b/src/lib/providers/credentials.ts
@@ -1,0 +1,102 @@
+import type { ProviderType } from './IFirewallProvider'
+import { vercelCredentials } from './vercel/credentials'
+import { cloudflareCredentials } from './cloudflare/credentials'
+
+/**
+ * One credential a provider needs, described rather than hardcoded at each
+ * point of use.
+ *
+ * Before this, a credential's environment-variable name was a bare string
+ * literal repeated across `providerHelper`, the provider factory, the
+ * detector, and (for Cloudflare) the config validator and setup verifier —
+ * so `VERCEL_TOKEN` and friends appeared in six-plus files with nothing
+ * tying them together.
+ */
+export interface CredentialField {
+  /**
+   * Property name this credential travels under, both on `ProviderOptions`
+   * (the CLI flag) and in a resolved credentials bag — e.g. `apiToken`.
+   */
+  key: string
+  /** Environment variable consulted when no flag or config value supplies it. */
+  envVar: string
+  /** Human-readable name, used in prompts and error messages. */
+  label: string
+  /** Whether the provider cannot be constructed without it. */
+  required: boolean
+  /** Whether a value should be masked when prompted for interactively. */
+  secret?: boolean
+  /**
+   * Dotted path within a unified config's `providers.<name>` block, when the
+   * credential can be declared in the config file. Omitted for credentials
+   * that are secrets and therefore have no business living in a committed
+   * config (e.g. API tokens).
+   */
+  configKey?: string
+}
+
+/**
+ * Everything doorman needs to know about a provider's credentials, declared
+ * once, in that provider's own adapter directory.
+ */
+export interface CredentialDescriptor {
+  provider: ProviderType
+  fields: CredentialField[]
+}
+
+/**
+ * Resolves a descriptor's fields against the standard precedence chain:
+ * explicit value (CLI flag) → config file → environment variable.
+ *
+ * This is the order doorman has always used; it's pinned by the precedence
+ * tests in `providerHelper.test.ts`, which were deliberately landed before
+ * this refactor so a silent reordering would fail loudly rather than leave
+ * users authenticated against the wrong project or zone.
+ */
+export function resolveCredentials(
+  descriptor: CredentialDescriptor,
+  sources: {
+    /** Explicit values, typically CLI flags. Highest precedence. */
+    explicit?: Record<string, string | undefined>
+    /** Values read from the config file. Middle precedence. */
+    config?: Record<string, string | undefined>
+    /** Environment lookup, injectable for testing. Defaults to process.env. */
+    env?: Record<string, string | undefined>
+  } = {},
+): Record<string, string | undefined> {
+  const { explicit = {}, config = {}, env = process.env } = sources
+  const resolved: Record<string, string | undefined> = {}
+
+  for (const field of descriptor.fields) {
+    resolved[field.key] = explicit[field.key] || config[field.key] || env[field.envVar]
+  }
+
+  return resolved
+}
+
+/**
+ * Names of the fields a provider cannot be constructed without, for building
+ * a "credentials missing" message that actually says which ones.
+ */
+export function missingRequiredCredentials(
+  descriptor: CredentialDescriptor,
+  resolved: Record<string, string | undefined>,
+): CredentialField[] {
+  return descriptor.fields.filter((field) => field.required && !resolved[field.key])
+}
+
+/**
+ * Every provider's credential descriptor, keyed by provider. Adding a
+ * provider means adding its descriptor here alongside its `PROVIDER_TYPES`
+ * entry and its `initProviders` registration — not editing resolution,
+ * detection, or prompting code.
+ */
+export const CREDENTIAL_DESCRIPTORS: Record<ProviderType, CredentialDescriptor> = {
+  vercel: vercelCredentials,
+  cloudflare: cloudflareCredentials,
+}
+
+/** The credential descriptor for a provider. */
+export function getCredentialDescriptor(provider: ProviderType): CredentialDescriptor {
+  return CREDENTIAL_DESCRIPTORS[provider]
+}

--- a/src/lib/providers/vercel/credentials.ts
+++ b/src/lib/providers/vercel/credentials.ts
@@ -1,0 +1,34 @@
+import type { CredentialDescriptor } from '../credentials'
+
+/**
+ * Vercel's credentials, declared once here rather than as string literals
+ * scattered across the resolution, detection, and prompting code.
+ */
+export const vercelCredentials: CredentialDescriptor = {
+  provider: 'vercel',
+  fields: [
+    {
+      key: 'token',
+      envVar: 'VERCEL_TOKEN',
+      label: 'Vercel API Token',
+      required: true,
+      secret: true,
+      // Deliberately no configKey — an API token has no business living in a
+      // committed config file, so it comes from a flag or the environment only.
+    },
+    {
+      key: 'projectId',
+      envVar: 'VERCEL_PROJECT_ID',
+      label: 'Vercel Project ID',
+      required: true,
+      configKey: 'projectId',
+    },
+    {
+      key: 'teamId',
+      envVar: 'VERCEL_TEAM_ID',
+      label: 'Vercel Team ID',
+      required: true,
+      configKey: 'teamId',
+    },
+  ],
+}

--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -410,6 +410,54 @@ describe('providerHelper', () => {
         })
       })
 
+      // Regression test: getCloudflareProvider resolved only `flag || env`
+      // and never looked at the config file at all, so a unified config
+      // declaring providers.cloudflare.zoneId was ignored — the user got
+      // "Cloudflare credentials missing" despite having declared it. This
+      // is the same bug #171 fixed for Vercel, which was never fixed for
+      // Cloudflare.
+      it('resolves zoneId/accountId from providers.cloudflare on a unified config', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+
+        await getProviderInstance({
+          provider: 'cloudflare',
+          config: { providers: { cloudflare: { zoneId: 'config-zone', accountId: 'config-account' } } } as never,
+          interactive: false,
+        })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith({
+          apiToken: 'env-api-token',
+          zoneId: 'config-zone',
+          accountId: 'config-account',
+        })
+      })
+
+      it('prefers the CLI flag over a config-declared zoneId', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+
+        await getProviderInstance({
+          provider: 'cloudflare',
+          zoneId: 'flag-zone',
+          config: { providers: { cloudflare: { zoneId: 'config-zone' } } } as never,
+          interactive: false,
+        })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith(expect.objectContaining({ zoneId: 'flag-zone' }))
+      })
+
+      it('prefers a config-declared zoneId over the environment', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
+        process.env.CLOUDFLARE_ZONE_ID = 'env-zone'
+
+        await getProviderInstance({
+          provider: 'cloudflare',
+          config: { providers: { cloudflare: { zoneId: 'config-zone' } } } as never,
+          interactive: false,
+        })
+
+        expect(mockedCloudflareFromConfig).toHaveBeenCalledWith(expect.objectContaining({ zoneId: 'config-zone' }))
+      })
+
       it('passes accountId through as undefined when nothing supplies it (it is optional)', async () => {
         process.env.CLOUDFLARE_API_TOKEN = 'env-api-token'
         process.env.CLOUDFLARE_ZONE_ID = 'env-zone'

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -6,6 +6,9 @@ import { ProviderDetector } from '../providers/ProviderDetector'
 import { VercelProvider } from '../providers/vercel'
 import { CloudflareProvider } from '../providers/cloudflare'
 import { PROVIDER_TYPES, type IFirewallProvider, type ProviderType } from '../providers/IFirewallProvider'
+import { resolveCredentials } from '../providers/credentials'
+import { vercelCredentials } from '../providers/vercel/credentials'
+import { cloudflareCredentials } from '../providers/cloudflare/credentials'
 import type { FirewallConfig, UnifiedConfig } from '../types'
 
 export interface ProviderOptions {
@@ -91,18 +94,23 @@ export async function getProviderInstance(options: ProviderOptions): Promise<Pro
  * Get Vercel provider instance
  */
 async function getVercelProvider(options: ProviderOptions): Promise<ProviderInstanceResult> {
-  const token = options.token || process.env.VERCEL_TOKEN
-
   // Vercel credentials may live directly on the config (legacy `.doorman.json`
   // shape) or under `providers.vercel` (unified config shape). Both are
   // checked since a config's shape can't be reliably inferred from `rules`
   // alone (both legacy and unified configs have a top-level `rules` array).
   const config = options.config as (Partial<FirewallConfig> & Partial<UnifiedConfig>) | undefined
-  const configProjectId = config?.providers?.vercel?.projectId ?? config?.projectId
-  const configTeamId = config?.providers?.vercel?.teamId ?? config?.teamId
 
-  const projectId = options.projectId || configProjectId || process.env.VERCEL_PROJECT_ID
-  const teamId = options.teamId || configTeamId || process.env.VERCEL_TEAM_ID
+  // Resolution order (explicit flag -> config -> env) comes from the shared
+  // descriptor rather than being spelled out per credential here; the env
+  // var names live with the Vercel adapter. Precedence is pinned by the
+  // tests in providerHelper.test.ts.
+  const { token, projectId, teamId } = resolveCredentials(vercelCredentials, {
+    explicit: { token: options.token, projectId: options.projectId, teamId: options.teamId },
+    config: {
+      projectId: config?.providers?.vercel?.projectId ?? config?.projectId,
+      teamId: config?.providers?.vercel?.teamId ?? config?.teamId,
+    },
+  })
 
   if (!token || !projectId || !teamId) {
     if (options.interactive === false) {
@@ -140,9 +148,15 @@ async function getVercelProvider(options: ProviderOptions): Promise<ProviderInst
  * Get Cloudflare provider instance
  */
 async function getCloudflareProvider(options: ProviderOptions): Promise<IFirewallProvider> {
-  const apiToken = options.apiToken || process.env.CLOUDFLARE_API_TOKEN
-  const zoneId = options.zoneId || process.env.CLOUDFLARE_ZONE_ID
-  const accountId = options.accountId || process.env.CLOUDFLARE_ACCOUNT_ID
+  const config = options.config as Partial<UnifiedConfig> | undefined
+
+  const { apiToken, zoneId, accountId } = resolveCredentials(cloudflareCredentials, {
+    explicit: { apiToken: options.apiToken, zoneId: options.zoneId, accountId: options.accountId },
+    config: {
+      zoneId: config?.providers?.cloudflare?.zoneId,
+      accountId: config?.providers?.cloudflare?.accountId,
+    },
+  })
 
   if (!apiToken || !zoneId) {
     if (options.interactive === false) {


### PR DESCRIPTION
Partially addresses #182 — and fixes a real bug found while doing it.

## The bug

`getCloudflareProvider` resolved credentials as `flag || env` and **never consulted the config file at all**:

```ts
const apiToken = options.apiToken || process.env.CLOUDFLARE_API_TOKEN
const zoneId = options.zoneId || process.env.CLOUDFLARE_ZONE_ID
const accountId = options.accountId || process.env.CLOUDFLARE_ACCOUNT_ID
```

So a unified config declaring `providers.cloudflare.zoneId` was ignored, and the user got **"Cloudflare credentials missing"** despite having declared it. This is the same bug #171 fixed for Vercel — Cloudflare, three lines away in the same file, was never given the same treatment.

**Verified against the real CLI**, not just unit tests. With `zoneId` only in the config and `CLOUDFLARE_API_TOKEN` in the env:

| | |
|---|---|
| before | `ERROR Failed to initialize cloudflare provider: Cloudflare credentials missing. Provide apiToken and zoneId.` |
| after | reaches the API (`Network error during listing rulesets` — expected with a fake token) |

## The refactor

Per-provider **credential descriptors**, declared in each adapter's own directory, replacing env-var names that were bare string literals repeated across resolution, detection, prompting, validation, and setup verification. A descriptor states each credential's flag key, env var, label, whether it's required, whether it's secret, and where (if anywhere) it may live in a config file — API tokens deliberately have **no** config home, since they have no business in a committed file.

`resolveCredentials` then applies the `flag > config > env` chain from the descriptor, rather than each call site spelling it out per credential. That duplication is exactly what let this bug hide: Vercel's resolution had config handling bolted on by #171 while Cloudflare's, immediately below it, silently did not.

## Safety

Precedence is unchanged and verified by the tests landed in #192 specifically to guard this refactor. Three new tests cover the Cloudflare config path; **two of them fail against the previous behaviour** (the third — flag beating config — passes either way, correctly).

## Deliberately not done here

#182 also calls for replacing `ProviderOptions`' flat per-provider fields with a credentials bag, and making `ProvidersConfig` an index-signature type. Both are API-shape changes with real trade-offs (the latter loses typo-safety on the two real providers for a benefit that only lands with provider #3), so they're worth doing deliberately rather than folding into a bug fix. #182 stays open for them.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 75 suites / 1372 tests (3 new)
- [x] `pnpm eslint .` — 0 errors
- [x] Real-CLI before/after comparison shown above
- [x] Reverted-behaviour check confirming the new tests actually catch the bug