### PR TITLE
fix: guard prompt() against TTY crashes, add --ci to init/template/add

### DIFF
--- a/src/commands/__tests__/add.test.ts
+++ b/src/commands/__tests__/add.test.ts
@@ -1,6 +1,111 @@
-import { generateRuleId } from '../add'
+import { getConfig, saveConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { prompt } from '../../lib/ui/prompt'
+import { generateRuleId, handler } from '../add'
+
+jest.mock('../../lib/logger', () => ({
+  logger: {
+    log: jest.fn(),
+    start: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+jest.mock('../../lib/utils/config', () => ({
+  getConfig: jest.fn(),
+  saveConfig: jest.fn(),
+}))
+
+jest.mock('../../lib/ui/prompt', () => ({
+  prompt: jest.fn(),
+}))
+
+const mockedGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const mockedSaveConfig = saveConfig as jest.MockedFunction<typeof saveConfig>
+const mockedPrompt = prompt as jest.MockedFunction<typeof prompt>
+
+const inlineRuleArgs = {
+  name: 'Block Admin',
+  field: 'path',
+  op: 'eq',
+  value: '/admin',
+  action: 'deny',
+  dryRun: false,
+  debug: false,
+}
 
 describe('add command', () => {
+  describe('handler — duplicate rule name (regression tests for #216)', () => {
+    const originalIsTTY = process.stdin.isTTY
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      mockedGetConfig.mockResolvedValue({
+        rules: [
+          {
+            name: 'Block Admin',
+            conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/admin' }] }],
+            action: { mitigate: { action: 'deny' } },
+            active: true,
+          },
+        ],
+        ips: [],
+      } as any)
+      mockedSaveConfig.mockResolvedValue(undefined)
+      jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit called with "${code}"`)
+      }) as any)
+      process.stdin.isTTY = true
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+      process.stdin.isTTY = originalIsTTY
+    })
+
+    it('warns and cancels when the user declines to proceed on a TTY', async () => {
+      mockedPrompt.mockResolvedValue(false as any)
+
+      await handler({ ...inlineRuleArgs } as any)
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('already exists'))
+      expect(mockedSaveConfig).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith('Cancelled.')
+    })
+
+    it('adds the rule anyway when the user confirms past the duplicate warning', async () => {
+      mockedPrompt.mockResolvedValue(true as any)
+
+      await handler({ ...inlineRuleArgs } as any)
+
+      expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+      const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+      expect((savedConfig as any).rules).toHaveLength(2)
+    })
+
+    it('skips cleanly instead of prompting when stdin is not a TTY, even without --ci', async () => {
+      process.stdin.isTTY = false
+
+      await handler({ ...inlineRuleArgs } as any)
+
+      expect(mockedPrompt).not.toHaveBeenCalled()
+      expect(mockedSaveConfig).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Skipping'))
+    })
+
+    it('skips cleanly instead of prompting when --ci is set, even on a TTY', async () => {
+      await handler({ ...inlineRuleArgs, ci: true } as any)
+
+      expect(mockedPrompt).not.toHaveBeenCalled()
+      expect(mockedSaveConfig).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Skipping'))
+    })
+  })
+
   describe('generateRuleId', () => {
     it('converts a simple name to snake_case with rule_ prefix', () => {
       expect(generateRuleId('Block Admin')).toBe('rule_block_admin')

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -1,6 +1,109 @@
-import { BASIC_TEMPLATE_RULES, SECURITY_FOCUSED_TEMPLATE_RULES } from '../init'
+import { saveConfig } from '../../lib/utils/config'
+import { logger } from '../../lib/logger'
+import { prompt } from '../../lib/ui/prompt'
+import { BASIC_TEMPLATE_RULES, SECURITY_FOCUSED_TEMPLATE_RULES, handler } from '../init'
 import { firewallConfigSchema } from '../../lib/schemas/firewallSchemas'
 import { createEmptyConfig } from '../../lib/utils/createEmptyConfig'
+
+jest.mock('fs', () => ({ existsSync: jest.fn().mockReturnValue(false) }))
+
+jest.mock('../../lib/logger', () => ({
+  logger: {
+    log: jest.fn(),
+    start: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+jest.mock('../../lib/utils/config', () => ({
+  saveConfig: jest.fn(),
+}))
+
+jest.mock('../../lib/ui/prompt', () => ({
+  prompt: jest.fn(),
+}))
+
+const mockedSaveConfig = saveConfig as jest.MockedFunction<typeof saveConfig>
+const mockedPrompt = prompt as jest.MockedFunction<typeof prompt>
+
+describe('init command handler — --interactive default (regression tests for #221)', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedSaveConfig.mockResolvedValue(undefined)
+    process.stdin.isTTY = true
+  })
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY
+  })
+
+  it('does not prompt when a template is given positionally and --interactive is not set', async () => {
+    await handler({ template: 'security-focused', config: '.doorman.json', force: false } as any)
+
+    expect(mockedPrompt).not.toHaveBeenCalled()
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+    expect((savedConfig as any).rules).toEqual(SECURITY_FOCUSED_TEMPLATE_RULES)
+  })
+
+  it('runs the interactive wizard when no template is given and --interactive is not set', async () => {
+    mockedPrompt
+      .mockResolvedValueOnce('prj_123') // project ID
+      .mockResolvedValueOnce(false) // "using a team account?"
+      .mockResolvedValueOnce(false) // "show token help?" (VERCEL_TOKEN unset in test env)
+      .mockResolvedValueOnce('basic') // template select
+
+    await handler({ config: '.doorman.json', force: false } as any)
+
+    expect(mockedPrompt).toHaveBeenCalled()
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+    expect((savedConfig as any).rules).toEqual(BASIC_TEMPLATE_RULES)
+  })
+
+  it('still runs the wizard when --interactive is explicitly set, even with a template given', async () => {
+    mockedPrompt.mockResolvedValueOnce('prj_123').mockResolvedValueOnce(false).mockResolvedValueOnce(false)
+
+    await handler({ template: 'basic', interactive: true, config: '.doorman.json', force: false } as any)
+
+    expect(mockedPrompt).toHaveBeenCalled()
+  })
+
+  it('does not prompt when --interactive=false is explicit, even with no template', async () => {
+    await handler({ interactive: false, config: '.doorman.json', force: false } as any)
+
+    expect(mockedPrompt).not.toHaveBeenCalled()
+    expect(mockedSaveConfig).toHaveBeenCalledTimes(1)
+    const [savedConfig] = mockedSaveConfig.mock.calls[0]!
+    expect((savedConfig as any).rules).toEqual([])
+  })
+
+  it("surfaces a prompt() rejection (e.g. prompt.ts's non-TTY guard, #221) as a clean handled error, not an unhandled crash", async () => {
+    // Mirrors exactly what the real prompt() now throws on a non-TTY
+    // (src/lib/ui/prompt.ts) — this test's concern is init.ts's existing
+    // try/catch -> handleCommandError wiring surfacing that message intact,
+    // not re-testing the TTY guard itself (see prompt.test.ts for that).
+    mockedPrompt.mockRejectedValueOnce(
+      new Error('Cannot prompt for "Enter your Vercel Project ID:" — no interactive terminal available.'),
+    )
+    jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with "${code}"`)
+    }) as any)
+
+    await expect(handler({ config: '.doorman.json', force: false } as any)).rejects.toThrow(
+      'process.exit called with "1"',
+    )
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('no interactive terminal available'))
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+  })
+})
 
 describe('init command templates', () => {
   it('produces a schema-valid config for the basic template', () => {

--- a/src/commands/__tests__/template.test.ts
+++ b/src/commands/__tests__/template.test.ts
@@ -29,6 +29,8 @@ const mockedSaveConfig = saveConfig as jest.MockedFunction<typeof saveConfig>
 const mockedPrompt = prompt as jest.MockedFunction<typeof prompt>
 
 describe('template command', () => {
+  const originalIsTTY = process.stdin.isTTY
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockedGetConfig.mockResolvedValue({ rules: [], ips: [] } as any)
@@ -36,10 +38,15 @@ describe('template command', () => {
     jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit called with "${code}"`)
     }) as any)
+    // The duplicate-name prompt tests below simulate an attached terminal —
+    // the non-interactive auto-skip path (regression tests for #216) sets
+    // this to false itself, per test.
+    process.stdin.isTTY = true
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+    process.stdin.isTTY = originalIsTTY
   })
 
   it('appends the named template rules to the existing config and saves it', async () => {
@@ -136,6 +143,47 @@ describe('template command', () => {
     const [savedConfig] = mockedSaveConfig.mock.calls[0]!
     // Original rule plus the duplicate-named template rule, both retained.
     expect((savedConfig as any).rules.length).toBe(2)
+  })
+
+  it('skips cleanly instead of prompting when stdin is not a TTY, even without --ci (regression test for #216)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Deny WordPress URLs',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/wp-admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+    process.stdin.isTTY = false
+
+    await handler({ name: 'wordpress', dryRun: false, debug: false } as any)
+
+    expect(mockedPrompt).not.toHaveBeenCalled()
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Skipping'))
+  })
+
+  it('skips cleanly instead of prompting when --ci is set, even on a TTY (regression test for #216)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Deny WordPress URLs',
+          conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/wp-admin' }] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await handler({ name: 'wordpress', dryRun: false, debug: false, ci: true } as any)
+
+    expect(mockedPrompt).not.toHaveBeenCalled()
+    expect(mockedSaveConfig).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Skipping'))
   })
 
   it('does not warn when running the template against an empty config', async () => {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -40,6 +40,7 @@ interface AddOptions {
   config?: string
   dryRun?: boolean
   debug?: boolean
+  ci?: boolean
 }
 
 export const command = 'add [type]'
@@ -148,6 +149,7 @@ export const builder = {
     description: 'Enable debug logging',
     default: false,
   },
+  ci: { type: 'boolean', description: 'Run in CI mode (non-interactive)', default: false },
 }
 
 const VALID_RULE_TYPES: RuleType[] = [
@@ -617,6 +619,14 @@ export const handler = async (argv: Arguments<AddOptions>) => {
       const duplicateWarning = checkDuplicates({ ...config, rules }, rule)
       if (duplicateWarning) {
         logger.warn(chalk.yellow(`⚠️  ${duplicateWarning}`))
+
+        // See template.ts's identical guard and #216 — matches the safe
+        // `initial: false` default rather than crashing on a missing TTY.
+        if (argv.ci || !process.stdin.isTTY) {
+          logger.info(chalk.dim('Skipping — non-interactive and a conflicting rule already exists. Rule not added.'))
+          return
+        }
+
         const proceed = (await prompt('Proceed anyway?', {
           type: 'confirm',
           initial: false,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -149,7 +149,9 @@ export const builder = {
     type: 'string',
     description: 'Template to use for initialization (empty, basic, or security-focused)',
     choices: ['empty', 'basic', 'security-focused'],
-    default: 'empty',
+    // No `default` here (deliberately) — the handler distinguishes "no
+    // template given" from "'empty' given explicitly" to decide whether
+    // --interactive should default on. See the `interactive` option below.
   },
   config: {
     alias: 'c',
@@ -166,8 +168,11 @@ export const builder = {
   interactive: {
     alias: 'i',
     type: 'boolean',
-    description: 'Interactive setup with guided prompts',
-    default: true,
+    description: 'Interactive setup with guided prompts (default: on unless a template is given positionally)',
+    // No `default` here either — see resolveInteractive below. Forcing a
+    // static `true` made the documented quick-start (`doorman init
+    // security-focused`) crash non-interactively, since naming a template
+    // doesn't opt out of the wizard. See #221.
   },
   projectId: {
     alias: 'p',
@@ -206,11 +211,22 @@ const showHelpLinks = () => {
   logger.log('')
 }
 
-const promptForProjectDetails = async (argv: Arguments<InitOptions>) => {
+/**
+ * `--interactive` has no static default (see the builder) so an explicit
+ * `--interactive`/`--no-interactive` always wins; absent that, a positional
+ * template reads as "just scaffold this" (non-interactive), and no template
+ * reads as "walk me through it" (interactive) — matching how `doorman init
+ * <template>` is documented in SKILL.md's quick-start. See #221.
+ */
+function resolveInteractive(argv: Arguments<InitOptions>): boolean {
+  return argv.interactive ?? argv.template === undefined
+}
+
+const promptForProjectDetails = async (argv: Arguments<InitOptions>, interactive: boolean) => {
   let projectId = argv.projectId
   let teamId = argv.teamId
 
-  if (argv.interactive) {
+  if (interactive) {
     logger.log(chalk.bold('📋 Project Configuration'))
     logger.log(chalk.dim('We need your Vercel project details to configure the firewall.\n'))
 
@@ -267,8 +283,9 @@ const promptForProjectDetails = async (argv: Arguments<InitOptions>) => {
 export const handler = async (argv: Arguments<InitOptions>) => {
   try {
     const configPath = argv.config || '.doorman.json'
+    const interactive = resolveInteractive(argv)
 
-    if (argv.interactive) {
+    if (interactive) {
       showWelcomeMessage()
     }
 
@@ -285,9 +302,9 @@ export const handler = async (argv: Arguments<InitOptions>) => {
     }
 
     // Get project details
-    const { projectId, teamId } = await promptForProjectDetails(argv)
+    const { projectId, teamId } = await promptForProjectDetails(argv, interactive)
 
-    if (argv.interactive) {
+    if (interactive) {
       logger.log('')
       logger.log(chalk.bold('🎨 Template Selection'))
       logger.log(chalk.dim('Choose a starting template for your firewall configuration:\n'))
@@ -299,8 +316,8 @@ export const handler = async (argv: Arguments<InitOptions>) => {
     }
 
     // Allow template selection in interactive mode
-    let template = argv.template
-    if (argv.interactive && !argv.template) {
+    let template = argv.template ?? 'empty'
+    if (interactive && !argv.template) {
       template = (await prompt('Select a template:', {
         type: 'select',
         options: ['empty', 'basic', 'security-focused'],
@@ -378,7 +395,7 @@ export const handler = async (argv: Arguments<InitOptions>) => {
     }
 
     // Show help links if interactive
-    if (argv.interactive && (!projectId || !process.env.VERCEL_TOKEN)) {
+    if (interactive && (!projectId || !process.env.VERCEL_TOKEN)) {
       showHelpLinks()
     }
   } catch (error) {

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -14,6 +14,7 @@ interface TemplateOptions {
   config?: string
   dryRun?: boolean
   debug?: boolean
+  ci?: boolean
 }
 
 export const command = 'template [name]'
@@ -40,6 +41,7 @@ export const builder = {
     description: 'Enable debug logging',
     default: false,
   },
+  ci: { type: 'boolean', description: 'Run in CI mode (non-interactive)', default: false },
 }
 
 /**
@@ -108,6 +110,18 @@ export const handler = async (argv: Arguments<TemplateOptions>) => {
 
     if (duplicateNames.length > 0) {
       logger.warn(chalk.yellow(`⚠️  Rule name(s) already exist in the configuration: ${duplicateNames.join(', ')}`))
+
+      // Matches the safe default (`initial: false`) a human would hit Enter
+      // on — an unattended run shouldn't hang waiting for a terminal that
+      // isn't there, and shouldn't silently duplicate rules either. See
+      // #216: this used to fall through to `prompt()` unconditionally, which
+      // crashed with a raw libuv error under CI/agents with no explicit
+      // opt-out.
+      if (argv.ci || !process.stdin.isTTY) {
+        logger.info(chalk.dim('Skipping — non-interactive and rule name(s) already exist. Template not applied.'))
+        return
+      }
+
       const proceed = (await prompt('Proceed anyway?', {
         type: 'confirm',
         initial: false,

--- a/src/lib/ui/__tests__/prompt.test.ts
+++ b/src/lib/ui/__tests__/prompt.test.ts
@@ -11,14 +11,26 @@ jest.mock('consola', () => ({
 
 describe('prompt wrapper', () => {
   let exitSpy: jest.SpyInstance
+  const originalIsTTY = process.stdin.isTTY
 
   beforeEach(() => {
     mockConsolaPrompt.mockReset()
     exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    // Every behavioral test below exercises what happens once a prompt is
+    // actually shown — simulate an attached terminal so the new TTY guard
+    // (tested separately below) doesn't short-circuit them.
+    process.stdin.isTTY = true
   })
 
   afterEach(() => {
     exitSpy.mockRestore()
+    process.stdin.isTTY = originalIsTTY
+  })
+
+  it('throws a clean, actionable error instead of reaching consola when stdin is not a TTY (regression test for #221)', async () => {
+    process.stdin.isTTY = false
+    await expect(prompt('Rule name:', { type: 'text' })).rejects.toThrow(/no interactive terminal available/)
+    expect(mockConsolaPrompt).not.toHaveBeenCalled()
   })
 
   it('normalizes an empty text prompt to an empty string instead of undefined', async () => {

--- a/src/lib/ui/prompt.ts
+++ b/src/lib/ui/prompt.ts
@@ -11,6 +11,18 @@ import consola from 'consola'
  * @returns The user's response.
  */
 export const prompt: typeof consola.prompt = async (message, options) => {
+  // consola.prompt has no TTY check of its own — without stdin attached to a
+  // real terminal it throws a raw libuv error ("TTY initialization failed:
+  // uv_tty_init returned EINVAL") from deep inside Node internals. Guard
+  // here, once, for every caller (init/template/add/remove/...) rather than
+  // in each command — see #221.
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      `Cannot prompt for "${message}" — no interactive terminal available. ` +
+        `Re-run with the appropriate non-interactive flag for this command (e.g. --interactive=false, --ci, --force).`,
+    )
+  }
+
   const response = await consola.prompt(message, options)
 
   // An empty optional text prompt resolves to `undefined`/`null`, not the cancel symbol.


### PR DESCRIPTION
Fixes #221. Fixes #216.

## Problem

Every command that calls the shared `prompt()` wrapper (`src/lib/ui/prompt.ts`) crashed with a raw libuv internals error — `TTY initialization failed: uv_tty_init returned EINVAL (invalid argument)` — whenever stdin wasn't a real terminal. No guard existed before `consola.prompt` tried to touch it.

Two independent reports converged on the same root cause:
- **#221**: `doorman init`'s `--interactive` flag defaulted to `true` unconditionally. SKILL.md's own quick-start documents `doorman init security-focused` as a one-shot command, but naming a template positionally never opted out of the wizard, so the *documented* command crashed non-interactively out of the box.
- **#216**: `doorman template <name>` and `doorman add --name ... --field ...` (the flag-driven, scriptable form) unconditionally prompt for confirmation when the target rule name already exists — with no `--ci`, `--yes`, or any escape hatch. Any idempotent script/CI/agent call (`doorman template ai-bots` run twice, expecting the second call to be a no-op) hard-failed forever.

## Fix

One change per root cause, not one big patch:

- **`prompt.ts`**: throws a clean, actionable error (`Cannot prompt for "..." — no interactive terminal available. Re-run with the appropriate non-interactive flag...`) when `!process.stdin.isTTY`, before ever reaching `consola.prompt`. Fixes the crash message everywhere this is called from — `init`, `template`, `add`, `remove`, and anywhere else that shares it — in one place, exactly as #221 suggested.
- **`init.ts`**: `--interactive` now has no static default. Resolved in the handler (`resolveInteractive`) instead: an explicit `--interactive`/`--no-interactive` always wins; absent that, a positional template means "just scaffold this" (interactive off), no template means "walk me through it" (on). `doorman init security-focused` — the exact documented quick-start — now works as shown, without touching the docs, since the code now matches what SKILL.md already says.
- **`template.ts` / `add.ts`**: added `--ci` (matching the convention `list`/`export`/`backup`/`status` already use). A duplicate-rule-name collision now skips cleanly — matching the safe `initial: false` a human would hit Enter on — under `--ci` **or** whenever stdin isn't a TTY, instead of falling through to an unconditional prompt with no opt-out either way.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean — 1473 tests, +11 new across the four affected files (`prompt.test.ts`, `init.test.ts`, `template.test.ts`, `add.test.ts` — the latter two previously had zero handler-level tests, only `generateRuleId`/template-constant coverage).
- Mutation-verify: reverted all four source files to `origin/main` at once (kept the new/updated tests), ran the four affected suites — 7 of the new tests failed with the exact expected messages: "no interactive terminal available" never thrown (resolved to `""` instead); `mockedPrompt` never called became "called once with 'Proceed anyway?'"; the wizard never ran when it should have (`mockedPrompt` call count 0 instead of >=1). The remaining new tests (explicit-flag-still-wins, positive-path) correctly did **not** fail against the old code — they're supplementary coverage confirming the fix doesn't regress existing explicit-flag behavior, not independent proof of the bug, and I'm not claiming otherwise. Restored the fix, full suite green again.
- End-to-end against the real compiled CLI, in genuinely non-TTY contexts (this shell is one), reproducing every scenario from both issues verbatim:
  - `doorman init security-focused` (#221's exact repro) — now exits 0, produces a config `doorman validate` accepts, no wizard.
  - `doorman init` alone (no template, wizard would run) — now fails with the clean actionable message instead of the raw libuv string.
  - `doorman template ai-bots` run twice (#216's exact repro) — second run exits 0: `Skipping — non-interactive and rule name(s) already exist. Template not applied.`
  - `doorman add --name "Detect AI Bots" --field path --op pre --value "/admin" --action deny` run twice, then a third time with explicit `--ci` — same clean skip both ways, first run still succeeds normally.

## Scope note

`remove.ts` (mentioned in #221 as reproducing the same crash signature) already has its own `--force` escape hatch and wasn't in either issue's stated file list — it gets the crash-message cleanup for free from the shared `prompt.ts` fix, but I didn't add `remove`-specific CI-auto-skip logic since that wasn't what was reported. Happy to do a follow-up if useful.
