### PR TITLE
fix: stop vercelToUnified writing undefined-valued keys, breaking diffs

### DIFF
--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -867,6 +867,150 @@ describe('VercelFirewallService', () => {
       expect(changes.hasChanges).toBe(false)
     })
 
+    it('should detect no changes for a non-trivial rule with an ordinary (non-negated) condition (regression test for #203)', async () => {
+      // Empty rules/ips (above) can never exercise the diff comparison this
+      // guards — vercelToUnified previously wrote `negated: condition.neg`
+      // and `key: condition.key` unconditionally, so an ordinary condition
+      // (no `neg`/`key` in the source) translated to `negated: undefined`/
+      // `key: undefined` rather than omitting the keys entirely. isDeepEqual
+      // treats that as a different object shape than the local config (which,
+      // loaded from disk, never has those keys at all — JSON.stringify drops
+      // `undefined`), so this rule would show up as a phantom "update" on
+      // every single sync. Same bug, same fix shape, as Fastly's
+      // pushUnifiedCondition (see FastlyFirewallService.test.ts).
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [mockVercelConfig.rules[0]!],
+        ips: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bots',
+            description: 'Block bad bots',
+            enabled: true,
+            // Deliberately no `negated`/`key` keys — matches what a real
+            // local .doorman.json has for an ordinary condition. `group: 0`
+            // and `conditionLogic: 'AND'` are included because
+            // vercelToUnified legitimately always sets both (source group
+            // index; single-group default) — they're not part of the
+            // undefined-vs-absent bug this test targets, and omitting them
+            // here would fail the comparison for an unrelated reason
+            // (getChanges compares configRule as-authored, without applying
+            // unifiedRuleSchema's conditionLogic default first — a separate,
+            // real gap, filed as its own issue rather than folded in here).
+            conditionLogic: 'AND',
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot', group: 0 }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('should detect no changes for a rate-limit rule with only requests/window set (regression test for #203)', async () => {
+      // Same class of bug, one level up from conditions: vercelToUnified's
+      // action-building previously wrote rateLimit/redirect/duration (and,
+      // nested, characteristics/mitigationTimeout/countingExpression) as
+      // undefined-valued keys rather than omitting them, for exactly the
+      // shape doorman's own "Rate Limit API" template produces (requests +
+      // window only, nothing else).
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [
+          {
+            id: 'rule_2',
+            name: 'Rate Limit API',
+            active: true,
+            conditionGroup: [{ conditions: [{ type: 'path' as const, op: 'pre' as const, value: '/api/' }] }],
+            action: {
+              mitigate: {
+                action: 'rate_limit' as const,
+                rateLimit: { requests: 100, window: '1m' },
+                redirect: null,
+                actionDuration: null,
+              },
+            },
+          },
+        ],
+        ips: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_2',
+            name: 'Rate Limit API',
+            enabled: true,
+            conditionLogic: 'AND',
+            conditions: [{ field: 'path', operator: 'starts_with', value: '/api/', group: 0 }],
+            action: { type: 'rate_limit', rateLimit: { requests: 100, window: '1m' } },
+          },
+        ],
+        ips: [],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('should detect no changes for a redirect rule with permanent unset (regression test for #203)', async () => {
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [
+          {
+            id: 'rule_3',
+            name: 'Redirect old page',
+            active: true,
+            conditionGroup: [{ conditions: [{ type: 'path' as const, op: 'eq' as const, value: '/old' }] }],
+            action: {
+              mitigate: {
+                action: 'redirect' as const,
+                redirect: { location: '/new' },
+                rateLimit: null,
+                actionDuration: null,
+              },
+            },
+          },
+        ],
+        ips: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_3',
+            name: 'Redirect old page',
+            enabled: true,
+            conditionLogic: 'AND',
+            conditions: [{ field: 'path', operator: 'eq', value: '/old', group: 0 }],
+            action: { type: 'redirect', redirect: { location: '/new' } },
+          },
+        ],
+        ips: [],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
     it('should include version from remote config', async () => {
       jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue(mockVercelConfig)
 
@@ -918,6 +1062,30 @@ describe('VercelFirewallService', () => {
       expect(changes.ipsToUpdate?.[0]?.hostname).toBe('changed.example.com')
       expect(changes.ipsToAdd).toHaveLength(0)
       expect(changes.ipsToDelete).toHaveLength(0)
+    })
+
+    it('should detect no changes for an IP rule with no hostname/notes set (regression test for #203)', async () => {
+      // Same class of bug as the rule-level fixes above, in
+      // vercelIPToUnified: a hostname-less IP rule (the real #219 scenario)
+      // previously still produced `hostname: undefined, notes: undefined`
+      // keys, so it would phantom-diff on every sync too.
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [],
+        ips: [{ id: 'ip_2', ip: '192.168.1.100/32', action: 'deny' as const }],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [],
+        ips: [{ id: 'ip_2', ip: '192.168.1.100/32', action: 'deny' }],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.ipsToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
     })
 
     it('treats an id-less local rule as an addition rather than matching it to an unrelated remote rule', async () => {

--- a/src/lib/providers/vercel/translator.ts
+++ b/src/lib/providers/vercel/translator.ts
@@ -53,8 +53,15 @@ export function vercelToUnified(rule: VercelCustomRule): TranslationResult<Unifi
         field: mapVercelTypeToUnified(condition.type),
         operator,
         value: condition.value as string | number | string[] | number[],
-        negated: condition.neg,
-        key: condition.key,
+        // Conditional spread, not `negated: condition.neg` — an unconditional
+        // assignment creates a `negated: undefined` key for an ordinary
+        // condition, which isDeepEqual treats as a different shape than the
+        // key being absent entirely (the local-config-loaded-from-disk case,
+        // since JSON.stringify drops undefined). That mismatch makes every
+        // non-negated rule show up as a phantom "update" on every sync. Same
+        // bug, same fix, as Fastly's pushUnifiedCondition. See #203.
+        ...(condition.neg ? { negated: true } : {}),
+        ...(condition.key ? { key: condition.key } : {}),
         group: groupIndex,
       })
     }
@@ -73,30 +80,54 @@ export function vercelToUnified(rule: VercelCustomRule): TranslationResult<Unifi
     )
   }
 
+  // Conditional spread, not `key: value ?? undefined` — the same
+  // undefined-vs-absent-key bug as the condition loop above (see #203), one
+  // level up: an ordinary rule with no rate limit/redirect/duration set
+  // (the common case — deny/challenge/log/bypass) previously still produced
+  // `rateLimit: undefined, redirect: undefined, duration: undefined` keys,
+  // which isDeepEqual treats as extra keys the local config never has.
   const action: UnifiedAction = {
     type: rule.action.mitigate.action,
-    rateLimit: rule.action.mitigate.rateLimit
+    ...(rule.action.mitigate.rateLimit
       ? {
-          requests: rule.action.mitigate.rateLimit.requests,
-          window: rule.action.mitigate.rateLimit.window,
-          characteristics: rule.action.mitigate.rateLimit.characteristics,
-          mitigationTimeout: rule.action.mitigate.rateLimit.mitigationTimeout,
-          countingExpression: rule.action.mitigate.rateLimit.countingExpression,
+          rateLimit: {
+            requests: rule.action.mitigate.rateLimit.requests,
+            window: rule.action.mitigate.rateLimit.window,
+            // Same conditional-spread reasoning, nested one level further —
+            // a rate-limit rule with only requests/window set (the common
+            // case, including doorman's own "Rate Limit API" template) still
+            // produced these three as undefined-valued keys otherwise.
+            ...(rule.action.mitigate.rateLimit.characteristics
+              ? { characteristics: rule.action.mitigate.rateLimit.characteristics }
+              : {}),
+            ...(rule.action.mitigate.rateLimit.mitigationTimeout
+              ? { mitigationTimeout: rule.action.mitigate.rateLimit.mitigationTimeout }
+              : {}),
+            ...(rule.action.mitigate.rateLimit.countingExpression
+              ? { countingExpression: rule.action.mitigate.rateLimit.countingExpression }
+              : {}),
+          },
         }
-      : undefined,
-    redirect: rule.action.mitigate.redirect
+      : {}),
+    ...(rule.action.mitigate.redirect
       ? {
-          location: rule.action.mitigate.redirect.location,
-          permanent: rule.action.mitigate.redirect.permanent,
+          redirect: {
+            location: rule.action.mitigate.redirect.location,
+            ...(rule.action.mitigate.redirect.permanent ? { permanent: rule.action.mitigate.redirect.permanent } : {}),
+          },
         }
-      : undefined,
-    duration: rule.action.mitigate.actionDuration || undefined,
+      : {}),
+    ...(rule.action.mitigate.actionDuration ? { duration: rule.action.mitigate.actionDuration } : {}),
   }
 
   const unifiedRule: UnifiedRule = {
     id: rule.id,
     name: rule.name,
-    description: rule.description,
+    // Conditional spread, not `description: rule.description` — same
+    // undefined-vs-absent-key bug, one more level up: a rule with no
+    // description (very common — it's optional in both shapes) previously
+    // still produced a `description: undefined` key. See #203.
+    ...(rule.description ? { description: rule.description } : {}),
     enabled: rule.active,
     conditions,
     // Informational only once `group` is set above — real join semantics
@@ -180,8 +211,12 @@ export function vercelIPToUnified(ip: VercelIPBlockingRule): UnifiedIPRule {
   return {
     id: ip.id,
     ip: ip.ip,
-    hostname: ip.hostname,
-    notes: ip.notes,
+    // Conditional spread — same undefined-vs-absent-key bug as
+    // vercelToUnified above (#203): a hostname-less IP rule (both fields
+    // are optional; hostname especially so after #219) previously still
+    // produced `hostname: undefined, notes: undefined` keys.
+    ...(ip.hostname ? { hostname: ip.hostname } : {}),
+    ...(ip.notes ? { notes: ip.notes } : {}),
     action: ip.action,
   }
 }


### PR DESCRIPTION
Fixes #203.

## Problem

#203 asked to verify whether `vercelToUnified` had the same bug already found and fixed in Fastly's translator: unconditionally assigning an optional field (`negated: condition.neg`, `key: condition.key`) instead of a conditional spread. `isDeepEqual` compares `Object.keys().length` between the two sides — `{ negated: undefined, ... }` has one more key than an object that omits `negated` entirely, even though both mean "not negated." A local config loaded from disk never has the key for an ordinary condition (`JSON.stringify` drops `undefined` on save), but the remote side, freshly translated on every `status`/`diff`/`sync`, always did. **Every non-negated rule showed up as a phantom "update" on every single sync, forever.**

Confirmed real before touching anything (per the issue's own "needs verifying against real behavior, not just reasoning about the code"): wrote the regression test first, ran it against the unmodified translator, watched it fail with exactly the predicted shape.

## Fix, and what else the same sweep found

Fixed `condition.neg`/`condition.key` as reported. While confirming the fix actually closed the gap (my first test still failed after that alone), the same exact pattern turned up three more times in the same file, each blocking the "no changes when configs match" scenario for increasingly common cases:

- **The action object** (`rateLimit`/`redirect`/`duration`) — hits *any* ordinary `deny`/`challenge`/`log`/`bypass` rule, arguably more common than a negated condition.
- **Nested inside `rateLimit`** (`characteristics`/`mitigationTimeout`/`countingExpression`) and **inside `redirect`** (`permanent`) — hits any rule using doorman's own "Rate Limit API" template, or any redirect rule.
- **The rule-level `description` field**, and **`vercelIPToUnified`'s `hostname`/`notes`** — a hostname-less IP rule (today's #219 fix made that a supported, documented shape) hits this too.

All fixed the same way: conditional spread instead of unconditional assignment. I stopped there rather than chasing this pattern further — see the scope note below.

**Cloudflare's translator was checked too**, per #203's own suggestion — it doesn't have this pattern at all (it builds Wirefilter expression strings, not structured `negated`/`key` conditions), so there's nothing to fix on that side.

## What's deliberately *not* in this PR

Isolating the regression test surfaced an adjacent but distinct bug: a local rule that omits `conditionLogic` (which `unifiedRuleSchema` defaults to `'AND'`) also phantom-diffs, because `getChanges` calls `unifiedConfigSchema.safeParse(config)` for validation only and then diffs the original *unparsed* `config.rules` — the schema's default never actually gets applied before comparison. Different root cause (defaulting/parsing, not conditional-assignment), so filed separately as **#225** rather than folded in here.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean — 1488 tests, +5 new in `VercelFirewallService.test.ts`.
- Mutation-verify: reverted `translator.ts` to `origin/main`, kept the new/updated tests — all 4 failed with the exact expected shape. The IP-rule test's failure output is worth calling out specifically: Jest's diff literally printed `"hostname": undefined, "notes": undefined` in the received object — about as direct a confirmation of the bug as a failure message gets. Restored the fix, full suite green again (one unrelated flake in `CloudflarePerformanceBenchmarks.test.ts`, confirmed by re-running that file alone: 19/19 clean).
- End-to-end against `demos/mock-server.mjs`: a fixture combining an ordinary `deny` rule, a rate-limit rule, and a hostname-less IP rule, with a matching local config — `doorman diff` and `doorman status` both report zero changes, matching what a real "nothing actually changed" sync should see.
