### PR TITLE
fix: unifiedToCloudflare never populated redirect action_parameters

### DIFF
--- a/src/lib/providers/cloudflare/__tests__/translator.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/translator.test.ts
@@ -181,15 +181,30 @@ describe('cloudflare/translator', () => {
       expect(result.ratelimit!.characteristics).toEqual(['ip.src'])
     })
 
-    it('defaults mitigation_timeout to 3600 when not specified', () => {
+    it('defaults mitigation_timeout to 3600 when not specified, and warns about it (regression test for #199)', () => {
       const rule = makeUnifiedRule({
         action: {
           type: 'rate_limit',
           rateLimit: { requests: 10, window: '60s' },
         },
       })
-      const { result } = unifiedToCloudflare(rule)
+      const { result, warnings } = unifiedToCloudflare(rule)
       expect(result.ratelimit!.mitigation_timeout).toBe(3600)
+      // The dead vercelToCloudflare code this was ported from warned here;
+      // unifiedToCloudflare silently defaulted the same value with nothing
+      // telling the user it happened.
+      expect(warnings.some((w) => w.field === 'action.rateLimit.mitigationTimeout')).toBe(true)
+    })
+
+    it('does not warn about mitigation_timeout when it was explicitly set', () => {
+      const rule = makeUnifiedRule({
+        action: {
+          type: 'rate_limit',
+          rateLimit: { requests: 10, window: '60s', mitigationTimeout: 600 },
+        },
+      })
+      const { warnings } = unifiedToCloudflare(rule)
+      expect(warnings.some((w) => w.field === 'action.rateLimit.mitigationTimeout')).toBe(false)
     })
 
     it('uses rule name as description fallback', () => {
@@ -230,6 +245,61 @@ describe('cloudflare/translator', () => {
         const { result } = unifiedToCloudflare(rule)
         expect(result.ratelimit!.period).toBe(86400)
       })
+    })
+  })
+
+  // Regression coverage for #199: unifiedToCloudflare mapped action.type
+  // 'redirect' to Cloudflare's `action: 'redirect'` but never populated
+  // action_parameters.from_value — the target URL and status code a
+  // Cloudflare redirect rule actually needs to do anything. A second,
+  // now-deleted translator (dead code, zero production callers) got this
+  // right; the live path never did.
+  describe('redirect action (UnifiedAction.redirect)', () => {
+    const redirectRule = (redirect: UnifiedRule['action']['redirect']): UnifiedRule => ({
+      id: 'r3',
+      name: 'Redirect old page',
+      enabled: true,
+      conditions: [{ field: 'path', operator: 'eq', value: '/old' }],
+      action: { type: 'redirect', redirect },
+    })
+
+    it('emits action_parameters.from_value with status 302 for a non-permanent redirect', () => {
+      const { result, warnings } = unifiedToCloudflare(redirectRule({ location: '/new' }))
+
+      expect(result.action).toBe('redirect')
+      expect(result.action_parameters).toEqual({
+        from_value: { status_code: 302, target_url: { value: '/new' } },
+      })
+      expect(warnings).toEqual([])
+    })
+
+    it('uses status 301 when permanent is true', () => {
+      const { result } = unifiedToCloudflare(redirectRule({ location: '/new', permanent: true }))
+
+      expect(result.action_parameters).toEqual({
+        from_value: { status_code: 301, target_url: { value: '/new' } },
+      })
+    })
+
+    it('prefers an explicit statusCode over the permanent-derived 301/302', () => {
+      const { result } = unifiedToCloudflare(redirectRule({ location: '/new', statusCode: 308, permanent: true }))
+
+      expect(result.action_parameters).toEqual({
+        from_value: { status_code: 308, target_url: { value: '/new' } },
+      })
+    })
+
+    it('includes preserve_query_string when set', () => {
+      const { result } = unifiedToCloudflare(redirectRule({ location: '/new', preserveQueryString: true }))
+
+      expect(result.action_parameters).toEqual({
+        from_value: { status_code: 302, target_url: { value: '/new' }, preserve_query_string: true },
+      })
+    })
+
+    it('does not set action_parameters at all when a redirect action has no redirect details', () => {
+      const { result } = unifiedToCloudflare(redirectRule(undefined))
+      expect(result.action_parameters).toBeUndefined()
     })
   })
 

--- a/src/lib/providers/cloudflare/translator.ts
+++ b/src/lib/providers/cloudflare/translator.ts
@@ -112,11 +112,38 @@ export function unifiedToCloudflare(rule: UnifiedRule): TranslationResult<Cloudf
     } else {
       // Default to 1 hour (3600 seconds) for rate limit blocks
       cloudflareRule.ratelimit.mitigation_timeout = 3600
+      warnings.push(
+        TranslationWarningSystem.createWarning(
+          'rate_limiting_precision',
+          rule.id,
+          'action.rateLimit.mitigationTimeout',
+          `No mitigationTimeout set for rate limit rule "${rule.name}" — defaulted to Cloudflare's 3600s (1 hour) block duration.`,
+        ),
+      )
     }
 
     // Add counting expression if specified
     if (rule.action.rateLimit.countingExpression) {
       cloudflareRule.ratelimit.counting_expression = rule.action.rateLimit.countingExpression
+    }
+  }
+
+  // Redirect target. Without this, a translated redirect rule reaches
+  // Cloudflare as `action: 'redirect'` with no destination at all — an
+  // incomplete rule the API is likely to reject outright, or silently
+  // accept as a redirect-to-nowhere. See #199. Prefers an explicit
+  // `statusCode` (redirectSchema supports any 3xx) over the permanent-only
+  // 301/302 the previous (dead, since-removed) vercelToCloudflare code
+  // used, since the unified type carries more precision than that.
+  if (rule.action.type === 'redirect' && rule.action.redirect) {
+    cloudflareRule.action_parameters = {
+      from_value: {
+        status_code: rule.action.redirect.statusCode ?? (rule.action.redirect.permanent ? 301 : 302),
+        target_url: { value: rule.action.redirect.location },
+        ...(rule.action.redirect.preserveQueryString !== undefined
+          ? { preserve_query_string: rule.action.redirect.preserveQueryString }
+          : {}),
+      },
     }
   }
 


### PR DESCRIPTION
Fixes #199.

## Problem

`unifiedToCloudflare` (the live path — used by `CloudflareFirewallService.syncRules`) maps `action.type: 'redirect'` to Cloudflare's `action: 'redirect'`, but never populated `action_parameters.from_value` — the target URL and status code a Cloudflare redirect rule actually needs. A `UnifiedConfig` rule with a redirect action, synced to Cloudflare, produced a rule with `action: 'redirect'` and no destination.

Found via a second, dead `vercelToCloudflare` function (zero production callers, removed in #196's cleanup) that correctly built this — the live `unifiedToCloudflare` never had the equivalent logic; the two functions' redirect handling diverged at some point and nothing caught the gap, since nothing exercised redirect-to-Cloudflare through the live path in the test suite either.

## Fix

Ported the dead code's logic into `unifiedToCloudflare`, adapted from Vercel's shape (`rule.action.mitigate.redirect`) to Unified's (`rule.action.redirect`) — with one deliberate improvement over a literal port: `UnifiedAction.redirect` also carries an explicit `statusCode` (the unified `redirectSchema` supports any 3xx code, not just 301/302) and `preserveQueryString`, and `CloudflareRedirectActionParameters.from_value` already supports both on the target side too. So `status_code` now prefers an explicit `statusCode` when set, falling back to the permanent-only 301/302 derivation the dead code used, and `preserve_query_string` is carried through when set — rather than reproducing the older code's narrower behavior just because that's what existed before.

Also fixed the smaller instance flagged alongside it: the dead code warned when defaulting a rate-limit rule's `mitigationTimeout` to Cloudflare's 3600s; the live path applied the same default silently. Reused the existing `rate_limiting_precision` warning key (already used by Fastly's translator for the same category of adjustment) rather than inventing a new one.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean — 1490 tests, +7 new in `cloudflare/__tests__/translator.test.ts` (5 for the redirect fix, 2 for the mitigation_timeout warning).
- Mutation-verify: reverted `translator.ts` to `origin/main`, kept the new tests — all 5 redirect tests failed with `action_parameters: undefined` (exactly the reported bug — a redirect rule producing no destination), the warning test failed with no matching warning present. Restored the fix, full suite green again (one unrelated flake in `CloudflarePerformanceBenchmarks.test.ts`, confirmed by re-running that file alone: 19/19 clean).
- Per the issue's own acceptance criteria — "manual verification against `demos/mock-server.mjs` if it supports a Cloudflare fixture with a redirect rule; otherwise service-level test coverage is sufficient" — checked, and no Cloudflare mock server exists (only `mock-server.mjs` for Vercel and `fastly-mock-server.mjs`). The mutation-verified translator tests satisfy the stated fallback, since they exercise the real `unifiedToCloudflare` function directly rather than a mock of it.
