### PR TITLE
fix: stop polluting stdout so --format json is actually valid JSON

### DIFF
--- a/src/commands/__tests__/diff.test.ts
+++ b/src/commands/__tests__/diff.test.ts
@@ -3,6 +3,7 @@ import { logger } from '../../lib/logger'
 import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
 import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { getStdoutText } from '../../tests/testHelpers/loggerMock'
 import { handler } from '../diff'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
@@ -27,6 +28,27 @@ describe('diff command', () => {
     await handler({ provider: 'vercel', token: 't', projectId: 'prj', teamId: 'team', debug: false, ci: true } as any)
 
     expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('No differences found'))
+  })
+
+  it('still outputs valid JSON when format is json and configs match (regression test for #209)', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    // Previously this case never reached the format check at all — the
+    // no-changes branch returned a plain sentence regardless of --format.
+    expect(logger.success).not.toHaveBeenCalled()
+    const stdout = getStdoutText(logger as any)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.summary.hasChanges).toBe(false)
   })
 
   it('prints rule changes for the Vercel provider as JSON when format is json', async () => {
@@ -57,6 +79,11 @@ describe('diff command', () => {
     expect(jsonCall).toBeDefined()
     const parsed = JSON.parse(jsonCall![0])
     expect(parsed.rules.toAdd).toHaveLength(1)
+
+    // Whole-stream check — the "Calculating differences..." spinner used to
+    // print unconditionally ahead of this, on the same stdout stream.
+    const stdout = getStdoutText(logger as any)
+    expect(() => JSON.parse(stdout)).not.toThrow()
   })
 
   it('reports differences for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/__tests__/export.test.ts
+++ b/src/commands/__tests__/export.test.ts
@@ -3,6 +3,7 @@ import { logger } from '../../lib/logger'
 import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
 import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { getStdoutText } from '../../tests/testHelpers/loggerMock'
 import { handler } from '../export'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
@@ -59,6 +60,21 @@ describe('export command', () => {
 
     const logged = (logger.log as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
     expect(JSON.parse(logged)).toEqual(localVercelConfig)
+  })
+
+  it('writes nothing but the payload to stdout for any format when no --output is given (regression test for #209)', async () => {
+    mockedGetConfig.mockResolvedValue(localVercelConfig as any)
+
+    // Whole-stream check across every logger method — the "Exporting
+    // configuration in ... format..." spinner used to print unconditionally
+    // on stdout ahead of the payload, for every format, not just json.
+    await handler({ source: 'local', format: 'json', debug: false, ci: true } as any)
+    expect(() => JSON.parse(getStdoutText(logger as any))).not.toThrow()
+
+    jest.clearAllMocks()
+    mockedGetConfig.mockResolvedValue(localVercelConfig as any)
+    await handler({ source: 'local', format: 'markdown', debug: false, ci: true } as any)
+    expect(getStdoutText(logger as any)).not.toContain('Exporting configuration')
   })
 
   it('exports the local config as markdown to stdout', async () => {

--- a/src/commands/__tests__/list.test.ts
+++ b/src/commands/__tests__/list.test.ts
@@ -6,6 +6,7 @@ import {
   mockVercelClientPrototype,
   emptyCloudflareRuleset,
 } from '../../tests/testHelpers/providerMocks'
+import { getStdoutText } from '../../tests/testHelpers/loggerMock'
 import { handler } from '../list'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
@@ -90,12 +91,28 @@ describe('list command', () => {
       ci: true,
     } as any)
 
-    const jsonCall = (logger.info as unknown as jest.Mock).mock.calls.find((call) =>
-      String(call[0]).includes('"rules"'),
-    )
+    const jsonCall = (logger.log as unknown as jest.Mock).mock.calls.find((call) => String(call[0]).includes('"rules"'))
     expect(jsonCall).toBeDefined()
     const parsed = JSON.parse(jsonCall![0])
     expect(parsed.rules).toHaveLength(1)
+  })
+
+  it('writes nothing but the JSON payload to stdout when format is json (regression test for #209)', async () => {
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    // Whole-stream check, not a single mock call — see getStdoutText's
+    // docstring for why the bug this guards against shipped past
+    // per-call-only assertions in the first place.
+    const stdout = getStdoutText(logger as any)
+    expect(() => JSON.parse(stdout)).not.toThrow()
   })
 
   it('lists rules for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -71,19 +71,21 @@ async function diffWithProvider(
   config: UnifiedConfig,
   argv: Arguments<DiffOptions>,
 ): Promise<void> {
-  logger.start('Calculating differences...')
-  const changes = await provider.getChanges(config)
+  const isJson = argv.format === 'json'
 
-  if (!changes.hasChanges) {
-    logger.success(chalk.green('No differences found. Local and remote configurations are in sync.'))
-    return
+  if (!isJson) {
+    logger.start('Calculating differences...')
   }
+  const changes = await provider.getChanges(config)
 
   const ipsToAdd = changes.ipsToAdd ?? []
   const ipsToUpdate = changes.ipsToUpdate ?? []
   const ipsToDelete = changes.ipsToDelete ?? []
 
-  if (argv.format === 'json') {
+  // Checked before the no-changes early return below — an in-sync config is
+  // a valid, common result, and `--format json` must produce parseable JSON
+  // for it too, not silently fall back to a human sentence. See #209.
+  if (isJson) {
     logger.log(
       JSON.stringify(
         {
@@ -103,6 +105,11 @@ async function diffWithProvider(
         2,
       ),
     )
+    return
+  }
+
+  if (!changes.hasChanges) {
+    logger.success(chalk.green('No differences found. Local and remote configurations are in sync.'))
     return
   }
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -202,6 +202,14 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
     // (for every provider), so a remote JSON export no longer leaks
     // API-only fields (id, crs, projectKey, ownerId, valid,
     // validationErrors) the way a raw Vercel API response used to.
+    // No `--output` (or `-`) means the payload itself goes to stdout, so any
+    // progress chrome printed ahead of it would land in the same stream a
+    // caller might pipe or redirect (`doorman export --format json | jq`,
+    // `... --format markdown > report.md`) — confirmed this isn't json-only,
+    // every format is affected when redirected. Suppressed rather than moved
+    // to stderr, matching list.ts/diff.ts; see #209.
+    const isStdout = argv.output === '-' || !argv.output
+
     let config: FirewallConfig | UnifiedConfig
 
     if (argv.source === 'remote') {
@@ -222,7 +230,7 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
           errorContext: 'exporting configuration',
         },
         async ({ provider }) => {
-          logger.start('Fetching remote configuration...')
+          if (!isStdout) logger.start('Fetching remote configuration...')
           config = await provider.fetchConfig()
         },
       )
@@ -230,7 +238,7 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
       config = await getConfig(argv.config)
     }
 
-    logger.start(`Exporting configuration in ${argv.format} format...`)
+    if (!isStdout) logger.start(`Exporting configuration in ${argv.format} format...`)
 
     let output: string
     let defaultExtension: string
@@ -273,7 +281,7 @@ export const handler = async (argv: Arguments<ExportOptions>) => {
 
     const outputPath = argv.output || `firewall-export.${defaultExtension}`
 
-    if (argv.output === '-' || !argv.output) {
+    if (isStdout) {
       logger.log(output)
     } else {
       writeFileSync(outputPath, output, 'utf8')

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -110,7 +110,15 @@ export const handler = async (argv: Arguments<ListOptions>) => {
  * assume the Vercel-specific rule shape (conditionGroup/action.mitigate).
  */
 async function listWithProvider(provider: IFirewallProvider, argv: Arguments<ListOptions>): Promise<void> {
-  logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
+  const isJson = argv.format === 'json'
+
+  // Progress/status lines are human-facing chrome, not part of the `json`
+  // contract — `doorman list --format json | jq .` needs stdout to contain
+  // nothing but the payload. Suppressed rather than moved to stderr to avoid
+  // a second logger stream just for this; see #209.
+  if (!isJson) {
+    logger.start(`Fetching firewall configuration${argv.configVersion ? ` version ${argv.configVersion}` : ''} ...`)
+  }
 
   const liveConfig = await provider.fetchConfig(argv.configVersion)
   const rules = liveConfig.rules
@@ -118,17 +126,19 @@ async function listWithProvider(provider: IFirewallProvider, argv: Arguments<Lis
   const version = liveConfig.metadata?.version ?? liveConfig.version
   const updatedAt = liveConfig.metadata?.updatedAt
 
+  if (isJson) {
+    // logger.log (not logger.info) — info prepends consola's ℹ icon, which
+    // would corrupt the payload the same way the suppressed lines above did.
+    logger.log(JSON.stringify({ version, updatedAt, rules, ips }, null, 2))
+    return
+  }
+
   logger.info(
     `Found ${chalk.cyan(rules.length)} custom rules and ${chalk.cyan(ips.length)} IP blocking rules\n` +
       chalk.dim(
         `Version: ${chalk.yellow(version ?? 'unknown')}${updatedAt ? ` • Last Updated: ${chalk.yellow(updatedAt)}` : ''}`,
       ),
   )
-
-  if (argv.format === 'json') {
-    logger.info(JSON.stringify({ version, updatedAt, rules, ips }, null, 2))
-    return
-  }
 
   if (rules.length === 0 && ips.length === 0) {
     logger.info(chalk.yellow('No rules found'))

--- a/src/tests/testHelpers/loggerMock.ts
+++ b/src/tests/testHelpers/loggerMock.ts
@@ -25,3 +25,46 @@ export function createLoggerMock() {
     level: 3,
   }
 }
+
+/**
+ * consola methods excluded by getStdoutText below: `warn`/`error`/`fatal`/
+ * `fail` write to stderr in the real CLI, and `debug`/`verbose`/`trace`/
+ * `silent` are gated by consola's default log level (3, matching this
+ * mock's `level: 3`) and print nothing at all unless `--debug` raises it —
+ * unlike this mock, where every method is an unconditional jest.fn() with
+ * no level-gating, so calling one always records a call whether or not the
+ * real CLI would have printed anything.
+ */
+const NON_DEFAULT_STDOUT_METHODS = new Set(['warn', 'error', 'fatal', 'fail', 'debug', 'verbose', 'trace', 'silent'])
+
+/**
+ * Reconstructs, in real invocation order, everything a command actually
+ * wrote to stdout — across *every* mocked logger method, not just one.
+ *
+ * Inspecting a single method's calls (e.g. `logger.log.mock.calls`) misses
+ * pollution from a different method (`logger.start`, `logger.info`) that
+ * lands on the same real stdout stream ahead of or after it — which is
+ * exactly how the #209 JSON-format bugs shipped with passing tests: each
+ * test checked one method in isolation, never what a real
+ * `doorman ... --format json | jq` pipeline would receive. Use this instead
+ * whenever a test needs to assert something about the whole output stream
+ * (e.g. "this is valid, parseable JSON with nothing else mixed in").
+ */
+export function getStdoutText(logger: ReturnType<typeof createLoggerMock>): string {
+  const calls: { order: number; text: string }[] = []
+
+  for (const [name, fn] of Object.entries(logger)) {
+    if (NON_DEFAULT_STDOUT_METHODS.has(name) || !jest.isMockFunction(fn)) continue
+    fn.mock.calls.forEach((args: unknown[], i: number) => {
+      calls.push({
+        order: fn.mock.invocationCallOrder[i] ?? 0,
+        text: args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '),
+      })
+    })
+  }
+
+  return calls
+    .sort((a, b) => a.order - b.order)
+    .map((c) => c.text)
+    .join('\n')
+}


### PR DESCRIPTION
Fixes #209.

## Problem

`list`, `diff`, and `export` all print human progress/status text to stdout unconditionally, ahead of the structured payload — so `doorman list --format json | jq .` (the exact workflow SKILL.md and `cicd.md` document for CI/scripting) fails to parse. Full detail and repro in #209; summary:

- `list.ts` / `export.ts`: a `logger.start(...)` spinner (and, for `list`, a `logger.info('Found N rules...')` line too) print before `argv.format` is even checked. `list`'s JSON payload was also emitted via `logger.info(JSON.stringify(...))`, which prepends consola's `ℹ` icon — corrupting it even in isolation.
- `diff.ts`: worse — the no-changes case returns a plain sentence before the `--format === 'json'` branch is ever reached, regardless of what format was requested.
- Confirmed while testing that `export`'s pollution isn't json-specific: `doorman export --format markdown > report.md` gets the same spinner line as its first line. Fixed generally (gated on "is output going to stdout at all", not on format) rather than just for json — same root cause, and leaving markdown/yaml/terraform partially broken after fixing json only would leave the acceptance criteria half-met.

## Fix

- `list.ts`, `diff.ts`: suppress the progress spinner (and, for `list`, the status line) when `--format json`; route the JSON payload through `logger.log` instead of `logger.info`.
- `diff.ts`: check `argv.format === 'json'` before the `hasChanges` early return, so an in-sync config still produces `{"summary":{"hasChanges":false},...}` instead of a sentence.
- `export.ts`: compute `isStdout` once (`argv.output === '-' || !argv.output`) and gate both progress lines on it; also replaces a duplicate inline check at the write site.

Suppressed rather than moved to stderr — avoids introducing a second logger stream just for this, and "no chrome on stdout" is what the `--format json` contract actually needs.

## Why the bugs shipped past existing tests

`list.test.ts`/`diff.test.ts`/`export.test.ts` already had JSON-format tests, and they passed. They just each inspected a single logger method's mock calls in isolation (`logger.info.mock.calls`, `logger.log.mock.calls`) — a polluting `logger.start` call sitting on a *different* mock method was invisible to them. That's a materially different check than "what does a real `| jq` pipeline actually receive," which sees every method's output concatenated in real invocation order.

Added `getStdoutText(logger)` to `loggerMock.ts`: walks every mocked method except the ones that route to stderr in the real CLI (`warn`/`error`/`fatal`/`fail`) or are gated off by default log level (`debug`/`verbose`/`trace`/`silent` — real consola gates these at level 3; a plain `jest.fn()` mock doesn't, so without this exclusion the helper picked up an unconditional `withCredentials` debug line that would never actually print), sorts by `mock.invocationCallOrder`, and joins — reconstructing the real stdout stream a shell pipeline would see. Used it to add/strengthen the regression tests for all three commands.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean (1443 tests).
- Mutation-verify: temporarily reverted just the three command source files (kept the new/updated tests), reran — all 5 new/updated assertions failed with the exact expected errors (e.g. `SyntaxError: Unexpected token 'C', "Calculatin"... is not valid JSON` for diff's spinner leak), confirming they actually catch the regressions. Restored the fix, full suite green again.
- End-to-end against the real target that surfaced this (doorman-www's live Vercel firewall config, see #209's provenance): built this branch and ran the compiled CLI from `.www` —
  - `list --format json | jq .` → parses
  - `diff --format json` with the config actually in sync → `{"summary":{"hasChanges":false},...}`, not a sentence
  - `export --format json` and `export --format markdown` to stdout → both clean, no leading chrome
  - Default table output for `list`/`diff` spot-checked unchanged (spinner and summary lines still present, as expected for the human path).
