### PR TITLE
fix: stop hard-requiring VERCEL_TEAM_ID for Vercel provider

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -36,7 +36,8 @@ export const handler = async (_argv: Arguments<SetupOptions>) => {
   logger.log('   • Click on your team name in the top-left')
   logger.log('   • Go to Team Settings → General')
   logger.log('   • Copy the Team ID')
-  logger.log('   • Leave empty if using personal account')
+  logger.log('   • Leave empty to use your Vercel default team (every account has one)')
+  logger.log('   • Belong to more than one team? Set this explicitly, or doorman will use whichever is your default')
   logger.log('')
 
   // Step 3: API Token

--- a/src/lib/providers/__tests__/Providers.test.ts
+++ b/src/lib/providers/__tests__/Providers.test.ts
@@ -108,10 +108,11 @@ describe('VercelProvider', () => {
       expect(() => VercelProvider.fromEnv()).toThrow(/VERCEL_PROJECT_ID/)
     })
 
-    it('throws when VERCEL_TEAM_ID is missing', () => {
+    it('creates a provider when VERCEL_TEAM_ID is missing — every Vercel account has a default team (regression test for #207)', () => {
       process.env.VERCEL_TOKEN = 'token'
       process.env.VERCEL_PROJECT_ID = 'project'
-      expect(() => VercelProvider.fromEnv()).toThrow(/VERCEL_TEAM_ID/)
+      const provider = VercelProvider.fromEnv()
+      expect(provider.name).toBe('vercel')
     })
   })
 
@@ -135,6 +136,11 @@ describe('VercelProvider', () => {
 
     it('throws when token is missing from both config and env', () => {
       expect(() => VercelProvider.fromConfig({})).toThrow(/token/)
+    })
+
+    it('creates a provider without a teamId (regression test for #207)', () => {
+      const provider = VercelProvider.fromConfig({ token: 'token', projectId: 'project' })
+      expect(provider.name).toBe('vercel')
     })
   })
 

--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -56,12 +56,12 @@ export class VercelClient extends BaseFirewallClient {
   /**
    * Creates an instance of VercelClient.
    * @param projectId - The ID of the Vercel project.
-   * @param teamId - The ID of the Vercel team.
+   * @param teamId - The ID of the Vercel team. Omit for a personal (non-team) account.
    * @param token - The authentication token for the Vercel API.
    */
   constructor(
     private projectId: string,
-    private teamId: string,
+    private teamId: string | undefined,
     private token: string,
   ) {
     // No static base path because URLs are constructed per-request with query params
@@ -85,7 +85,13 @@ export class VercelClient extends BaseFirewallClient {
   private getUrl(configVersion?: number): string {
     const baseUrl = configVersion !== undefined ? `${VERCEL_API_BASE_URL}/${configVersion}` : VERCEL_API_BASE_URL
     logger.debug('API URL:', baseUrl)
-    return `${baseUrl}?projectId=${this.projectId}&teamId=${this.teamId}`
+    // teamId is omitted entirely (not sent as an empty/`undefined` literal)
+    // when absent. Every Vercel account — including a Hobby account — is a
+    // team with its own Team ID; omitting the param doesn't mean "no team",
+    // it tells Vercel to resolve the request against the token's *default*
+    // team. Only matters if the caller belongs to more than one team.
+    const teamParam = this.teamId ? `&teamId=${this.teamId}` : ''
+    return `${baseUrl}?projectId=${this.projectId}${teamParam}`
   }
 
   // Note: response handling is centralized in BaseFirewallClient.makeRequest

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -66,7 +66,11 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
         providers: {
           vercel: {
             projectId: this.client['projectId'],
-            teamId: this.client['teamId'],
+            // Omitted entirely (not set to `undefined`/`''`) when the client
+            // has no explicit team ID — an unconditionally-set optional
+            // field is exactly the isDeepEqual/diffing pitfall documented
+            // in #199/#203.
+            ...(this.client['teamId'] ? { teamId: this.client['teamId'] } : {}),
           },
         },
         rules,

--- a/src/lib/providers/vercel/VercelProvider.ts
+++ b/src/lib/providers/vercel/VercelProvider.ts
@@ -30,10 +30,10 @@ export class VercelProvider {
       throw new Error('VERCEL_PROJECT_ID environment variable is required')
     }
 
-    if (!teamId) {
-      throw new Error('VERCEL_TEAM_ID environment variable is required')
-    }
-
+    // teamId is intentionally not validated here — omitting it lets Vercel
+    // resolve the request against the token's default team, which is fine
+    // for anyone with just one team. Explicit teamId only matters for
+    // callers that belong to more than one and want a non-default one.
     const client = new VercelClient(projectId, teamId, token)
     return new VercelFirewallService(client)
   }
@@ -54,10 +54,7 @@ export class VercelProvider {
       throw new Error('Vercel project ID is required (provide projectId or set VERCEL_PROJECT_ID env var)')
     }
 
-    if (!teamId) {
-      throw new Error('Vercel team ID is required (provide teamId or set VERCEL_TEAM_ID env var)')
-    }
-
+    // teamId is intentionally not validated here — see fromEnv() above.
     logger.debug('Creating Vercel provider with config:', {
       projectId,
       teamId,

--- a/src/lib/providers/vercel/__tests__/VercelClient.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelClient.test.ts
@@ -105,6 +105,22 @@ describe('VercelClient', () => {
       expect(calledUrl).toContain(`teamId=${teamId}`)
     })
 
+    // Regression test for #207: a client constructed with no teamId (every
+    // Vercel account has a default team, so omitting it is valid) must omit
+    // the query param entirely rather than sending the literal string
+    // `teamId=undefined`, which would not resolve to the intended team.
+    it('omits teamId from the URL entirely when the client was constructed without one', async () => {
+      const clientWithoutTeam = new VercelClient(projectId, undefined, token)
+      jest.spyOn(clientWithoutTeam as any, 'delay').mockResolvedValue(undefined)
+      fetchSpy.mockResolvedValue(createMockResponse(mockVercelConfig))
+
+      await clientWithoutTeam.fetchFirewallConfig()
+
+      const calledUrl = fetchSpy.mock.calls[0]![0] as string
+      expect(calledUrl).toContain(`projectId=${projectId}`)
+      expect(calledUrl).not.toContain('teamId')
+    })
+
     it('should fetch a specific config version', async () => {
       const versionConfig = { ...mockVercelConfig.active, version: 5 }
       fetchSpy.mockResolvedValue(createMockResponse(versionConfig))

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -131,6 +131,22 @@ describe('VercelFirewallService', () => {
       expect(result.providers?.vercel).toEqual({ projectId: 'proj_123', teamId: 'team_456' })
     })
 
+    // Regression test for #207: a client with no teamId (every Vercel
+    // account has a default team, so this is a normal, supported case) must
+    // omit the key entirely from providers.vercel rather than setting it to
+    // `undefined` — an unconditionally-set optional key is exactly the
+    // isDeepEqual/diffing pitfall documented in #199/#203.
+    it('omits teamId from providers.vercel when the client has none', async () => {
+      const clientWithoutTeam = new VercelClient('proj_123', undefined, 'test-token')
+      const serviceWithoutTeam = new VercelFirewallService(clientWithoutTeam)
+      jest.spyOn(clientWithoutTeam, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
+
+      const result = await serviceWithoutTeam.fetchConfig()
+
+      expect(result.providers?.vercel).toEqual({ projectId: 'proj_123' })
+      expect(result.providers?.vercel).not.toHaveProperty('teamId')
+    })
+
     it('should pass version parameter to client', async () => {
       const spy = jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
 

--- a/src/lib/providers/vercel/credentials.ts
+++ b/src/lib/providers/vercel/credentials.ts
@@ -27,7 +27,11 @@ export const vercelCredentials: CredentialDescriptor = {
       key: 'teamId',
       envVar: 'VERCEL_TEAM_ID',
       label: 'Vercel Team ID',
-      required: true,
+      // Omitting it is safe — Vercel resolves the request against the
+      // token's default team, and doorman's own config schema already
+      // treats it as optional (see issue #207). Only needed explicitly by
+      // callers who belong to more than one team and want a non-default one.
+      required: false,
       configKey: 'teamId',
     },
   ],

--- a/src/lib/ui/__tests__/promptForCredentials.test.ts
+++ b/src/lib/ui/__tests__/promptForCredentials.test.ts
@@ -41,4 +41,19 @@ describe('promptForCredentials', () => {
 
     expect(promptSecretMock).not.toHaveBeenCalled()
   })
+
+  // Regression test for #207: a blank answer means "use my Vercel default
+  // team" (every account has one), not an invalid/incomplete answer — it
+  // must resolve to `undefined`, not the literal empty string.
+  it('resolves teamId to undefined when the user leaves the prompt blank', async () => {
+    promptMock.mockImplementation((message: string) => {
+      if (message.includes('Team ID')) return Promise.resolve('')
+      if (message.includes('Project ID')) return Promise.resolve('typed-project')
+      throw new Error(`Unexpected prompt: ${message}`)
+    })
+
+    const result = await promptForCredentials({})
+
+    expect(result).toEqual({ token: 'typed-token', teamId: undefined, projectId: 'typed-project' })
+  })
 })

--- a/src/lib/ui/promptForCredentials.ts
+++ b/src/lib/ui/promptForCredentials.ts
@@ -5,7 +5,7 @@ export async function promptForCredentials(args: {
   token?: string
   teamId?: string
   projectId?: string
-}): Promise<{ token: string; teamId: string; projectId: string }> {
+}): Promise<{ token: string; teamId?: string; projectId: string }> {
   const token =
     args.token ||
     process.env.VERCEL_TOKEN ||
@@ -13,13 +13,17 @@ export async function promptForCredentials(args: {
       `What is your Vercel API Auth Token? (https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token#creating-an-access-token) `,
     ))
 
-  const teamId =
+  const teamIdAnswer =
     args.teamId ||
     process.env.VERCEL_TEAM_ID ||
     (await prompt(
-      `What is your Vercel Team ID? (See https://vercel.com/docs/accounts/create-a-team#find-your-team-id)`,
+      `What is your Vercel Team ID? Leave blank to use your Vercel default team (every account, including Hobby, is a team). Only needed if you belong to more than one team and want to target a non-default one. (See https://vercel.com/docs/accounts#find-your-team-id)`,
       { type: 'text' },
     ))
+  // An empty answer means "use my Vercel default team" — normalize to
+  // `undefined` rather than carrying a `''` team ID through to the API
+  // client, which omits the param entirely and lets Vercel resolve it.
+  const teamId = teamIdAnswer || undefined
 
   const projectId =
     args.projectId ||

--- a/src/lib/utils/__tests__/providerHelper.test.ts
+++ b/src/lib/utils/__tests__/providerHelper.test.ts
@@ -234,6 +234,25 @@ describe('providerHelper', () => {
       )
     })
 
+    // Regression test for #207: token + projectId alone must be enough in
+    // non-interactive mode (e.g. CI). A missing teamId just means "use my
+    // Vercel default team" and must never throw or block on its own.
+    it('does not throw for Vercel in non-interactive mode when only teamId is missing', async () => {
+      process.env.VERCEL_TOKEN = 'token'
+      process.env.VERCEL_PROJECT_ID = 'proj'
+
+      const { provider, vercelCredentials } = await getProviderInstance({
+        provider: 'vercel',
+        interactive: false,
+      })
+
+      expect(provider.name).toBe('vercel')
+      expect(vercelCredentials?.teamId).toBeUndefined()
+      expect(VercelProvider.fromConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'token', projectId: 'proj', teamId: undefined }),
+      )
+    })
+
     it('throws for Cloudflare when credentials missing and non-interactive', async () => {
       await expect(getProviderInstance({ provider: 'cloudflare', interactive: false })).rejects.toThrow(
         /credentials missing/,

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -46,7 +46,7 @@ export interface ProviderInstanceResult {
    * prompted the user interactively, and prompting again would ask for the
    * same values a second time.
    */
-  vercelCredentials?: { token: string; projectId: string; teamId: string }
+  vercelCredentials?: { token: string; projectId: string; teamId?: string }
 }
 
 /**
@@ -123,9 +123,13 @@ async function getVercelProvider(options: ProviderOptions): Promise<ProviderInst
     },
   })
 
-  if (!token || !projectId || !teamId) {
+  // teamId is deliberately excluded from this completeness check — omitting
+  // it just means "use my Vercel default team" (every account has one), so
+  // its absence alone must never block a user or force a re-prompt (see
+  // issue #207).
+  if (!token || !projectId) {
     if (options.interactive === false) {
-      throw new Error('Vercel credentials missing. Provide token, projectId, and teamId.')
+      throw new Error('Vercel credentials missing. Provide token and projectId.')
     }
 
     logger.warn('Missing Vercel credentials')

--- a/src/tests/testHelpers/providerMocks.ts
+++ b/src/tests/testHelpers/providerMocks.ts
@@ -96,11 +96,11 @@ export function mockVercelClientPrototype(
   MockedVercelClient.mockImplementation(function (
     this: VercelClient,
     projectId: string,
-    teamId: string,
+    teamId: string | undefined,
     token: string,
   ) {
     Object.assign(this, { projectId, teamId, token })
-  } as unknown as (projectId: string, teamId: string, token: string) => VercelClient)
+  } as unknown as (projectId: string, teamId: string | undefined, token: string) => VercelClient)
 
   MockedVercelClient.prototype.fetchFirewallConfig = jest.fn().mockResolvedValue(config) as any
   MockedVercelClient.prototype.createFirewallRule = jest


### PR DESCRIPTION
## Summary

Fixes #207. Every doorman command except `init` hard-failed with `Vercel team ID is required` whenever `VERCEL_TEAM_ID` wasn't set — contradicting `setup.ts`, `README.md`, `init.ts`, and doorman's own config schema, all of which already treat it as optional (`init.ts` even has a working "Are you using a Vercel team account?" flow that only asks for one if you say yes).

**Correction from the issue discussion, worth restating here**: omitting `teamId` does *not* mean "no team" — every Vercel account, including a free Hobby one, is itself a team with its own Team ID (confirmed against Vercel's own docs after being challenged on this — see the issue thread). Omitting it means "use whichever team is currently my Vercel default," which is exactly what Vercel's REST API supports (`teamId` is documented as an optional param platform-wide). That's the behavior this PR restores; the risk it doesn't solve is a user who belongs to more than one team silently getting their default team if they don't set one explicitly — `setup.ts`'s copy now calls that out.

## Changes

- `VercelClient`: `teamId` is now `string | undefined`; `getUrl()` omits the `teamId` query param entirely when absent, instead of baking in the literal string `teamId=undefined`.
- `VercelProvider.fromEnv()` / `fromConfig()`: dropped the "team ID is required" throws.
- `src/lib/providers/vercel/credentials.ts`: `teamId.required` → `false`.
- `providerHelper.ts`: `getVercelProvider`'s completeness check no longer includes `teamId` — a missing team ID alone never blocks or forces a re-prompt.
- `promptForCredentials.ts`: the team ID prompt can be left blank; a blank answer normalizes to `undefined` rather than being carried through as `''` (previously, even trying to "skip" by hitting enter would immediately hit the same required-field error).
- `VercelFirewallService.fetchConfig()`: `providers.vercel.teamId` is now omitted entirely (not set to `undefined`) when the client has none — an unconditionally-set optional key is the same `isDeepEqual`/diffing pitfall documented in #199/#203.
- `setup.ts`: updated the Team ID guidance to explain the default-team behavior and call out the multi-team case.

## Test plan

- [x] `pnpm compile && pnpm jest && pnpm eslint .` clean (1440/1440 tests; one `CloudflarePerformanceBenchmarks` timing assertion flaked on the full run, confirmed unrelated by re-running that file alone — 19/19 passed; this PR touches no Cloudflare code)
- [x] Mutation-verified every new/changed assertion: stashed just the 6 source fix files (keeping the new tests), confirmed all 5 new/changed tests fail with on-point messages against the old code (`VERCEL_TEAM_ID environment variable is required`, a TS2345 type error on the now-optional constructor param, `teamId: ''` instead of `undefined`, etc.), then restored the fix and confirmed green again.
- [x] End-to-end against `demos/mock-server.mjs`: built the CLI, ran `doorman list --ci --provider vercel` with only `VERCEL_TOKEN`/`VERCEL_PROJECT_ID` set (no `VERCEL_TEAM_ID`) against the mock server — exited 0 and listed rules; the mock server's logged request URL was `/v1/security/firewall/config?projectId=prj_demo123` with `teamId` completely absent. Re-ran with `VERCEL_TEAM_ID` set too, to confirm the existing team-account path is unaffected (exit 0, same output).
