### PR TITLE
fix: stop retrying non-idempotent rule/IP creation on Vercel

### DIFF
--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -204,7 +204,11 @@ export class VercelClient extends BaseFirewallClient {
       },
     }
 
-    return this.patch<CustomRule>(this.getUrl(), body)
+    // `rules.insert` is not idempotent — a retry after a response is lost
+    // (e.g. a connection reset arriving after Vercel already created the
+    // rule) creates a second, duplicate rule. `rules.update` is safe to
+    // retry (keyed by id). See #195.
+    return this.patch<CustomRule>(this.getUrl(), body, isNewRule ? { retries: 0 } : undefined)
   }
 
   /**
@@ -256,7 +260,9 @@ export class VercelClient extends BaseFirewallClient {
       },
     }
 
-    return this.patch<IPBlockingRule>(this.getUrl(), body)
+    // Same non-idempotency risk as updateFirewallRule's `rules.insert` —
+    // see #195.
+    return this.patch<IPBlockingRule>(this.getUrl(), body, isNewRule ? { retries: 0 } : undefined)
   }
 
   /**

--- a/src/lib/providers/vercel/__tests__/VercelClient.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelClient.test.ts
@@ -236,6 +236,28 @@ describe('VercelClient', () => {
 
       await expect(client.updateFirewallRule(rule)).rejects.toThrow()
     })
+
+    // Regression tests for #195: rules.insert is not idempotent — retrying
+    // it after a response is lost (the request reached Vercel and created
+    // the rule, but the client never saw the success) creates a duplicate.
+    // rules.update is safe to retry (keyed by id).
+    it('does not retry a create (rules.insert) after a network failure', async () => {
+      const newRule = { ...rule, id: '-' }
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateFirewallRule(newRule)).rejects.toThrow()
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('still retries an update (rules.update) after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateFirewallRule(rule)).rejects.toThrow()
+
+      // Default `retries: 3` -> up to 4 attempts total.
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(1)
+    })
   })
 
   describe('createFirewallRule', () => {
@@ -329,6 +351,25 @@ describe('VercelClient', () => {
       const body = JSON.parse(calledOptions.body as string)
       expect(body.action).toBe('ip.insert')
       expect(body.id).toBeNull()
+    })
+
+    // Regression tests for #195 — same non-idempotency risk as
+    // updateFirewallRule's rules.insert.
+    it('does not retry a create (ip.insert) after a network failure', async () => {
+      const newIpRule = { ...ipRule, id: '-' }
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateIPBlockingRule(newIpRule)).rejects.toThrow()
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('still retries an update (ip.update) after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateIPBlockingRule(ipRule)).rejects.toThrow()
+
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(1)
     })
 
     it('should create an IP blocking rule via createIPBlockingRule', async () => {


### PR DESCRIPTION
Fixes #195.

## Problem

`BaseFirewallClient.makeRequest` retries every request up to 3 times, gated only on `AbortError` (timeouts) and non-429 4xx status. `VercelClient.updateFirewallRule`/`updateIPBlockingRule` route rule/IP **creation** through `PATCH` with `action: 'rules.insert'`/`'ip.insert'` — not idempotent. A connection reset arriving *after* Vercel already created the rule (not a timeout — those abort and were already excluded) retries and creates a second, duplicate rule the user never asked for.

## Design discussion (before implementing)

The issue lays out four options and recommends #1 (gate retries by method, with per-call opt-in). Discussed this in chat first rather than implementing directly, since taken literally "gate by HTTP method" has a wrinkle: Vercel puts both creation (`rules.insert`, unsafe) and update (`rules.update`, safe — keyed by id) on the *same* `PATCH` verb, so a blanket "PATCH doesn't retry" would also strip retry resilience from the safe update path.

Landed on a narrower version of the same recommendation: `RequestOptions.retries` already exists and already does exactly the right thing (`retries: 0` → exactly one attempt, no retry — confirmed by reading the loop: `for (attempt = 0; attempt <= retries; attempt++)`). So rather than adding a new idempotency-gating concept to `BaseFirewallClient`, the two non-idempotent call sites just pass it explicitly:

```ts
return this.patch<CustomRule>(this.getUrl(), body, isNewRule ? { retries: 0 } : undefined)
```

`rules.update`/`ip.update` are untouched and keep retrying by default. Cloudflare's `updateRuleset` (PUT, full-replace, genuinely idempotent) is also untouched — correctly out of scope per the issue's own scope table.

Skipped the other three options for the reasons the issue itself gives: idempotency keys (#2) aren't viable since Vercel's API doesn't offer one; reconcile-after-retry (#3) is real but meaningfully more complex and racy, worth revisiting only if duplicate-creation turns out to matter in practice rather than building it speculatively now; pre- vs post-send failure detection (#4) is inherently fuzzy across runtimes.

## Verification

- `pnpm compile && pnpm jest && pnpm eslint .` clean — 1498 tests, +4 new in `VercelClient.test.ts`.
- Mutation-verify: reverted `VercelClient.ts` to `origin/main`, kept the new tests — both "does not retry a create" tests failed with **4** fetch calls instead of 1 (default `retries: 3` → up to 4 attempts), exactly the duplicate-creation risk described. Restored the fix, full suite green again.
- End-to-end against `demos/mock-server.mjs`: a fresh rule synced via `doorman sync --ci` still creates exactly once and succeeds normally — confirms the fix doesn't touch the happy path. The retry-after-failure behavior itself is exercised directly by the fetch-mocked unit tests above (which drive the real retry loop in `BaseFirewallClient`, not a stub) — no dedicated failure-injection fixture exists for simulating a lost response specifically, the same mock-server gap noted in #199.
