### PR TITLE
fix: warn when doorman backup's output dir isn't gitignored

### DIFF
--- a/src/commands/__tests__/backup.test.ts
+++ b/src/commands/__tests__/backup.test.ts
@@ -59,6 +59,7 @@ describe('backup command', () => {
   let tempDir: string
   let backupDir: string
   let configPath: string
+  const originalCwd = process.cwd()
 
   beforeEach(async () => {
     jest.clearAllMocks()
@@ -79,6 +80,7 @@ describe('backup command', () => {
 
   afterEach(async () => {
     jest.restoreAllMocks()
+    process.chdir(originalCwd)
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 
@@ -128,6 +130,81 @@ describe('backup command', () => {
     expect(content.ips[0].hostname).toBe('example.com')
     expect(content.ips[0].notes).toBe('Known bad actor')
     expect(content.ips[0].action).toBe('deny')
+  })
+
+  it('warns when the output dir is not gitignored in a git repo (regression test for #211)', async () => {
+    await fs.mkdir(join(tempDir, '.git'))
+    process.chdir(tempDir)
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      config: configPath,
+      output: 'backups',
+      debug: false,
+      ci: true,
+    } as any)
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("isn't in .gitignore"))
+  })
+
+  it('does not warn when the output dir is already covered by .gitignore', async () => {
+    await fs.mkdir(join(tempDir, '.git'))
+    await fs.writeFile(join(tempDir, '.gitignore'), 'backups/\n')
+    process.chdir(tempDir)
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      config: configPath,
+      output: 'backups',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const warnTexts = (logger.warn as unknown as jest.Mock).mock.calls.map((c) => String(c[0]))
+    expect(warnTexts.some((t) => t.includes("isn't in .gitignore"))).toBe(false)
+  })
+
+  it('does not warn outside a git repo', async () => {
+    process.chdir(tempDir) // no .git created
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      config: configPath,
+      output: 'backups',
+      debug: false,
+      ci: true,
+    } as any)
+
+    const warnTexts = (logger.warn as unknown as jest.Mock).mock.calls.map((c) => String(c[0]))
+    expect(warnTexts.some((t) => t.includes("isn't in .gitignore"))).toBe(false)
+  })
+
+  it('does not warn for an absolute --output path, even unignored in a git repo', async () => {
+    await fs.mkdir(join(tempDir, '.git'))
+    process.chdir(tempDir)
+
+    await handler({
+      provider: 'vercel',
+      token: 't',
+      projectId: 'prj',
+      teamId: 'team',
+      config: configPath,
+      output: backupDir, // absolute, from the outer beforeEach
+      debug: false,
+      ci: true,
+    } as any)
+
+    const warnTexts = (logger.warn as unknown as jest.Mock).mock.calls.map((c) => String(c[0]))
+    expect(warnTexts.some((t) => t.includes("isn't in .gitignore"))).toBe(false)
   })
 
   it('creates a backup file for the Cloudflare provider without crashing (regression test for #82)', async () => {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { existsSync, mkdirSync, readdirSync, statSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join } from 'path'
 import { LogLevels } from 'consola'
 import { Arguments } from 'yargs'
 import { logger } from '../lib/logger'
@@ -9,6 +9,7 @@ import { FirewallConfig } from '../lib/types'
 import { prompt } from '../lib/ui/prompt'
 import { getConfig, saveConfig } from '../lib/utils/config'
 import { handleCommandError } from '../lib/utils/handleCommandError'
+import { isDirGitignored, isGitRepo } from '../lib/utils/gitignoreCheck'
 import type { ProviderType } from '../lib/providers/IFirewallProvider'
 import { providerOption } from '../lib/utils/providerOption'
 import { withCredentials } from '../lib/utils/withCredentials'
@@ -236,6 +237,23 @@ export const handler = async (argv: Arguments<BackupOptions>) => {
           `${chalk.dim('Rules:')} ${remoteConfig.rules.length} custom, ${remoteConfig.ips?.length ?? 0} IP blocking`,
         )
         logger.log(`${chalk.dim('Created:')} ${new Date().toLocaleString()}`)
+
+        // A firewall backup is a full snapshot of rule names/conditions/regex
+        // patterns — reasonable to keep out of git history by default. Only
+        // warn when we can positively tell we're in a git repo without an
+        // ignore entry already covering it; see gitignoreCheck.ts for why
+        // this is a best-effort literal match, not full gitignore semantics.
+        // Skipped for an absolute --output: it isn't meaningfully "relative
+        // to the repo root" the way the default `./backups` is, so a root
+        // .gitignore literal-match can't say anything useful about it.
+        if (!isAbsolute(backupDir) && isGitRepo() && !isDirGitignored(backupDir)) {
+          logger.warn(
+            chalk.yellow(
+              `💡 ${backupDir} isn't in .gitignore — firewall backups may contain rule details you don't want in git history.`,
+            ),
+          )
+        }
+
         logger.log('')
         logger.log(chalk.dim('To restore this backup later, run:'))
         logger.log(chalk.cyan(`doorman backup --restore ${backupFilename}`))

--- a/src/lib/utils/__tests__/gitignoreCheck.test.ts
+++ b/src/lib/utils/__tests__/gitignoreCheck.test.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { isDirGitignored, isGitRepo } from '../gitignoreCheck'
+
+describe('gitignoreCheck', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(join(tmpdir(), 'doorman-gitignore-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  describe('isGitRepo', () => {
+    it('returns true when .git exists', async () => {
+      await fs.mkdir(join(tempDir, '.git'))
+      expect(isGitRepo(tempDir)).toBe(true)
+    })
+
+    it('returns false when .git does not exist', () => {
+      expect(isGitRepo(tempDir)).toBe(false)
+    })
+  })
+
+  describe('isDirGitignored', () => {
+    it('returns false when there is no .gitignore at all', () => {
+      expect(isDirGitignored('backups', tempDir)).toBe(false)
+    })
+
+    it.each([['backups'], ['backups/'], ['/backups'], ['/backups/']])(
+      'matches a %s entry against target "backups"',
+      async (entry) => {
+        await fs.writeFile(join(tempDir, '.gitignore'), `node_modules\n${entry}\n*.log\n`)
+        expect(isDirGitignored('backups', tempDir)).toBe(true)
+      },
+    )
+
+    it('matches "./backups" the same as "backups"', async () => {
+      await fs.writeFile(join(tempDir, '.gitignore'), 'backups/\n')
+      expect(isDirGitignored('./backups', tempDir)).toBe(true)
+    })
+
+    it('matches a subdirectory of an ignored parent (backups/foo under backups/)', async () => {
+      await fs.writeFile(join(tempDir, '.gitignore'), 'backups/\n')
+      expect(isDirGitignored('backups/nested', tempDir)).toBe(true)
+    })
+
+    it('ignores comments and blank lines rather than matching them', async () => {
+      await fs.writeFile(join(tempDir, '.gitignore'), '# backups\n\n  \nnode_modules\n')
+      expect(isDirGitignored('backups', tempDir)).toBe(false)
+    })
+
+    it('returns false when .gitignore has unrelated entries only', async () => {
+      await fs.writeFile(join(tempDir, '.gitignore'), 'node_modules\ndist\n*.log\n')
+      expect(isDirGitignored('backups', tempDir)).toBe(false)
+    })
+
+    it('does not treat a name that merely starts with the same prefix as a match', async () => {
+      // "backups-archive" should not be considered covered by a "backups/" entry
+      await fs.writeFile(join(tempDir, '.gitignore'), 'backups/\n')
+      expect(isDirGitignored('backups-archive', tempDir)).toBe(false)
+    })
+  })
+})

--- a/src/lib/utils/gitignoreCheck.ts
+++ b/src/lib/utils/gitignoreCheck.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Best-effort check for whether `targetDir` (relative to `cwd`) is covered
+ * by a `.gitignore` at the repo root. Intentionally not a full gitignore-
+ * semantics implementation (no glob matching, no negation, no nested
+ * `.gitignore` merging, no global excludes file) — this backs an advisory
+ * nudge, not a correctness guarantee, so a literal/prefix match against the
+ * root `.gitignore` is enough: it covers the overwhelmingly common patterns
+ * (`backups/`, `/backups`, `backups`) without the complexity of a real
+ * gitignore parser. A caller relying on this for anything beyond "should I
+ * print a one-line reminder" is using it wrong.
+ *
+ * Returns `false` (i.e. "not confirmed ignored, consider warning") when
+ * there's no git repo or no `.gitignore` at all — callers should treat that
+ * as "can't tell" and decide separately whether a warning is even relevant
+ * outside a git repo.
+ */
+export function isGitRepo(cwd: string = process.cwd()): boolean {
+  return existsSync(join(cwd, '.git'))
+}
+
+export function isDirGitignored(targetDir: string, cwd: string = process.cwd()): boolean {
+  const gitignorePath = join(cwd, '.gitignore')
+  if (!existsSync(gitignorePath)) {
+    return false
+  }
+
+  const normalized = targetDir.replace(/^\.\//, '').replace(/^\//, '').replace(/\/$/, '')
+
+  let lines: string[]
+  try {
+    lines = readFileSync(gitignorePath, 'utf8').split('\n')
+  } catch {
+    return false
+  }
+
+  return lines.some((rawLine) => {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) return false
+    const pattern = line.replace(/^\//, '').replace(/\/$/, '')
+    return pattern === normalized || normalized.startsWith(`${pattern}/`)
+  })
+}


### PR DESCRIPTION
Fixes #211.

## Problem

`doorman backup` defaults to `./backups` and never checks whether that's covered by `.gitignore`. A backup is a full snapshot of remote firewall rules — names, conditions, regex patterns — which can say more about internal infrastructure than a project wants sitting in git history, and nothing stopped it from landing there silently. Reproduced exactly this in `doorman-www`: the first `doorman backup` there left an untracked `backups/` one `git add .` away from being committed.

## Change

- `src/lib/utils/gitignoreCheck.ts` (new): `isGitRepo(cwd)` and `isDirGitignored(targetDir, cwd)`. Deliberately a literal/prefix match against just the root `.gitignore` — no glob support, no nested-`.gitignore` merging, no negation, no global excludes file. This backs a one-line advisory, not a correctness guarantee, and the existing codebase doesn't shell out to `git` anywhere (checked — no `child_process` usage in `src`), so `git check-ignore` would've been a new dependency pattern for what's ultimately a nudge. Covers the common real patterns (`backups/`, `/backups`, `backups`) and their prefix form for nested paths.
- `backup.ts`: after a successful backup, warn once via `logger.warn` when `!isAbsolute(backupDir) && isGitRepo() && !isDirGitignored(backupDir)`. Skipped for an absolute `--output` — a root-relative `.gitignore` can't meaningfully speak to an arbitrary absolute path (e.g. `/var/backups/doorman`), so guessing there would be more likely wrong than useful.
- Never blocks: this is a `logger.warn` with no prompt, so it behaves identically under `--ci` and interactive — nothing to gate.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean (1459 tests, up from 1445 — 12 new in `gitignoreCheck.test.ts`, 4 new + 2 unchanged in `backup.test.ts`, plus one `eslint --fix` formatting nit from the initial draft).
- Mutation-verify: reverted `backup.ts` to its pre-fix (origin/main) state and removed `gitignoreCheck.ts` entirely, keeping only the new tests — the positive-case test (`warns when the output dir is not gitignored`) failed with `Number of calls: 0` against the reverted code, as expected (the other three new tests are negative-case guards — "don't warn when X" — which also pass against the unfixed code, since "never warns at all" trivially satisfies "don't warn," so they don't independently prove the fix; the positive-case failure is what confirms it). Restored the fix, full suite green again.
- End-to-end against the real repo that surfaced this (`doorman-www`, `backups/` still ungitignored there as of this PR): built this branch and ran `doorman backup --config .doorman.json` from `.www` — got `💡 ./backups isn't in .gitignore — firewall backups may contain rule details you don't want in git history.` Then temporarily added `backups/` to `.www/.gitignore` and re-ran — warning gone, backup still created normally. Reverted `.www/.gitignore` back to its original content afterward (this PR only touches the `doorman` CLI repo, not `doorman-www`).

Note: didn't fix `doorman-www`'s own `.gitignore` as part of this PR — that's a one-line, separate change to a different repo; happy to send it if useful, just didn't want to bundle an unrelated repo's config change into this one.
