### PR TITLE
docs: remove nonexistent --provider flag from init/validate examples

### DIFF
--- a/skills/doorman/references/cicd.md
+++ b/skills/doorman/references/cicd.md
@@ -203,21 +203,21 @@ doorman sync --provider cloudflare --config .doorman.json
 ```bash
 # Migrate rules between providers
 doorman download --provider vercel --config .doorman.json
-doorman validate --provider cloudflare --config .doorman.json
+doorman validate --config .doorman.json
 doorman sync --provider cloudflare --config .doorman.json
 ```
 
 ## Command Flags Reference
 
-Global flags available on all commands:
+Common flags (availability varies by command):
 
-| Flag                                              | Description                                                    |
-| ------------------------------------------------- | -------------------------------------------------------------- |
-| `--config <path>`                                 | Path to config file (default: auto-discovered `.doorman.json`) |
-| `--provider vercel\|cloudflare\|fastly`           | Override provider detection                                    |
-| `--format json\|table\|yaml\|markdown\|terraform` | Output format (command-dependent)                              |
-| `--verbose`                                       | Show detailed output                                           |
-| `--output <path>`                                 | Write output to file instead of stdout                         |
+| Flag                                              | Description                                                                                           |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--config <path>`                                 | Path to config file (default: auto-discovered `.doorman.json`)                                        |
+| `--provider vercel\|cloudflare\|fastly`           | Override provider detection — `sync`/`diff`/`download`/`list`/`status`/`watch`/`backup`/`export` only |
+| `--format json\|table\|yaml\|markdown\|terraform` | Output format (command-dependent)                                                                     |
+| `--verbose`                                       | Show detailed output                                                                                  |
+| `--output <path>`                                 | Write output to file instead of stdout                                                                |
 
 ## Error Handling in Automation
 

--- a/skills/doorman/references/cloudflare.md
+++ b/skills/doorman/references/cloudflare.md
@@ -15,6 +15,7 @@ CLOUDFLARE_ACCOUNT_ID=acc_xxx      # Optional — enables Lists API for bulk IP 
 ### API Token Permissions
 
 Create a Custom Token at https://dash.cloudflare.com/profile/api-tokens with:
+
 - **Zone > Firewall Services > Edit** — for custom rulesets
 - **Account > Account Filter Lists > Edit** — for Lists API (bulk IP management, requires `CLOUDFLARE_ACCOUNT_ID`)
 
@@ -37,13 +38,14 @@ Multi-provider config with explicit provider declaration:
 }
 ```
 
-Or pass `--provider cloudflare` to any command to override the default.
+Or pass `--provider cloudflare` to any provider-aware command (`sync`, `diff`, `download`, `list`, `status`, `watch`, `backup`, `export`) to override auto-detection.
 
 ## Usage
 
+`doorman init` only supports Vercel today — it has no `--provider` flag and doesn't prompt for Cloudflare credentials. Create `.doorman.json` by hand using the config shape above, then:
+
 ```bash
-doorman init --provider cloudflare          # Initialize Cloudflare config
-doorman validate --provider cloudflare      # Validate against Cloudflare constraints
+doorman validate                            # Validate — auto-detects Cloudflare from the config's `provider` field
 doorman sync --provider cloudflare          # Deploy to Cloudflare
 doorman download --provider cloudflare      # Pull rules from Cloudflare
 doorman diff --provider cloudflare          # Compare local vs live
@@ -56,33 +58,33 @@ Doorman translates its unified rule format into Cloudflare Wirefilter expression
 
 ### Field Mapping
 
-| Doorman Type | Cloudflare Field |
-|-------------|------------------|
-| `path` | `http.request.uri.path` |
-| `method` | `http.request.method` |
-| `host` | `http.host` |
-| `user_agent` | `http.user_agent` |
-| `ip_address` | `ip.src` |
-| `header` | `http.request.headers["key"]` |
-| `query` | `http.request.uri.query` |
-| `cookie` | `http.cookie` |
-| `geo_country` | `ip.geoip.country` |
-| `geo_city` | `ip.geoip.city` |
-| `geo_continent` | `ip.geoip.continent` |
-| `geo_country_region` | `ip.geoip.subdivision_1` |
-| `geo_as_number` | `ip.geoip.asnum` |
-| `scheme` | `ssl` (boolean) |
+| Doorman Type         | Cloudflare Field              |
+| -------------------- | ----------------------------- |
+| `path`               | `http.request.uri.path`       |
+| `method`             | `http.request.method`         |
+| `host`               | `http.host`                   |
+| `user_agent`         | `http.user_agent`             |
+| `ip_address`         | `ip.src`                      |
+| `header`             | `http.request.headers["key"]` |
+| `query`              | `http.request.uri.query`      |
+| `cookie`             | `http.cookie`                 |
+| `geo_country`        | `ip.geoip.country`            |
+| `geo_city`           | `ip.geoip.city`               |
+| `geo_continent`      | `ip.geoip.continent`          |
+| `geo_country_region` | `ip.geoip.subdivision_1`      |
+| `geo_as_number`      | `ip.geoip.asnum`              |
+| `scheme`             | `ssl` (boolean)               |
 
 ### Action Mapping
 
-| Doorman Action | Cloudflare Action |
-|---------------|-------------------|
-| `deny` | `block` |
-| `challenge` | `managed_challenge` |
-| `rate_limit` | `block` + `ratelimit` config |
-| `redirect` | `redirect` + `from_value` params |
-| `log` | `log` |
-| `bypass` | `skip` |
+| Doorman Action | Cloudflare Action                |
+| -------------- | -------------------------------- |
+| `deny`         | `block`                          |
+| `challenge`    | `managed_challenge`              |
+| `rate_limit`   | `block` + `ratelimit` config     |
+| `redirect`     | `redirect` + `from_value` params |
+| `log`          | `log`                            |
+| `bypass`       | `skip`                           |
 
 ## Lists API (Bulk IP Management)
 
@@ -97,16 +99,16 @@ Without `CLOUDFLARE_ACCOUNT_ID`, IP blocking falls back to individual WAF rules 
 
 ## Limitations & Differences
 
-| Feature | Vercel | Cloudflare | Notes |
-|---------|--------|------------|-------|
-| `re` operator | All plans | Enterprise only | Use `sub`/`pre`/`suf` as alternatives |
-| `environment` type | Yes | No | Vercel-specific concept |
-| `ja3_digest`/`ja4_digest` | Yes | No | Vercel TLS fingerprints |
-| `region` type | Yes | No | Vercel edge region |
-| IP Lists (bulk) | Individual rules | Lists API | Cloudflare needs `accountId` |
-| Max custom rules | ~100 | 5-125 (plan dependent) | Free: 5, Pro: 20, Business: 100, Enterprise: 125+ |
-| Rate limit | Via rule action | Separate phase | Different underlying mechanism |
-| Rule order | Parallel evaluation | Sequential (first match wins) | Ordering matters on Cloudflare |
+| Feature                   | Vercel              | Cloudflare                    | Notes                                             |
+| ------------------------- | ------------------- | ----------------------------- | ------------------------------------------------- |
+| `re` operator             | All plans           | Enterprise only               | Use `sub`/`pre`/`suf` as alternatives             |
+| `environment` type        | Yes                 | No                            | Vercel-specific concept                           |
+| `ja3_digest`/`ja4_digest` | Yes                 | No                            | Vercel TLS fingerprints                           |
+| `region` type             | Yes                 | No                            | Vercel edge region                                |
+| IP Lists (bulk)           | Individual rules    | Lists API                     | Cloudflare needs `accountId`                      |
+| Max custom rules          | ~100                | 5-125 (plan dependent)        | Free: 5, Pro: 20, Business: 100, Enterprise: 125+ |
+| Rate limit                | Via rule action     | Separate phase                | Different underlying mechanism                    |
+| Rule order                | Parallel evaluation | Sequential (first match wins) | Ordering matters on Cloudflare                    |
 
 ## Translation Warnings
 
@@ -117,7 +119,7 @@ The `RuleTranslator` surfaces warnings when a translation is lossy:
 - **Duration differences** — `actionDuration` maps differently between providers
 - **Negation edge cases** — complex negated conditions may produce subtly different behavior in Wirefilter
 
-Run `doorman validate --provider cloudflare` to surface warnings before deploying.
+Run `doorman validate` to surface warnings before deploying — it auto-detects Cloudflare from the config's `provider` field.
 
 ## Cloudflare-Specific Validation
 
@@ -166,9 +168,7 @@ The `CloudflareOptimizer` consolidates rules for efficient deployment:
       "name": "Rate Limit API",
       "description": "Limit API requests to 100/min per IP",
       "active": true,
-      "conditionGroup": [
-        { "conditions": [{ "type": "path", "op": "pre", "value": "/api/" }] }
-      ],
+      "conditionGroup": [{ "conditions": [{ "type": "path", "op": "pre", "value": "/api/" }] }],
       "action": {
         "mitigate": {
           "action": "rate_limit",
@@ -181,8 +181,6 @@ The `CloudflareOptimizer` consolidates rules for efficient deployment:
       }
     }
   ],
-  "ips": [
-    { "ip": "203.0.113.0/24", "action": "deny", "notes": "Known attack subnet" }
-  ]
+  "ips": [{ "ip": "203.0.113.0/24", "action": "deny", "notes": "Known attack subnet" }]
 }
 ```

--- a/skills/doorman/references/fastly.md
+++ b/skills/doorman/references/fastly.md
@@ -33,13 +33,14 @@ Multi-provider config with explicit provider declaration:
 }
 ```
 
-Or pass `--provider fastly` to any command to override the default.
+Or pass `--provider fastly` to any provider-aware command (`sync`, `diff`, `download`, `list`, `status`, `watch`, `backup`, `export`) to override auto-detection.
 
 ## Usage
 
+`doorman init` only supports Vercel today — it has no `--provider` flag and doesn't prompt for Fastly credentials. Create `.doorman.json` by hand using the config shape above, then:
+
 ```bash
-doorman init --provider fastly          # Initialize Fastly config
-doorman validate --provider fastly      # Validate against Fastly constraints
+doorman validate                        # Validate — auto-detects Fastly from the config's `provider` field
 doorman sync --provider fastly          # Deploy to Fastly
 doorman download --provider fastly      # Pull rules from Fastly
 doorman diff --provider fastly          # Compare local vs live


### PR DESCRIPTION
## Summary

`skills/doorman/references/cloudflare.md` and `fastly.md` documented `doorman init --provider <name>` and `doorman validate --provider <name>` as valid usage. Neither flag exists:

- `init.ts` has no `--provider` option at all — it always creates a legacy Vercel-shaped config (`createEmptyConfig()` + `projectId`/`teamId` prompts) regardless of what's passed.
- `validate.ts` has no `--provider` option either — it auto-detects the config shape from the file's own content (`hasProviderMetadata`) and validates against the matching schema.

Since `bin/run.ts` doesn't run yargs in `.strict()` mode, passing `--provider` to either command doesn't error — it's silently ignored. Verified empirically before writing the fix:

```bash
$ doorman init --provider cloudflare --interactive=false --force --config test.json
$ cat test.json
{ "$schema": "...", "firewallEnabled": true, "rules": [], "ips": [] }   # plain Vercel shape, no provider fields

$ doorman validate --config <hand-authored-cloudflare-config>   # no --provider needed
✔ Configuration is valid
```

Anyone following the docs literally to set up Cloudflare or Fastly got a broken, silently-wrong Vercel config with no error message explaining why.

## Why fix the docs instead of implementing the flag

This is the same bug class as #99, which found (and fixed, directly in the wiki) the identical `init --provider cloudflare` / `validate --provider` claims in `Cloudflare-Setup.md` / `Commands-Overview.md`. That issue's resolution was to document the real path — hand-author the config — rather than add the flag, and the wiki has carried that fix (now covering Fastly too) ever since.

That resolution still holds:
- `.kiro/steering/adding-a-provider.md`'s "what a new provider touches" checklist — updated same-day for Fastly (#186) — never lists `init.ts` as something a provider adds.
- `validate.ts` was clearly built to auto-detect from config content, not to take a provider flag; that's not an oversight, it's the design.
- No commit in `init.ts`'s history ever added provider-flag logic — this was never a regression, just docs that were aspirational from the `unified-config-v2`/`cloudflare-production-readiness` spec stage and never implemented.

`skills/doorman/references/` just wasn't in #99's scope (that pass only touched the wiki), so the same bug persisted there untouched.

## What's fixed

Beyond the two originally-reported lines (`cloudflare.md:45`, `fastly.md:41`), a repo-wide sweep for the same claim (`init --provider` / `validate --provider` / "provider available on all commands") found two more living-doc instances of the identical bug and fixed those too, for consistency with #99's own multi-page scope:

- `cloudflare.md` — Usage block (`init`/`validate` lines) + a second `validate --provider cloudflare` in the Translation Warnings section
- `fastly.md` — Usage block
- `cicd.md` — a `validate --provider cloudflare` in the provider-migration example, and the "Global flags available on all commands" table, which listed `--provider` as global (it's only on `sync`/`diff`/`download`/`list`/`status`/`watch`/`backup`/`export`)

`.kiro/specs/*` and `RELEASE-2.0.md` still contain the old `init --provider` phrasing but were left untouched — they're frozen historical records per this repo's convention, not living docs.

## Verification

- `pnpm compile && pnpm eslint .` clean (0 errors)
- `pnpm jest`: 1435/1435 passing (pre-commit hook's own full run also went 1435/1435 — the `CloudflarePerformanceBenchmarks` timing test flaked once on an interactive `pnpm jest` run beforehand, isolated and confirmed clean on rerun, consistent with the known-flaky pattern from #205)
- Empirically ran `doorman init --provider cloudflare` and `--provider fastly` (confirmed both silently produce a plain Vercel config) and `doorman validate` with no `--provider` against hand-authored Cloudflare and Fastly configs (confirmed both validate successfully) before writing the corrected doc text
- Docs-only change; no source files touched

## Test plan

- [x] `pnpm compile`
- [x] `pnpm eslint .`
- [x] `pnpm jest` (full suite)
- [x] Manual CLI verification of `init --provider <name>` and `validate` (no flag) against real config files for both Cloudflare and Fastly
