### PR TITLE
fix: reconcile native/unified schema drift on redirect, ex/nex, hostname

### DIFF
--- a/schema/firewall-config.schema.json
+++ b/schema/firewall-config.schema.json
@@ -251,7 +251,7 @@
           "const": "deny"
         }
       },
-      "required": ["ip", "hostname", "action"],
+      "required": ["ip", "action"],
       "additionalProperties": false
     }
   }

--- a/src/commands/__tests__/validate.test.ts
+++ b/src/commands/__tests__/validate.test.ts
@@ -82,6 +82,28 @@ describe('validate command', () => {
     expect(logger.success).not.toHaveBeenCalled()
   })
 
+  it('includes the actual validation failure detail even without --verbose (regression test for #219)', async () => {
+    mockedGetConfig.mockResolvedValue({
+      rules: [
+        {
+          name: 'Broken Rule',
+          conditionGroup: [{ conditions: [] }],
+          action: { mitigate: { action: 'deny' } },
+          active: true,
+        },
+      ],
+      ips: [],
+    } as any)
+
+    await expect(handler({ verbose: false } as any)).rejects.toThrow('process.exit called with "1"')
+
+    // Previously this was just "Configuration validation failed" with
+    // nothing else — the only way to see *why* was to pass --verbose.
+    const errorText = (logger.error as unknown as jest.Mock).mock.calls.map((c) => String(c[0])).join('\n')
+    expect(errorText).toContain('conditionGroup')
+    expect(errorText).not.toBe('Configuration validation failed')
+  })
+
   it('exits with an error when a Cloudflare config is missing required rule fields', async () => {
     mockedGetConfig.mockResolvedValue({
       provider: 'cloudflare',

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -118,8 +118,22 @@ export const handler = async (argv: Arguments<ValidateOptions>) => {
     // Final result
     if (zodResult.success && ajvValid) {
       logger.success(chalk.green('Configuration is valid'))
-    } else {
+    } else if (argv.verbose) {
+      // The detailed breakdown was already printed above — a bare message
+      // here avoids showing every failure twice.
       throw new Error('Configuration validation failed')
+    } else {
+      // Surface *why*, not just *that* it failed, even without --verbose —
+      // previously this was the only path to any detail at all, which made
+      // a real failure (e.g. #219) meaningfully harder to diagnose than it
+      // needed to be.
+      const details = [
+        ...(!zodResult.success
+          ? zodResult.error.errors.map((err) => `${err.path.join('.') || '(root)'}: ${err.message}`)
+          : []),
+        ...(!ajvValid ? ajvErrors.map((err) => `${err.instancePath || '(root)'}: ${err.message}`) : []),
+      ]
+      throw new Error(`Configuration validation failed:\n  ${details.join('\n  ')}`)
     }
   } catch (error) {
     handleCommandError(error, 'validating configuration')

--- a/src/constants/schema.ts
+++ b/src/constants/schema.ts
@@ -261,7 +261,7 @@ export const schema = {
           const: 'deny',
         },
       },
-      required: ['ip', 'hostname', 'action'],
+      required: ['ip', 'action'],
       additionalProperties: false,
     },
   },

--- a/src/lib/schemas/__tests__/commonSchemas.test.ts
+++ b/src/lib/schemas/__tests__/commonSchemas.test.ts
@@ -175,6 +175,16 @@ describe('commonSchemas', () => {
     it('rejects invalid URL', () => {
       expect(redirectSchema.safeParse({ location: 'not-a-url' }).success).toBe(false)
     })
+
+    it('accepts a relative path, matching the native schema and documented behavior (regression test for #212)', () => {
+      expect(redirectSchema.safeParse({ location: '/v2/api/' }).success).toBe(true)
+      // The exact real-world case from #212 (a deployed griffen.codes rule).
+      expect(redirectSchema.safeParse({ location: '/correct-path' }).success).toBe(true)
+    })
+
+    it('still rejects a bare string that is neither an absolute URL nor a path', () => {
+      expect(redirectSchema.safeParse({ location: 'just some text' }).success).toBe(false)
+    })
   })
 
   describe('providerTypeSchema', () => {

--- a/src/lib/schemas/__tests__/firewallSchemas.test.ts
+++ b/src/lib/schemas/__tests__/firewallSchemas.test.ts
@@ -1,0 +1,29 @@
+import { ipBlockingRuleSchema } from '../firewallSchemas'
+
+describe('firewallSchemas', () => {
+  describe('ipBlockingRuleSchema', () => {
+    it('accepts an IP rule with hostname omitted, matching unifiedIPRuleSchema and the documented behavior (regression test for #219)', () => {
+      // The exact real-world case from #219, isolated to just this field.
+      const result = ipBlockingRuleSchema.safeParse({
+        ip: '192.168.1.100/32',
+        action: 'deny',
+        notes: 'blocked',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('still accepts an IP rule with hostname present', () => {
+      const result = ipBlockingRuleSchema.safeParse({
+        ip: '192.168.1.100/32',
+        hostname: 'example.com',
+        action: 'deny',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('still rejects a missing/invalid ip', () => {
+      expect(ipBlockingRuleSchema.safeParse({ action: 'deny' }).success).toBe(false)
+      expect(ipBlockingRuleSchema.safeParse({ ip: 'not-an-ip', action: 'deny' }).success).toBe(false)
+    })
+  })
+})

--- a/src/lib/schemas/__tests__/nativeUnifiedSchemaAgreement.test.ts
+++ b/src/lib/schemas/__tests__/nativeUnifiedSchemaAgreement.test.ts
@@ -1,0 +1,72 @@
+import { firewallConfigSchema } from '../firewallSchemas'
+import { unifiedConfigSchema } from '../unifiedSchemas'
+import { toUnifiedConfig } from '../../utils/vercelConfigAdapter'
+import type { FirewallConfig } from '../../types'
+
+/**
+ * #212, #213, and #219 were three independent instances of the same
+ * underlying problem: `doorman validate` checks a config against the native
+ * (Vercel-shaped) schemas, while `status`/`diff`/`backup`/`sync` translate
+ * the same on-disk config to `UnifiedConfig` first and check *that* against
+ * a separate set of schemas — and the two sets disagreed on what counts as
+ * valid. A config could pass one and fail the other, on a rule that was
+ * already live in production.
+ *
+ * Rather than only unit-testing each fixed field in isolation (see
+ * firewallSchemas.test.ts / unifiedSchemas.test.ts / commonSchemas.test.ts),
+ * this file exercises the actual translation pipeline (`toUnifiedConfig`,
+ * the same function `status`/`diff`/`backup` call) against one config
+ * combining all three real-world cases from the issues, and asserts both
+ * validation paths accept it. This is the "shared regression test" #213 and
+ * #219 both suggested — a fix to one field, verified only in isolation,
+ * wouldn't have caught a fourth field drifting the same way in the future
+ * the way this end-to-end check would.
+ */
+describe('native vs unified schema agreement (regression tests for #212/#213/#219)', () => {
+  // Modeled directly on the real griffen.codes rules each issue quoted.
+  const nativeConfig: FirewallConfig = {
+    projectId: 'prj_test',
+    teamId: 'team_test',
+    version: 5,
+    rules: [
+      {
+        id: 'rule_allow_supabase_cookies',
+        name: 'Allow Supabase Cookies',
+        // #213: `nex` (exists/not_exists) conditions carry no `value`.
+        conditionGroup: [{ conditions: [{ type: 'cookie', op: 'nex', key: 'supabase_auth' }] }],
+        action: { mitigate: { action: 'bypass' } },
+        active: true,
+      },
+      {
+        id: 'rule_emergency_redirect',
+        name: 'Emergency redirect',
+        conditionGroup: [{ conditions: [{ type: 'path', op: 'eq', value: '/old-page' }] }],
+        // #212: a relative-path redirect location, not an absolute URL.
+        action: { mitigate: { action: 'redirect', redirect: { location: '/correct-path' } } },
+        active: true,
+      },
+    ],
+    // #219: no `hostname` on the IP rule.
+    ips: [{ id: 'ip_blocked', ip: '192.168.1.100/32', action: 'deny', notes: 'Known bad actor' }],
+  }
+
+  it("passes doorman validate's native schema (firewallConfigSchema)", () => {
+    const result = firewallConfigSchema.safeParse(nativeConfig)
+    expect(result.success).toBe(true)
+  })
+
+  it("also passes status/diff/backup/sync's schema (unifiedConfigSchema), once translated by the same toUnifiedConfig() they call", () => {
+    const unified = toUnifiedConfig(nativeConfig)
+    const result = unifiedConfigSchema.safeParse(unified)
+
+    if (!result.success) {
+      // Fail with the actual Zod issues, not just true/false — this is the
+      // one test in the suite most likely to need real debugging if a
+      // future field reintroduces this class of drift.
+      throw new Error(
+        `unifiedConfigSchema rejected the translated config:\n${JSON.stringify(result.error.issues, null, 2)}`,
+      )
+    }
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/lib/schemas/__tests__/unifiedSchemas.test.ts
+++ b/src/lib/schemas/__tests__/unifiedSchemas.test.ts
@@ -64,6 +64,25 @@ describe('unifiedSchemas', () => {
       })
       expect(result.success).toBe(false)
     })
+
+    it.each(['exists', 'not_exists'])(
+      'accepts a %s condition with no value at all, matching ruleConditionSchema (regression test for #213)',
+      (operator) => {
+        // The exact real-world case from #213 (a deployed griffen.codes rule,
+        // translated from Vercel's `op: "nex"` via mapVercelOperatorToUnified).
+        const result = unifiedConditionSchema.safeParse({
+          field: 'cookie',
+          operator,
+          key: 'supabase_auth',
+        })
+        expect(result.success).toBe(true)
+      },
+    )
+
+    it('still requires a value for every other operator', () => {
+      const result = unifiedConditionSchema.safeParse({ field: 'path', operator: 'eq' })
+      expect(result.success).toBe(false)
+    })
   })
 
   describe('unifiedActionSchema', () => {

--- a/src/lib/schemas/commonSchemas.ts
+++ b/src/lib/schemas/commonSchemas.ts
@@ -78,7 +78,17 @@ export const rateLimitSchema = z.object({
 
 // Redirect schema
 export const redirectSchema = z.object({
-  location: z.string().url(),
+  // Accepts an absolute URL or a relative path (e.g. "/v2/api/") — the
+  // native Vercel schema (firewallSchemas.ts's redirectSchema) never
+  // constrained this at all, and relative paths are both documented
+  // (references/rules.md) and used by real deployed rules. A bare
+  // `.url()` here rejected both. See #212.
+  location: z
+    .string()
+    .refine(
+      (value) => value.startsWith('/') || z.string().url().safeParse(value).success,
+      'location must be an absolute URL or a path starting with "/"',
+    ),
   statusCode: z.number().int().min(300).max(399).optional(),
   permanent: z.boolean().optional(),
   preserveQueryString: z.boolean().optional(),

--- a/src/lib/schemas/firewallSchemas.ts
+++ b/src/lib/schemas/firewallSchemas.ts
@@ -180,7 +180,10 @@ export { ruleActionSchema }
 export const ipBlockingRuleSchema = z.object({
   id: idSchema,
   ip: ipAddressSchema,
-  hostname: z.string(),
+  // Optional: purely informational (references/rules.md), matching
+  // unifiedIPRuleSchema and the documented behavior — Vercel's API doesn't
+  // need it. See #219.
+  hostname: z.string().optional(),
   notes: z.string().optional(),
   action: z.literal('deny'),
 }) satisfies z.ZodType<IPBlockingRule>

--- a/src/lib/schemas/unifiedSchemas.ts
+++ b/src/lib/schemas/unifiedSchemas.ts
@@ -18,13 +18,25 @@ import {
  */
 
 // Unified condition schema
-export const unifiedConditionSchema = z.object({
-  field: fieldTypeSchema.or(z.string()), // Allow custom fields
-  operator: operatorSchema,
-  value: z.union([z.string(), z.number(), z.array(z.string()), z.array(z.number())]),
-  negated: z.boolean().optional(),
-  key: z.string().optional(), // For header, query, cookie
-}) satisfies z.ZodType<UnifiedCondition>
+export const unifiedConditionSchema = z
+  .object({
+    field: fieldTypeSchema.or(z.string()), // Allow custom fields
+    operator: operatorSchema,
+    value: z.union([z.string(), z.number(), z.array(z.string()), z.array(z.number())]).optional(),
+    negated: z.boolean().optional(),
+    key: z.string().optional(), // For header, query, cookie
+  })
+  .refine(
+    // `exists`/`not_exists` (unified's equivalent of Vercel's `ex`/`nex` —
+    // see providers/vercel/translator.ts's operator map) carry no value by
+    // design, per #85. ruleConditionSchema (firewallSchemas.ts) already
+    // gets this right; this schema never did, so a real rule translated
+    // from a valid native config (any `ex`/`nex` condition) failed
+    // status/diff/backup even though `doorman validate` accepted it. #213.
+    (condition) =>
+      condition.operator === 'exists' || condition.operator === 'not_exists' || condition.value !== undefined,
+    { message: 'value is required unless operator is "exists" or "not_exists"', path: ['value'] },
+  ) satisfies z.ZodType<UnifiedCondition>
 
 // Unified action schema
 export const unifiedActionSchema = z.object({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,7 +90,7 @@ export interface CustomRule {
 export interface IPBlockingRule {
   id?: string
   ip: string
-  hostname: string
+  hostname?: string // Informational only — not required by Vercel's API (#219)
   notes?: string
   action: 'deny' // Currently only 'deny' is supported for IP blocking
 }

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -13,7 +13,8 @@ import type { ProviderType } from '../providers/IFirewallProvider'
 export interface UnifiedCondition {
   field: FieldType | string
   operator: Operator
-  value: string | number | string[] | number[]
+  // Optional: `exists`/`not_exists` operators carry no value by design (#85, #213).
+  value?: string | number | string[] | number[]
   negated?: boolean
   key?: string // For header, query, cookie conditions
   /**

--- a/src/lib/types/vercel.ts
+++ b/src/lib/types/vercel.ts
@@ -116,7 +116,7 @@ export interface VercelCustomRule {
 export interface VercelIPBlockingRule {
   id?: string
   ip: string
-  hostname: string
+  hostname?: string // Informational only — not required by Vercel's API (#219)
   notes?: string
   action: 'deny' // Currently only 'deny' is supported for IP blocking
 }

--- a/src/lib/ui/table/formatIPBlockingRule.ts
+++ b/src/lib/ui/table/formatIPBlockingRule.ts
@@ -16,7 +16,7 @@ export function formatIPBlockingRule(rule: IPBlockingRule & { changeStatus?: str
   return {
     id: rule.id || '-',
     ip: rule.ip,
-    hostname: rule.hostname,
+    hostname: rule.hostname || '-',
     notes: rule.notes || '-',
     status: rule.changeStatus ? chalk.yellow(rule.changeStatus) : chalk.red('deny'),
   }


### PR DESCRIPTION
Fixes #212. Fixes #213. Fixes #219.

## Problem

`doorman validate` checks a config against the native (Vercel-shaped) schemas. `status`/`diff`/`backup`/`sync` translate the same on-disk config to `UnifiedConfig` first (`toUnifiedConfig`) and check *that* against a separate set of schemas. The two sets disagreed in three independent ways — each one rejecting a rule that was already live in production on a real Vercel Firewall (`griffen.codes`, predates `doorman`), while the *other* schema accepted the same file fine:

- **#212**: `commonSchemas.ts`'s `redirectSchema.location` required `z.string().url()`, rejecting relative paths (e.g. `/correct-path`) even though they're documented (`references/rules.md`) and the native `redirectSchema` in `firewallSchemas.ts` never constrained this field at all.
- **#213**: `unifiedSchemas.ts`'s `unifiedConditionSchema` required `value` unconditionally — no exemption for `exists`/`not_exists` (unified's name for Vercel's `ex`/`nex`), which by design (#85) carry no value. `ruleConditionSchema` (native) already had this exemption; it never made it into the unified schema.
- **#219**: this time the *native* schema was the wrong one — `firewallSchemas.ts`'s `ipBlockingRuleSchema` required `hostname`, but `unifiedIPRuleSchema`, both TS types (`unified.ts` vs. `vercel.ts`), and the skill docs already agreed it's optional and purely informational.

## Fix

- **#212**: `redirectSchema.location` now accepts an absolute URL *or* a path starting with `/`.
- **#213**: `unifiedConditionSchema` ports the same exists/not_exists exemption `ruleConditionSchema` already had. `UnifiedCondition.value` is now optional in the TS type to match (only cascade: `formatIPBlockingRule.ts`'s table renderer needed a `|| '-'` fallback for the newly-optional `hostname`, matching the pattern it already uses for `notes`).
- **#219**: `ipBlockingRuleSchema.hostname` now optional, matching `unifiedIPRuleSchema`. Both `IPBlockingRule` and `VercelIPBlockingRule` TS types updated to match (they're documented as structurally-parallel-but-separate interfaces — see `vercelConfigAdapter.ts`'s own comment on this — so both needed the same fix or this would just reintroduce the same class of drift between them).
- **Secondary, per #219's own note**: `doorman validate` without `--verbose` only ever threw `"Configuration validation failed"` with zero detail — verbose mode already printed the real Zod/AJV errors, non-verbose mode didn't surface them at all. Now it does, without double-printing under `--verbose`.

## The "shared regression test" both #213 and #219 asked for

Both issues suggested this as the real fix, not just patching the field that got reported: *"might be worth a shared regression test asserting `validate` and `status`/`diff`'s internal validation accept the same set of configs, given this is now the second/third time the two schemas have disagreed on the same file."*

Added `nativeUnifiedSchemaAgreement.test.ts`: one config combining all three real-world cases, asserted against `firewallConfigSchema` (validate's path) **and** against `unifiedConfigSchema` after running through the actual `toUnifiedConfig()` translation `status`/`diff`/`backup` call — not just isolated per-field schema checks. A future field drifting the same way should fail this test even if nobody thought to unit-test that specific field in isolation.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean — 1484 tests, +11 new across `commonSchemas.test.ts`, `unifiedSchemas.test.ts`, the new `firewallSchemas.test.ts` (didn't exist before this PR) and `nativeUnifiedSchemaAgreement.test.ts`, plus `validate.test.ts`.
- Mutation-verify: reverted the four behavior-carrying files (`commonSchemas.ts`, `unifiedSchemas.ts`, `firewallSchemas.ts`, `validate.ts`) to `origin/main` at once, kept the new/updated tests — all 7 failed with the exact expected Zod/AJV errors. The agreement test's second assertion is worth calling out specifically: against the reverted code it dumped **both** the #212 (`invalid url`) and #213 (`value` required) issues simultaneously from one translated config, exactly the combined-failure scenario the test exists to catch. Restored the fix, full suite green again — one unrelated flake in `CloudflarePerformanceBenchmarks.test.ts`'s timing assertion along the way, confirmed by re-running that file alone (19/19 clean), not caused by this change.
- End-to-end against the real compiled CLI, and this surfaced a real gap the unit tests alone would have missed: `doorman validate` on a local config combining all three shapes *still* failed on `hostname` after the source fix, because `schema/firewall-config.schema.json` and `src/constants/schema.ts` are generated build artifacts — `ValidationService`'s AJV layer validates against those, not the Zod schemas directly — and they were stale until `pnpm build:schema` regenerated them and the dist bundle was rebuilt. Both regenerated files are included in this commit (not reverted the way the incidental pre-commit-hook reformats are). After that, verified `status`, `diff`, and `backup` too, against `demos/mock-server.mjs` with a fixture built from the same three shapes — real HTTP → `vercelToUnified` translation → unified schema, not just direct function calls — all four commands now succeed end-to-end where they previously hard-failed.
