### PR TITLE
refactor: make BaseFirewallClient.getAuthHeaders() async

### DIFF
--- a/src/lib/providers/BaseFirewallClient.ts
+++ b/src/lib/providers/BaseFirewallClient.ts
@@ -36,8 +36,15 @@ export abstract class BaseFirewallClient {
   /**
    * Get authentication headers for API requests
    * Must be implemented by provider-specific clients
+   *
+   * Async because not every provider's credential is a static token: GCP
+   * Cloud Armor's service-account/ADC auth resolves to a short-lived OAuth2
+   * access token that needs refreshing roughly hourly, so the header value
+   * has to be computed fresh per request rather than once at construction
+   * time. Called from inside makeRequest()'s retry loop, so a token that
+   * expires mid-retry gets refreshed on the next attempt for free.
    */
-  protected abstract getAuthHeaders(): Record<string, string>
+  protected abstract getAuthHeaders(): Promise<Record<string, string>>
 
   /**
    * Make an HTTP request with retry logic and rate limit handling
@@ -79,7 +86,7 @@ export abstract class BaseFirewallClient {
             ...fetchOptions,
             headers: {
               'Content-Type': 'application/json',
-              ...this.getAuthHeaders(),
+              ...(await this.getAuthHeaders()),
               ...fetchOptions.headers,
             },
             signal: controller.signal,

--- a/src/lib/providers/__tests__/BaseFirewallClient.test.ts
+++ b/src/lib/providers/__tests__/BaseFirewallClient.test.ts
@@ -6,7 +6,7 @@ class TestClient extends BaseFirewallClient {
   constructor(baseUrl = 'https://api.example.com') {
     super(baseUrl, 'vercel')
   }
-  protected getAuthHeaders(): Record<string, string> {
+  protected async getAuthHeaders(): Promise<Record<string, string>> {
     return { Authorization: 'Bearer TEST' }
   }
   // Avoid real delays during tests

--- a/src/lib/providers/cloudflare/CloudflareClient.ts
+++ b/src/lib/providers/cloudflare/CloudflareClient.ts
@@ -76,7 +76,7 @@ export class CloudflareClient extends BaseFirewallClient {
   /**
    * Get authentication headers
    */
-  protected getAuthHeaders(): Record<string, string> {
+  protected async getAuthHeaders(): Promise<Record<string, string>> {
     return {
       Authorization: `Bearer ${this.apiToken}`,
       ...this.optimizer.getConnectionHeaders(),

--- a/src/lib/providers/fastly/FastlyClient.ts
+++ b/src/lib/providers/fastly/FastlyClient.ts
@@ -36,7 +36,7 @@ export class FastlyClient extends BaseFirewallClient {
     super(FASTLY_API_BASE_URL, 'fastly')
   }
 
-  protected getAuthHeaders(): Record<string, string> {
+  protected async getAuthHeaders(): Promise<Record<string, string>> {
     return {
       'Fastly-Key': this.apiToken,
     }

--- a/src/lib/providers/vercel/VercelClient.ts
+++ b/src/lib/providers/vercel/VercelClient.ts
@@ -72,7 +72,7 @@ export class VercelClient extends BaseFirewallClient {
    * Generates the headers required for the Vercel API requests.
    * @returns An object containing the headers.
    */
-  protected getAuthHeaders(): Record<string, string> {
+  protected async getAuthHeaders(): Promise<Record<string, string>> {
     return {
       Authorization: `Bearer ${this.token}`,
     }


### PR DESCRIPTION
## Summary

First slice of the GCP Cloud Armor epic (#187) — groundwork, no GCP code yet.

Every existing provider's auth is a static token computed once — a plain header object, synchronous. GCP Cloud Armor's auth (service-account key / Application Default Credentials) resolves through OAuth2 to a short-lived access token (~1h TTL, not meaningfully extendable) that has to be fetched fresh per request rather than cached once at client construction, per `google-auth-library`'s own `GoogleAuth.getRequestHeaders()` contract (itself async).

Widened the one abstract method that assumption lived in (`BaseFirewallClient.getAuthHeaders()`), rather than reimplementing GCP's client outside `BaseFirewallClient` and duplicating its ~120 lines of retry/429-backoff/`Retry-After`-parsing logic. I checked first whether that logic is already available as a standalone, reusable utility (the steering doc's own `.kiro/steering/adding-a-provider.md` gestures at a "#198 composable retry utility" as the intended escape-hatch mechanism) — it isn't: `src/lib/utils/retry.ts` exists but is only used by one test in isolation, never wired into any real client's request path. So skipping `BaseFirewallClient` here would mean duplicating or weakening battle-tested logic, not reusing anything.

Purely mechanical, behavior-preserving for the three existing providers: `getAuthHeaders()` has exactly one call site (inside the already-`async` `makeRequest()`), and Vercel/Cloudflare/Fastly's overrides are trivial synchronous one/two-liners whose body is unchanged — only `async` added to each.

Bonus this ordering gives GCP for free: the retry loop calls `getAuthHeaders()` fresh on every attempt, so a token that expires mid-retry gets refreshed on the next attempt with no extra code.

## Verification

- `pnpm exec tsc --noEmit && pnpm jest && pnpm eslint .` clean — full 1507-test suite unchanged (no new tests: nothing behavioral changed, the existing suite is the regression check for a signature-only edit).
- End-to-end against the real doorman-www Vercel config: `doorman status` still authenticates and reports accurate sync status through the full real call chain, confirming the now-async auth path works identically in practice, not just in types.

## Test plan

- [x] Unit tests pass (`pnpm jest`)
- [x] Typecheck + lint clean
- [x] E2e sanity check against a real config