### PR TITLE
feat: add --format json to status, matching list/diff/export

### DIFF
--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -3,6 +3,7 @@ import { logger } from '../../lib/logger'
 import { VercelClient } from '../../lib/providers/vercel/VercelClient'
 import { CloudflareClient } from '../../lib/providers/cloudflare/CloudflareClient'
 import { mockCloudflareClientPrototype, mockVercelClientPrototype } from '../../tests/testHelpers/providerMocks'
+import { getStdoutText } from '../../tests/testHelpers/loggerMock'
 import { handler } from '../status'
 
 jest.mock('../../lib/logger', () => ({ logger: require('../../tests/testHelpers/loggerMock').createLoggerMock() }))
@@ -76,6 +77,58 @@ describe('status command', () => {
     } as any)
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Changes detected'))
+  })
+
+  it('outputs valid JSON on stdout when format is json and configs match (#210)', async () => {
+    mockedGetConfig.mockResolvedValue({ version: 5, rules: [], ips: [] } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 'test-token',
+      projectId: 'prj_test',
+      teamId: 'team_test',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    // Whole-stream check (see getStdoutText docstring) — this is the same
+    // shape of bug fixed for list/diff/export in #209: a command that prints
+    // progress chrome ahead of --format json output on the same stdout
+    // stream.
+    const stdout = getStdoutText(logger as any)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.inSync).toBe(true)
+    expect(parsed.health.score).toEqual(expect.any(Number))
+  })
+
+  it('reflects drift in JSON output when local differs from remote (#210)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      version: 3,
+      rules: [
+        {
+          name: 'New Rule',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/new' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({
+      provider: 'vercel',
+      token: 'test-token',
+      projectId: 'prj_test',
+      teamId: 'team_test',
+      format: 'json',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const parsed = JSON.parse(getStdoutText(logger as any))
+    expect(parsed.inSync).toBe(false)
+    expect(parsed.rules.toAdd).toBe(1)
   })
 
   it('reports status for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -18,6 +18,7 @@ interface StatusOptions {
   zoneId?: string
   accountId?: string
   workspaceId?: string
+  format?: 'table' | 'json'
   debug?: boolean
   ci?: boolean
 }
@@ -53,6 +54,7 @@ export const builder = {
     type: 'string',
     description: 'Fastly Next-Gen WAF Workspace ID (defaults to FASTLY_WORKSPACE_ID env var)',
   },
+  format: { alias: 'f', type: 'string', choices: ['table', 'json'], description: 'Output format', default: 'table' },
   debug: {
     type: 'boolean',
     description: 'Enable debug logging',
@@ -78,14 +80,23 @@ export const handler = async (argv: Arguments<StatusOptions>) => {
       errorContext: 'checking status',
     },
     async ({ config, provider }) => {
-      await statusWithProvider(provider, toUnifiedConfig(config))
+      await statusWithProvider(provider, toUnifiedConfig(config), argv)
     },
   )
 }
 
-async function statusWithProvider(provider: IFirewallProvider, config: UnifiedConfig): Promise<void> {
-  logger.start('Checking sync status...')
+async function statusWithProvider(
+  provider: IFirewallProvider,
+  config: UnifiedConfig,
+  argv: Arguments<StatusOptions>,
+): Promise<void> {
+  const isJson = argv.format === 'json'
+
+  if (!isJson) {
+    logger.start('Checking sync status...')
+  }
   const changes = await provider.getChanges(config)
+  const health = provider.getHealthScore(config)
 
   const localVersion = config.metadata?.version
   // Only flag a mismatch when a local version was actually tracked before —
@@ -93,6 +104,37 @@ async function statusWithProvider(provider: IFirewallProvider, config: UnifiedCo
   // absence isn't itself a drift signal.
   const hasVersionChange =
     changes.version !== undefined && localVersion !== undefined && localVersion !== changes.version
+  const inSync = !changes.hasChanges && !hasVersionChange
+
+  if (isJson) {
+    logger.log(
+      JSON.stringify(
+        {
+          provider: provider.name,
+          inSync,
+          version: {
+            local: localVersion ?? null,
+            remote: changes.version ?? null,
+            matches: changes.version !== undefined ? !hasVersionChange : null,
+          },
+          rules: {
+            toAdd: changes.rulesToAdd.length,
+            toUpdate: changes.rulesToUpdate.length,
+            toDelete: changes.rulesToDelete.length,
+          },
+          ips: {
+            toAdd: changes.ipsToAdd?.length ?? 0,
+            toUpdate: changes.ipsToUpdate?.length ?? 0,
+            toDelete: changes.ipsToDelete?.length ?? 0,
+          },
+          health,
+        },
+        null,
+        2,
+      ),
+    )
+    return
+  }
 
   logger.log(chalk.bold(`\n📊 ${provider.name} Sync Status Summary\n`))
 
@@ -115,14 +157,13 @@ async function statusWithProvider(provider: IFirewallProvider, config: UnifiedCo
   logger.log(`  ${chalk.red('-')} ${changes.ipsToDelete?.length ?? 0} to delete`)
   logger.log('')
 
-  if (!changes.hasChanges && !hasVersionChange) {
+  if (inSync) {
     logger.success(chalk.green('✅ Everything is in sync!'))
   } else {
     logger.warn(chalk.yellow('⚠️  Changes detected. Run `sync` to apply changes.'))
   }
 
   logger.log('\n' + chalk.bold('🏥 Configuration Health Check'))
-  const health = provider.getHealthScore(config)
   logger.log(`${chalk.dim('Score:')} ${health.score}/100 (${health.grade})`)
   health.issues.forEach((issue) => {
     const marker =


### PR DESCRIPTION
Fixes #210.

## Problem

`list`, `diff`, and `export` all accept `-f, --format table|json`. `status` didn't — it only ever rendered the styled table, even though it's the one command combining sync drift *and* the config health score in a single call, exactly what a CI gate ("fail if health score < N" or "fail on undeployed drift") would want.

## Change

Adds the same `-f, --format` option, emitting:

```json
{
  "provider": "vercel",
  "inSync": true,
  "version": { "local": 2, "remote": 2, "matches": true },
  "rules": { "toAdd": 0, "toUpdate": 0, "toDelete": 0 },
  "ips": { "toAdd": 0, "toUpdate": 0, "toDelete": 0 },
  "health": { "score": 90, "grade": "excellent", "issues": [...], "recommendations": [] }
}
```

Deliberately counts only for `rules`/`ips`, not full rule objects — `status` is meant to stay a summary; `doorman diff --format json` (#215) already covers per-rule detail, so this doesn't duplicate it. `health` is the real `HealthScore` object passed through as-is rather than reshaped, so it can't drift from what the table view shows.

Also minor cleanup while touching this logic: hoisted the duplicate `provider.getHealthScore(config)` call (was previously computed after the table header was already printed) and reused the `inSync` boolean instead of recomputing `!changes.hasChanges && !hasVersionChange` a second time for the table branch.

Progress/spinner suppression under `--format json` follows the same pattern #215 established for `list`/`diff`, for the same reason (stdout has to be pipeline-safe by default).

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean (1445 tests).
- Mutation-verify: reverted just `status.ts` to its pre-fix (origin/main) state, kept the two new tests — both failed with `SyntaxError: Unexpected token 'C', "Checking s"...` (the format flag didn't exist yet, so it fell through to the table renderer regardless of `format: 'json'` in the test args). Restored the fix, suite green again.
- End-to-end against doorman-www's live Vercel firewall config (same target as #215's verification): `doorman status --format json | jq .` on the built CLI returns the JSON above with real data; default table output spot-checked unchanged.
