### PR TITLE
fix: write the config file atomically

### DIFF
--- a/src/lib/utils/__tests__/config.save.test.ts
+++ b/src/lib/utils/__tests__/config.save.test.ts
@@ -1,0 +1,146 @@
+jest.mock('../../logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+// `fs`'s exports aren't configurable, so jest.spyOn can't redefine them.
+// Mock the module instead, delegating to the real implementation by default
+// so only the specific call a test wants to fail is overridden.
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs')
+  return {
+    ...actual,
+    writeFileSync: jest.fn((...args: unknown[]) => actual.writeFileSync(...args)),
+    renameSync: jest.fn((...args: unknown[]) => actual.renameSync(...args)),
+  }
+})
+
+import { promises as fsp, mkdtempSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { saveConfig } from '../config'
+import { ValidationService } from '../../services/ValidationService'
+import type { FirewallConfig } from '../../types'
+
+const mockedWriteFileSync = writeFileSync as unknown as jest.Mock
+const mockedRenameSync = renameSync as unknown as jest.Mock
+
+const validConfig: FirewallConfig = { version: 1, rules: [], ips: [] }
+const previousConfig: FirewallConfig = { version: 7, rules: [], ips: [] }
+
+/** Writes bypassing the mock, so fixture setup can't be affected by it. */
+const writeReal = (path: string, contents: string) =>
+  (jest.requireActual('fs') as typeof import('fs')).writeFileSync(path, contents)
+
+describe('saveConfig', () => {
+  let dir: string
+  let configPath: string
+
+  beforeEach(() => {
+    mockedWriteFileSync.mockClear()
+    mockedRenameSync.mockClear()
+    dir = mkdtempSync(join(tmpdir(), 'doorman-save-'))
+    configPath = join(dir, '.doorman.json')
+  })
+
+  afterEach(async () => {
+    mockedWriteFileSync.mockReset()
+    mockedRenameSync.mockReset()
+    const actual = jest.requireActual('fs') as {
+      writeFileSync: (...a: never[]) => void
+      renameSync: (...a: never[]) => void
+    }
+    mockedWriteFileSync.mockImplementation((...args: never[]) => actual.writeFileSync(...args))
+    mockedRenameSync.mockImplementation((...args: never[]) => actual.renameSync(...args))
+    await fsp.rm(dir, { recursive: true, force: true })
+  })
+
+  it('writes the config', async () => {
+    await saveConfig(validConfig, configPath)
+
+    expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual(validConfig)
+  })
+
+  it('leaves no temp files behind on success', async () => {
+    await saveConfig(validConfig, configPath)
+
+    expect(readdirSync(dir).filter((f) => f.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('writes via a temp file rather than straight to the target', async () => {
+    await saveConfig(validConfig, configPath)
+
+    // The real write goes to a .tmp path; the target only ever appears via rename.
+    const writtenPath = mockedWriteFileSync.mock.calls[0]![0] as string
+    expect(writtenPath).not.toBe(configPath)
+    expect(writtenPath.endsWith('.tmp')).toBe(true)
+    expect(mockedRenameSync).toHaveBeenCalledWith(writtenPath, configPath)
+  })
+
+  // The point of the atomic write: `sync` saves this file *after* mutating
+  // the remote firewall, so a partial write would destroy the user's source
+  // of truth while the live firewall had already changed.
+  //
+  // Note a throwing mock can't simulate a genuinely *partial* write — the
+  // guarantee against that comes from the structure, covered by the
+  // "writes via a temp file" test above: the target is never written
+  // directly, so it can never be left half-written.
+  describe('atomicity', () => {
+    it('leaves the previous config intact when the write fails', async () => {
+      writeReal(configPath, JSON.stringify(previousConfig, null, 2))
+      mockedWriteFileSync.mockImplementation(() => {
+        throw new Error('ENOSPC: no space left on device')
+      })
+
+      await expect(saveConfig(validConfig, configPath)).rejects.toThrow('ENOSPC')
+
+      // Untouched — not truncated, not empty, still parseable.
+      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual(previousConfig)
+    })
+
+    it('leaves the previous config intact when the rename fails', async () => {
+      writeReal(configPath, JSON.stringify(previousConfig, null, 2))
+      mockedRenameSync.mockImplementation(() => {
+        throw new Error('EXDEV: cross-device link not permitted')
+      })
+
+      await expect(saveConfig(validConfig, configPath)).rejects.toThrow('EXDEV')
+
+      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual(previousConfig)
+    })
+
+    it('cleans up the temp file when the rename fails', async () => {
+      writeReal(configPath, JSON.stringify(previousConfig, null, 2))
+      mockedRenameSync.mockImplementation(() => {
+        throw new Error('EXDEV')
+      })
+
+      await expect(saveConfig(validConfig, configPath)).rejects.toThrow()
+
+      expect(readdirSync(dir).filter((f) => f.endsWith('.tmp'))).toEqual([])
+    })
+  })
+
+  describe('validation options', () => {
+    const invalidConfig = { rules: [{ name: 'no conditions' }] } as unknown as FirewallConfig
+
+    it('validates and throws by default', async () => {
+      await expect(saveConfig(invalidConfig, configPath)).rejects.toThrow()
+    })
+
+    it('skips validation entirely when validate is false', async () => {
+      await expect(saveConfig(invalidConfig, configPath, { validate: false })).resolves.toBeUndefined()
+    })
+
+    // Regression: the previous default-object-literal signature meant passing
+    // `{ throwOnError: false }` alone left `validate` undefined, so validation
+    // was skipped altogether rather than run-but-not-thrown.
+    it('still validates when only throwOnError is passed, but does not throw', async () => {
+      const spy = jest.spyOn(ValidationService.getInstance(), 'validateConfig')
+
+      await expect(saveConfig(invalidConfig, configPath, { throwOnError: false })).resolves.toBeUndefined()
+
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+  })
+})

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { randomBytes } from 'crypto'
 import { dirname } from 'path'
 import { logger } from '../logger'
 import { ValidationService } from '../services/ValidationService'
@@ -89,18 +90,24 @@ export async function getConfig(
 export async function saveConfig(
   config: FirewallConfig,
   configPath?: string,
-  options: ConfigSaveOptions = { validate: true, throwOnError: true },
+  options: ConfigSaveOptions = {},
 ): Promise<void> {
+  // Destructured defaults rather than a default object literal: a caller
+  // passing `{ throwOnError: false }` alone used to leave `validate`
+  // undefined, silently skipping validation entirely instead of the
+  // "validate but don't throw" it asked for.
+  const { validate = true, throwOnError = true } = options
+
   const filePath = configPath || (await ConfigFinder.findConfig()) || ConfigFinder.getDefaultConfigPath()
 
   // Validate config before saving if requested
-  if (options.validate) {
+  if (validate) {
     try {
       const validator: ValidationService = ValidationService.getInstance()
       validator.validateConfig(config)
     } catch (validationError) {
       logger.error('Config validation failed:', validationError)
-      if (options.throwOnError) {
+      if (throwOnError) {
         throw validationError
       }
     }
@@ -112,7 +119,30 @@ export async function saveConfig(
     mkdirSync(configDir, { recursive: true })
   }
 
-  writeFileSync(filePath, JSON.stringify(config, null, 2))
+  // Write atomically — temp file in the same directory, then rename (atomic
+  // on POSIX within one filesystem).
+  //
+  // A truncated config is worse than no write at all here: `sync` saves this
+  // file *after* mutating the remote firewall, so an interrupted plain write
+  // (Ctrl+C, crash, disk full) would leave the live firewall changed and the
+  // user's source of truth destroyed — the worst possible state to reconcile
+  // from, for a tool whose whole premise is that this file *is* the config.
+  const tempPath = `${filePath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`
+  try {
+    writeFileSync(tempPath, JSON.stringify(config, null, 2))
+    renameSync(tempPath, filePath)
+  } catch (error) {
+    try {
+      if (existsSync(tempPath)) {
+        unlinkSync(tempPath)
+      }
+    } catch {
+      // Best-effort cleanup; surfacing the original write failure matters more
+      // than a leftover temp file.
+    }
+    throw error
+  }
+
   logger.debug(`Config saved to ${filePath}`)
 }
 


### PR DESCRIPTION
Found while reading `config.ts` during #182 work — not tied to an existing issue.

## The problem

`saveConfig` wrote straight to the target:

```ts
writeFileSync(filePath, JSON.stringify(config, null, 2))
```

An interrupted write — Ctrl+C, crash, disk full — leaves `.doorman.json` truncated or empty.

That matters more here than in most places, because **`sync` saves this file *after* mutating the remote firewall** (`syncRules` at sync.ts:146, `saveConfig` at :170). A failed write there leaves the live firewall changed and the user's source of truth destroyed — the worst possible state to reconcile from, for a tool whose entire premise is that this file *is* the configuration. `download` has the same exposure, overwriting the config wholesale from remote state.

## The fix

Write to a temp file in the same directory, then `renameSync` over the target (atomic on POSIX within one filesystem), cleaning up the temp file if anything fails. The target is never written directly, so it can never be observed half-written.

## Also: a latent footgun in the same function

The options default was an object literal:

```ts
options: ConfigSaveOptions = { validate: true, throwOnError: true }
```

So a caller passing `{ throwOnError: false }` alone left `validate` as `undefined` → falsy → **validation skipped entirely**, rather than the "validate but don't throw" it asked for. No current caller does this (both pass `{ validate: false }`), but the next one would have been surprised. Destructured defaults instead.

## Verification

- **Mutation-verified**: reverting to the plain write fails three of the new tests.
- The suite is deliberately honest that a throwing mock **can't** simulate a genuinely partial write — that guarantee comes from the structure, which the `writes via a temp file` test asserts directly (the target only ever appears as the rename destination).
- End-to-end against `demos/mock-server.mjs`: a real `sync` still writes the config correctly (valid JSON, rule-ID write-back intact, no temp files left behind).

## Test plan
- [x] `pnpm compile`
- [x] `pnpm jest` — 76 suites / 1378 tests (9 new)
- [x] `pnpm eslint .` — 0 errors
- [x] Mutation check + end-to-end run described above