### PR TITLE
fix: noisy single-provider regex warnings, missing wordpress template id

### DIFF
--- a/src/lib/providers/vercel/__tests__/translator.test.ts
+++ b/src/lib/providers/vercel/__tests__/translator.test.ts
@@ -160,13 +160,20 @@ describe('vercel/translator', () => {
       expect(result.action.duration).toBe('1h')
     })
 
-    it('generates warning for regex patterns', () => {
+    // Regression test for #214 — vercelToUnified is the provider-agnostic
+    // Vercel-native -> Unified step every command (list/status/diff/backup/
+    // sync) runs on every fetch, with no destination provider in play. It
+    // previously warned "may need adjustment for target provider" on any
+    // regex condition unconditionally, which fired on ordinary single-
+    // provider Vercel usage with no migration happening at all — there's no
+    // call site today where this result feeds a different provider's
+    // unifiedToX translator, so the warning had no target to be about.
+    it('does not warn about regex patterns on ordinary (non-migration) translation', () => {
       const rule = makeVercelRule({
         conditionGroup: [{ conditions: [{ type: 'path', op: 're', value: '^/api/v[0-9]+' }] }],
       })
       const { warnings } = vercelToUnified(rule)
-      expect(warnings.length).toBeGreaterThan(0)
-      expect(warnings.some((w) => w.category === 'syntax_limitation')).toBe(true)
+      expect(warnings.some((w) => w.category === 'syntax_limitation')).toBe(false)
     })
 
     it('flattens multiple condition groups', () => {

--- a/src/lib/providers/vercel/translator.ts
+++ b/src/lib/providers/vercel/translator.ts
@@ -36,19 +36,6 @@ export function vercelToUnified(rule: VercelCustomRule): TranslationResult<Unifi
     for (const condition of group.conditions) {
       const operator = mapVercelOperatorToUnified(condition.op)
 
-      // Check for regex patterns and warn about potential compatibility issues
-      if (condition.op === 're' && typeof condition.value === 'string') {
-        warnings.push(
-          TranslationWarningSystem.createWarning(
-            'regex_patterns',
-            rule.id,
-            condition.type,
-            `Regular expression pattern may need adjustment for target provider: ${condition.value}`,
-            'Test the regex pattern in the target provider and adjust syntax if needed',
-          ),
-        )
-      }
-
       conditions.push({
         field: mapVercelTypeToUnified(condition.type),
         operator,

--- a/src/lib/templates/__tests__/index.test.ts
+++ b/src/lib/templates/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+import { templates } from '../index'
+
+describe('templates', () => {
+  it('gives every rule a stable, deterministic id (regression test for #217)', () => {
+    const rulesMissingIds = Object.entries(templates).flatMap(([templateName, template]) =>
+      template.config.rules.filter((rule) => !rule.id).map((rule) => `${templateName}: "${rule.name}"`),
+    )
+    expect(rulesMissingIds).toEqual([])
+  })
+
+  it("wordpress template's rule id matches Vercel's own generated id for the same rule name", () => {
+    const wordpress = templates.wordpress
+    expect(wordpress?.config.rules[0]?.id).toBe('rule_deny_word_press_ur_ls')
+  })
+})

--- a/src/lib/templates/rules/wordpress.ts
+++ b/src/lib/templates/rules/wordpress.ts
@@ -8,6 +8,7 @@ export const wordpress: Template = {
   config: {
     rules: [
       {
+        id: 'rule_deny_word_press_ur_ls',
         name: 'Deny WordPress URLs',
         description: '',
         conditionGroup: [

--- a/src/lib/translators/__tests__/TranslationWarningIntegration.test.ts
+++ b/src/lib/translators/__tests__/TranslationWarningIntegration.test.ts
@@ -42,14 +42,14 @@ describe('Translation Warning Integration', () => {
 
       const result = RuleTranslator.vercelToUnified(complexRule)
 
-      expect(result.warnings).toHaveLength(3) // 2 regex warnings + many conditions warning
-
-      // Check for regex pattern warnings
-      const regexWarnings = result.warnings.filter((w) => w.category === 'syntax_limitation')
-      expect(regexWarnings).toHaveLength(2) // user_agent and header regex patterns
-      expect(regexWarnings[0]?.message).toContain('Regular expression pattern')
-      expect(regexWarnings[0]?.severity).toBe('warning')
-      expect(regexWarnings[0]?.suggestion).toContain('Test the regex pattern')
+      // vercelToUnified is the provider-agnostic Vercel-native -> Unified
+      // step every command runs on every fetch, with no destination
+      // provider in play — it no longer warns about regex syntax here (see
+      // #214); that warning only makes sense once there's an actual target
+      // provider to translate into, which no current call site of this
+      // function has.
+      expect(result.warnings).toHaveLength(1) // many conditions warning only
+      expect(result.warnings.some((w) => w.category === 'syntax_limitation')).toBe(false)
 
       // Check for many conditions warning
       const performanceWarning = result.warnings.find((w) => w.category === 'performance_impact')


### PR DESCRIPTION
## Summary
- Closes #214 — `vercelToUnified` (the provider-agnostic Vercel-native → Unified step every command runs on every fetch) unconditionally warned "may need adjustment for target provider" on any regex condition, even for ordinary single-provider Vercel usage with no migration happening. Checked every call site (`VercelFirewallService.fetchConfig`/`getChanges`, `vercelConfigAdapter.toUnifiedConfig`) — all same-provider bookkeeping, none feed a different provider's `unifiedToX` translator. Removed the warning rather than threading speculative target-provider plumbing through for a caller that doesn't exist yet.
- Closes #217 — `wordpress` template's rule had no `id`, unlike `ai-bots`/`bad-bots`/`block-ofac-sanctioned-countries`. Added `id: 'rule_deny_word_press_ur_ls'`, the exact id Vercel itself generates for a rule with that name (confirmed against a real deployed rule), so it also matches what existing `vercel-doorman` users already have on disk.

## Test plan
- [x] Updated the two existing tests that asserted the old regex-warning behavior (`translator.test.ts`, `TranslationWarningIntegration.test.ts`)
- [x] Added `src/lib/templates/__tests__/index.test.ts` asserting every built-in template rule has an id, so a future template can't regress this silently
- [x] `pnpm test:ci` — 84/84 suites, 1509/1509 tests passing
- [x] `pnpm lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `pnpm build` — clean
- [x] Empirically verified both fixes against a real production Vercel firewall (16 rules, 4 with regex conditions): `status --ci` now runs with zero warnings; `template wordpress --ci --dry-run` now includes the `id`