### PR TITLE
feat: add CelExpressionBuilder/CelParser for Cloud Armor CEL

### DIFF
--- a/src/lib/translators/CelExpressionBuilder.ts
+++ b/src/lib/translators/CelExpressionBuilder.ts
@@ -1,0 +1,315 @@
+import type { UnifiedCondition } from '../types/unified'
+import { escapeCelString } from './celEscape'
+import { ipAddressSchema } from '../schemas/commonSchemas'
+
+/**
+ * Fields Cloud Armor's CEL vocabulary genuinely has no equivalent for, so a
+ * condition using one must fail loudly rather than be silently dropped or
+ * approximated. Confirmed against Cloud Armor's rules-language-reference —
+ * no continent/region/city-level geo attribute exists at all (only
+ * country-level `origin.region_code`), and no per-request port attribute
+ * exists (Cloud Armor operates at L7 behind a load balancer whose listening
+ * port isn't a per-request WAF-rule concern). `scheme` is deliberately
+ * omitted here too, pending confirmation of the actual CEL field name —
+ * safer to reject than to guess and emit something Cloud Armor rejects.
+ */
+const UNSUPPORTED_FIELDS = new Set(['region', 'city', 'port', 'scheme'])
+
+/**
+ * Fields that resolve to a `request.headers[...]` map lookup rather than a
+ * dedicated top-level field. Indexing an absent key throws a CEL runtime
+ * evaluation error (confirmed against Cloud Armor's own examples, which
+ * uniformly guard with `has(...)` first), so every one of these needs a
+ * `has(...) &&` prefix — see `buildHeaderCondition`.
+ */
+const HEADER_BACKED_FIELDS: Record<string, string> = {
+  host: 'host',
+  user_agent: 'user-agent',
+  referer: 'referer',
+}
+
+/**
+ * Builds Google Cloud Armor CEL expressions (`rule.match.expr.expression`)
+ * from `UnifiedCondition[]`, mirroring `ExpressionBuilder`'s structure for
+ * Cloudflare wirefilter — same AND-within-group/OR-across-groups grouping,
+ * same per-condition dispatch shape, different target grammar.
+ *
+ * Deliberately flat-only: Cloud Armor's real-world CEL usage is single-level
+ * boolean chains (confirmed via research on #187), so unlike wirefilter this
+ * never needs to represent an OR nested inside an AND — every group's
+ * conditions are AND'd, and groups are OR'd, exactly like Vercel's
+ * `conditionGroup[]` model this already mirrors for Cloudflare.
+ */
+export class CelExpressionBuilder {
+  /**
+   * Build a CEL expression from unified conditions. See
+   * `ExpressionBuilder.fromUnifiedConditions`'s doc comment for the grouping
+   * semantics this mirrors exactly.
+   */
+  public static fromUnifiedConditions(conditions: UnifiedCondition[], logic: 'AND' | 'OR' = 'AND'): string {
+    if (!conditions || conditions.length === 0) {
+      throw new Error('At least one condition is required')
+    }
+
+    const hasGroups = conditions.some((c) => c.group !== undefined)
+    if (!hasGroups) {
+      const expressions = conditions.map((condition) => this.fromUnifiedCondition(condition))
+      const connector = logic === 'AND' ? ' && ' : ' || '
+      return expressions.length > 1 ? `(${expressions.join(connector)})` : expressions[0]!
+    }
+
+    const groupedConditions = new Map<number, UnifiedCondition[]>()
+    for (const condition of conditions) {
+      const groupIndex = condition.group ?? 0
+      const bucket = groupedConditions.get(groupIndex)
+      if (bucket) {
+        bucket.push(condition)
+      } else {
+        groupedConditions.set(groupIndex, [condition])
+      }
+    }
+
+    const groupExpressions = Array.from(groupedConditions.values()).map((groupConditions) =>
+      this.combineWithAnd(groupConditions.map((c) => this.fromUnifiedCondition(c))),
+    )
+
+    return groupExpressions.length > 1 ? this.combineWithOr(groupExpressions) : groupExpressions[0]!
+  }
+
+  /**
+   * Build a CEL fragment from a single unified condition.
+   */
+  public static fromUnifiedCondition(condition: UnifiedCondition): string {
+    if (UNSUPPORTED_FIELDS.has(condition.field)) {
+      throw new Error(
+        `Cloud Armor has no CEL equivalent for the "${condition.field}" condition field — this rule cannot be represented and would otherwise be silently dropped.`,
+      )
+    }
+
+    if (condition.field === 'ip') {
+      return this.buildIpCondition(condition)
+    }
+
+    if (condition.field === 'cookie') {
+      return this.buildCookieCondition(condition)
+    }
+
+    const headerKey = HEADER_BACKED_FIELDS[condition.field]
+    if (headerKey) {
+      return this.buildHeaderCondition(headerKey, condition)
+    }
+
+    if (condition.field === 'header' || condition.field === 'query') {
+      if (condition.field === 'header') {
+        if (!condition.key) {
+          throw new Error('A "header" condition requires a key naming the header')
+        }
+        return this.buildHeaderCondition(condition.key, condition)
+      }
+      // Cloud Armor exposes only the raw, undecoded query string
+      // (`request.query`) — no parsed per-parameter map, confirmed against
+      // the rules-language-reference. Always present (possibly empty), so
+      // no has() guard is needed, unlike the header-backed fields above.
+      return this.buildComparison('request.query', condition, false)
+    }
+
+    const simpleField = SIMPLE_FIELD_MAP[condition.field]
+    if (simpleField) {
+      return this.buildComparison(simpleField.path, condition, simpleField.numeric)
+    }
+
+    throw new Error(`Cloud Armor CEL builder has no mapping for condition field "${condition.field}"`)
+  }
+
+  /**
+   * `ip` conditions target `origin.ip`. A CIDR value (contains `/`) must use
+   * the dedicated `inIpRange()` function — CEL has no `in`-with-a-set-of-
+   * ranges operator the way wirefilter's `ip.src in {...}` does, so an
+   * `in`/`eq` condition with multiple CIDR values becomes an OR of
+   * individual `inIpRange()` calls. A bare IP (no `/`) uses plain `==`.
+   */
+  private static buildIpCondition(condition: UnifiedCondition): string {
+    const values = (Array.isArray(condition.value) ? condition.value : [condition.value]).map(String)
+    if (values.length === 0 || values.some((v) => !v)) {
+      throw new Error('An "ip" condition requires at least one value')
+    }
+
+    const checks = values.map((value) => {
+      if (!ipAddressSchema.safeParse(value).success) {
+        throw new Error(`Invalid IP address or CIDR range: ${value}`)
+      }
+      return value.includes('/')
+        ? `inIpRange(origin.ip, '${escapeCelString(value)}')`
+        : `origin.ip == '${escapeCelString(value)}'`
+    })
+
+    const negated = condition.operator === 'not_in' || condition.operator === 'ne'
+
+    if (checks.length > 1) {
+      const combined = `(${checks.join(' || ')})`
+      return negated ? `!${combined}` : combined
+    }
+
+    // A single check: `inIpRange(...)` is a function call, so `!` directly
+    // negates its boolean result with no ambiguity. A bare `origin.ip ==
+    // '...'` is NOT — CEL's `!` binds tighter than `==`, so `!origin.ip ==
+    // 'x'` would parse as `(!origin.ip) == 'x'`, a type error against a
+    // string. Needs explicit parens around the comparison before negating.
+    const check = checks[0]!
+    if (!negated) return check
+    return check.startsWith('inIpRange(') ? `!${check}` : `!(${check})`
+  }
+
+  /**
+   * A condition against a `request.headers[...]` map entry (an actual
+   * header, or one of the header-backed pseudo-fields — host/user-agent/
+   * referer/cookie all live in the headers map in Cloud Armor's model, there
+   * being no dedicated field for any of them). Every access is guarded with
+   * `has(...)` first, since indexing an absent key is a CEL runtime error,
+   * not an empty-string read.
+   *
+   * `exists`/`not_exists` map directly onto the guard itself. Every other
+   * operator is guarded *and* compared — deliberately: "header does not
+   * contain X" on a request where the header is entirely absent is treated
+   * as false (the header-negation rule doesn't apply to requests it can't
+   * even evaluate against), not vacuously true.
+   */
+  private static buildHeaderCondition(headerKey: string, condition: UnifiedCondition): string {
+    const field = `request.headers['${escapeCelString(headerKey)}']`
+    const guard = `has(${field})`
+
+    if (condition.operator === 'exists') return guard
+    if (condition.operator === 'not_exists') return `!${guard}`
+
+    return `(${guard} && ${this.buildComparison(field, condition, false)})`
+  }
+
+  /**
+   * Cloud Armor has no parsed per-cookie map — only the raw `Cookie` header
+   * string (confirmed against rules-language-reference: unlike a real cookie
+   * jar, there is nothing resembling `request.cookies['name']`). Without a
+   * `key`, a cookie condition checks the whole header, same as
+   * `buildHeaderCondition`. *With* a `key` — the common case, "is this
+   * specific cookie set to this value" — this composes a `key=value`
+   * substring and searches for it in the raw header, since that's the only
+   * thing CEL can actually check; `eq`/`ne`/`contains`/`not_contains` are
+   * the only operators where that composition is unambiguous (a `key`
+   * without a value, or `starts_with`/`matches`/etc. against a synthesized
+   * substring, doesn't have one obvious meaning) — anything else throws
+   * rather than emitting a check that looks precise but isn't.
+   */
+  private static buildCookieCondition(condition: UnifiedCondition): string {
+    const field = `request.headers['cookie']`
+    const guard = `has(${field})`
+
+    if (condition.operator === 'exists') return guard
+    if (condition.operator === 'not_exists') return `!${guard}`
+
+    if (!condition.key) {
+      return `(${guard} && ${this.buildComparison(field, condition, false)})`
+    }
+
+    if (!['eq', 'ne', 'contains', 'not_contains'].includes(condition.operator)) {
+      throw new Error(
+        `Cloud Armor can only check a specific cookie's value via substring search (has no parsed cookie map) — "${condition.operator}" on a keyed cookie condition has no unambiguous CEL representation.`,
+      )
+    }
+
+    const pair = `${condition.key}=${String(condition.value)}`
+    const check = `${field}.contains('${escapeCelString(pair)}')`
+    const negated = condition.operator === 'ne' || condition.operator === 'not_contains'
+    return `(${guard} && ${negated ? `!${check}` : check})`
+  }
+
+  /**
+   * A plain comparison against a field CEL always exposes directly (no
+   * `has()` guard needed) — string fields (`==`, `.contains()`,
+   * `.startsWith()`, `.endsWith()`, `.matches()`, `in [...]`) or the one
+   * numeric field (`asn`, via `==`/`>`/`>=`/`<`/`<=`).
+   */
+  private static buildComparison(field: string, condition: UnifiedCondition, numeric: boolean): string {
+    const { operator, value } = condition
+
+    if (operator === 'exists' || operator === 'not_exists') {
+      // Every field routed here is always present on the request (unlike
+      // the header-backed fields, which never reach this branch for these
+      // two operators — see buildHeaderCondition) — so existence is
+      // trivially always true/false rather than a meaningful check.
+      throw new Error(`"${operator}" is not meaningful for Cloud Armor's "${field}" — it is always present`)
+    }
+
+    if (operator === 'in' || operator === 'not_in') {
+      const values = Array.isArray(value) ? value : [value]
+      const list = values.map((v) => this.formatLiteral(v, numeric)).join(', ')
+      const expr = `${field} in [${list}]`
+      return operator === 'not_in' ? `!(${expr})` : expr
+    }
+
+    const literal = this.formatLiteral(value, numeric)
+
+    switch (operator) {
+      case 'eq':
+        return `${field} == ${literal}`
+      case 'ne':
+        return `${field} != ${literal}`
+      case 'contains':
+        return `${field}.contains(${literal})`
+      case 'not_contains':
+        return `!${field}.contains(${literal})`
+      case 'starts_with':
+        return `${field}.startsWith(${literal})`
+      case 'ends_with':
+        return `${field}.endsWith(${literal})`
+      case 'matches':
+        return `${field}.matches(${literal})`
+      case 'gt':
+        return `${field} > ${literal}`
+      case 'ge':
+        return `${field} >= ${literal}`
+      case 'lt':
+        return `${field} < ${literal}`
+      case 'le':
+        return `${field} <= ${literal}`
+      default:
+        throw new Error(`Cloud Armor CEL builder has no mapping for operator "${operator}"`)
+    }
+  }
+
+  private static formatLiteral(value: unknown, numeric: boolean): string {
+    if (numeric) {
+      const n = Number(value)
+      if (!Number.isFinite(n)) {
+        throw new Error(`Expected a numeric value, got "${String(value)}"`)
+      }
+      return String(n)
+    }
+    return `'${escapeCelString(String(value))}'`
+  }
+
+  /**
+   * Combine multiple CEL fragments with `&&`.
+   */
+  public static combineWithAnd(expressions: string[]): string {
+    if (expressions.length === 0) {
+      throw new Error('At least one expression is required')
+    }
+    return expressions.length === 1 ? expressions[0]! : `(${expressions.join(' && ')})`
+  }
+
+  /**
+   * Combine multiple CEL fragments with `||`.
+   */
+  public static combineWithOr(expressions: string[]): string {
+    if (expressions.length === 0) {
+      throw new Error('At least one expression is required')
+    }
+    return expressions.length === 1 ? expressions[0]! : `(${expressions.join(' || ')})`
+  }
+}
+
+const SIMPLE_FIELD_MAP: Record<string, { path: string; numeric: boolean }> = {
+  country: { path: 'origin.region_code', numeric: false },
+  asn: { path: 'origin.asn', numeric: true },
+  path: { path: 'request.path', numeric: false },
+  method: { path: 'request.method', numeric: false },
+}

--- a/src/lib/translators/CelParser.ts
+++ b/src/lib/translators/CelParser.ts
@@ -1,0 +1,668 @@
+import type { UnifiedCondition } from '../types/unified'
+import { unescapeCelString } from './celEscape'
+
+/**
+ * Parses a Google Cloud Armor CEL expression back into `UnifiedCondition[]`.
+ *
+ * Same discipline as `WirefilterParser` (#178): doorman only ever *writes*
+ * CEL via `CelExpressionBuilder`, so this is deliberately the inverse of
+ * that generator, not a general-purpose CEL parser. It understands exactly
+ * the grammar subset the builder can produce — `has(...)`/`inIpRange(...)`
+ * function calls, `field == value` and friends, `.contains()`/
+ * `.startsWith()`/`.endsWith()`/`.matches()` method calls, `field in
+ * [...]`, `&&`/`||`/`!`, bracket key access, and the guarded
+ * `(has(x) && ...)` shape every header-backed condition uses. Anything
+ * outside that subset — hand-authored CEL, or another tool's — is reported
+ * as unsupported (`null`) rather than guessed at.
+ *
+ * One inherent, documented lossy case: a *keyed* cookie condition
+ * (`{field: 'cookie', key: 'session', value: 'abc', operator: 'eq'}`)
+ * compiles to a `.contains('session=abc')` check — CEL has no parsed
+ * cookie map, so there is no CEL shape that distinguishes "this specific
+ * cookie's value" from "this substring happens to appear in the header".
+ * Parsing it back yields `{field: 'cookie', value: 'session=abc', operator:
+ * 'contains'}` — behaviorally identical (re-building it produces the exact
+ * same CEL), but cosmetically different from the original. This is a real
+ * boundary of what Cloud Armor can express, not a parser bug.
+ */
+
+// CEL field path (+ optional bracket key) -> unified field. Exact inverse of
+// CelExpressionBuilder's SIMPLE_FIELD_MAP/HEADER_BACKED_FIELDS — keep in sync.
+const SIMPLE_CEL_FIELD_TO_UNIFIED: Record<string, string> = {
+  'origin.region_code': 'country',
+  'origin.asn': 'asn',
+  'request.path': 'path',
+  'request.method': 'method',
+  'request.query': 'query',
+}
+
+const HEADER_KEY_TO_UNIFIED_FIELD: Record<string, string> = {
+  host: 'host',
+  'user-agent': 'user_agent',
+  referer: 'referer',
+  cookie: 'cookie',
+}
+
+const METHOD_TO_OPERATOR: Record<string, UnifiedCondition['operator']> = {
+  contains: 'contains',
+  startsWith: 'starts_with',
+  endsWith: 'ends_with',
+  matches: 'matches',
+}
+
+type TokenType =
+  | 'LPAREN'
+  | 'RPAREN'
+  | 'LBRACKET'
+  | 'RBRACKET'
+  | 'COMMA'
+  | 'DOT'
+  | 'STRING'
+  | 'NUMBER'
+  | 'IDENT'
+  | 'AND'
+  | 'OR'
+  | 'NOT'
+  | 'EQ'
+  | 'NE'
+  | 'GT'
+  | 'GE'
+  | 'LT'
+  | 'LE'
+
+interface Token {
+  type: TokenType
+  value: string
+}
+
+class ParseError extends Error {}
+
+function tokenize(expression: string): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+  const len = expression.length
+
+  const two = (a: string, b: string): boolean => expression[i] === a && expression[i + 1] === b
+
+  while (i < len) {
+    const ch = expression[i]!
+
+    if (/\s/.test(ch)) {
+      i++
+      continue
+    }
+    if (ch === '(') {
+      tokens.push({ type: 'LPAREN', value: ch })
+      i++
+      continue
+    }
+    if (ch === ')') {
+      tokens.push({ type: 'RPAREN', value: ch })
+      i++
+      continue
+    }
+    if (ch === '[') {
+      tokens.push({ type: 'LBRACKET', value: ch })
+      i++
+      continue
+    }
+    if (ch === ']') {
+      tokens.push({ type: 'RBRACKET', value: ch })
+      i++
+      continue
+    }
+    if (ch === ',') {
+      tokens.push({ type: 'COMMA', value: ch })
+      i++
+      continue
+    }
+    if (two('&', '&')) {
+      tokens.push({ type: 'AND', value: '&&' })
+      i += 2
+      continue
+    }
+    if (two('|', '|')) {
+      tokens.push({ type: 'OR', value: '||' })
+      i += 2
+      continue
+    }
+    if (two('=', '=')) {
+      tokens.push({ type: 'EQ', value: '==' })
+      i += 2
+      continue
+    }
+    if (two('!', '=')) {
+      tokens.push({ type: 'NE', value: '!=' })
+      i += 2
+      continue
+    }
+    if (two('>', '=')) {
+      tokens.push({ type: 'GE', value: '>=' })
+      i += 2
+      continue
+    }
+    if (two('<', '=')) {
+      tokens.push({ type: 'LE', value: '<=' })
+      i += 2
+      continue
+    }
+    if (ch === '!') {
+      tokens.push({ type: 'NOT', value: '!' })
+      i++
+      continue
+    }
+    if (ch === '>') {
+      tokens.push({ type: 'GT', value: '>' })
+      i++
+      continue
+    }
+    if (ch === '<') {
+      tokens.push({ type: 'LT', value: '<' })
+      i++
+      continue
+    }
+    // A DOT is only ever a field-path/method separator in this grammar
+    // subset — a bare '.' is never reachable while scanning a NUMBER below,
+    // since that branch consumes any '.' itself.
+    if (ch === '.') {
+      tokens.push({ type: 'DOT', value: ch })
+      i++
+      continue
+    }
+
+    if (ch === "'") {
+      let j = i + 1
+      let raw = ''
+      let closed = false
+      while (j < len) {
+        const current = expression[j]!
+        if (current === '\\' && j + 1 < len) {
+          raw += current + expression[j + 1]!
+          j += 2
+          continue
+        }
+        if (expression[j] === "'") {
+          closed = true
+          j++
+          break
+        }
+        raw += expression[j]
+        j++
+      }
+      if (!closed) {
+        throw new ParseError('Unterminated string literal')
+      }
+      tokens.push({ type: 'STRING', value: unescapeCelString(raw) })
+      i = j
+      continue
+    }
+
+    if (/[0-9]/.test(ch) || (ch === '-' && /[0-9]/.test(expression[i + 1] ?? ''))) {
+      let j = i + 1
+      while (j < len && /[0-9.]/.test(expression[j]!)) j++
+      tokens.push({ type: 'NUMBER', value: expression.slice(i, j) })
+      i = j
+      continue
+    }
+
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i
+      while (j < len && /[A-Za-z0-9_]/.test(expression[j]!)) j++
+      tokens.push({ type: 'IDENT', value: expression.slice(i, j) })
+      i = j
+      continue
+    }
+
+    throw new ParseError(`Unexpected character '${ch}' at position ${i}`)
+  }
+
+  return tokens
+}
+
+class TokenStream {
+  pos = 0
+  constructor(private tokens: Token[]) {}
+
+  peek(): Token | undefined {
+    return this.tokens[this.pos]
+  }
+
+  next(): Token {
+    const token = this.tokens[this.pos]
+    if (!token) {
+      throw new ParseError('Unexpected end of expression')
+    }
+    this.pos++
+    return token
+  }
+
+  expect(type: TokenType): Token {
+    const token = this.next()
+    if (token.type !== type) {
+      throw new ParseError(`Expected ${type} but got '${token.value}'`)
+    }
+    return token
+  }
+
+  isIdent(value: string): boolean {
+    const token = this.peek()
+    return !!token && token.type === 'IDENT' && token.value === value
+  }
+
+  atEnd(): boolean {
+    return this.pos >= this.tokens.length
+  }
+}
+
+interface FieldRef {
+  field: string
+  key?: string
+}
+
+type CelNode =
+  | { type: 'and'; children: CelNode[] }
+  | { type: 'or'; children: CelNode[] }
+  | { type: 'not'; child: CelNode }
+  | ({ type: 'has' } & FieldRef)
+  | { type: 'inIpRange'; value: string }
+  | ({ type: 'comparison'; operator: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le'; value: string | number } & FieldRef)
+  | ({ type: 'methodCall'; method: string; value: string } & FieldRef)
+  | ({ type: 'membership'; values: (string | number)[] } & FieldRef)
+
+/** A dotted field path, stopping before a trailing `.method(` — that's a method-call suffix, parsed separately. */
+function parseFieldPath(stream: TokenStream): string {
+  let path = stream.expect('IDENT').value
+  while (stream.peek()?.type === 'DOT') {
+    const savedPos = stream.pos
+    stream.next() // consume DOT
+    const identTok = stream.expect('IDENT')
+    if (stream.peek()?.type === 'LPAREN') {
+      stream.pos = savedPos
+      break
+    }
+    path += `.${identTok.value}`
+  }
+  return path
+}
+
+function parseFieldRef(stream: TokenStream): FieldRef {
+  const field = parseFieldPath(stream)
+  if (stream.peek()?.type === 'LBRACKET') {
+    stream.next()
+    const key = stream.expect('STRING')
+    stream.expect('RBRACKET')
+    return { field, key: key.value }
+  }
+  return { field }
+}
+
+function parseLiteral(stream: TokenStream): string | number {
+  const token = stream.next()
+  if (token.type === 'STRING') return token.value
+  if (token.type === 'NUMBER') return Number(token.value)
+  throw new ParseError(`Unexpected token '${token.value}' where a literal was expected`)
+}
+
+function parseLeaf(stream: TokenStream): CelNode {
+  if (stream.isIdent('has')) {
+    stream.next()
+    stream.expect('LPAREN')
+    const ref = parseFieldRef(stream)
+    stream.expect('RPAREN')
+    return { type: 'has', ...ref }
+  }
+
+  if (stream.isIdent('inIpRange')) {
+    stream.next()
+    stream.expect('LPAREN')
+    const ref = parseFieldRef(stream)
+    if (ref.field !== 'origin.ip') {
+      throw new ParseError(`inIpRange must reference origin.ip, got '${ref.field}'`)
+    }
+    stream.expect('COMMA')
+    const value = stream.expect('STRING')
+    stream.expect('RPAREN')
+    return { type: 'inIpRange', value: value.value }
+  }
+
+  const ref = parseFieldRef(stream)
+
+  if (stream.peek()?.type === 'DOT') {
+    stream.next()
+    const method = stream.expect('IDENT').value
+    if (!METHOD_TO_OPERATOR[method]) {
+      throw new ParseError(`Unrecognized method '${method}'`)
+    }
+    stream.expect('LPAREN')
+    const value = stream.expect('STRING')
+    stream.expect('RPAREN')
+    return { type: 'methodCall', ...ref, method, value: value.value }
+  }
+
+  if (stream.isIdent('in')) {
+    stream.next()
+    stream.expect('LBRACKET')
+    const values: (string | number)[] = []
+    while (stream.peek()?.type !== 'RBRACKET') {
+      values.push(parseLiteral(stream))
+      if (stream.peek()?.type === 'COMMA') stream.next()
+    }
+    stream.expect('RBRACKET')
+    return { type: 'membership', ...ref, values }
+  }
+
+  const opToken = stream.next()
+  const OP_MAP: Partial<Record<TokenType, 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le'>> = {
+    EQ: 'eq',
+    NE: 'ne',
+    GT: 'gt',
+    GE: 'ge',
+    LT: 'lt',
+    LE: 'le',
+  }
+  const operator = OP_MAP[opToken.type]
+  if (!operator) {
+    throw new ParseError(`Unexpected token '${opToken.value}' after field reference`)
+  }
+  const value = parseLiteral(stream)
+  return { type: 'comparison', ...ref, operator, value }
+}
+
+function parsePrimary(stream: TokenStream): CelNode {
+  if (stream.peek()?.type === 'LPAREN') {
+    stream.next()
+    const inner = parseOr(stream)
+    stream.expect('RPAREN')
+    return inner
+  }
+  return parseLeaf(stream)
+}
+
+function parseUnary(stream: TokenStream): CelNode {
+  if (stream.peek()?.type === 'NOT') {
+    stream.next()
+    return { type: 'not', child: parsePrimary(stream) }
+  }
+  return parsePrimary(stream)
+}
+
+function parseAnd(stream: TokenStream): CelNode {
+  const children = [parseUnary(stream)]
+  while (stream.peek()?.type === 'AND') {
+    stream.next()
+    children.push(parseUnary(stream))
+  }
+  return children.length === 1 ? children[0]! : { type: 'and', children }
+}
+
+function parseOr(stream: TokenStream): CelNode {
+  const children = [parseAnd(stream)]
+  while (stream.peek()?.type === 'OR') {
+    stream.next()
+    children.push(parseAnd(stream))
+  }
+  return children.length === 1 ? children[0]! : { type: 'or', children }
+}
+
+function parseExpression(expression: string): CelNode {
+  const stream = new TokenStream(tokenize(expression))
+  const node = parseOr(stream)
+  if (!stream.atEnd()) {
+    throw new ParseError('Unexpected trailing tokens')
+  }
+  return node
+}
+
+/** A leaf that's a single ip check — one `inIpRange(...)` or `origin.ip == '...'`. */
+function isIpCheckLeaf(
+  node: CelNode,
+): node is Extract<CelNode, { type: 'inIpRange' }> | Extract<CelNode, { type: 'comparison' }> {
+  if (node.type === 'inIpRange') return true
+  if (node.type === 'comparison' && node.field === 'origin.ip' && node.operator === 'eq') return true
+  return false
+}
+
+/** `(ipCheck || ipCheck || ...)` — CelExpressionBuilder's shape for an ip condition with multiple CIDR/IP values. */
+function isIpOrGroup(node: CelNode): node is Extract<CelNode, { type: 'or' }> {
+  return node.type === 'or' && node.children.length > 0 && node.children.every(isIpCheckLeaf)
+}
+
+function ipCheckValue(
+  node: Extract<CelNode, { type: 'inIpRange' }> | Extract<CelNode, { type: 'comparison' }>,
+): string {
+  return node.type === 'inIpRange' ? node.value : String(node.value)
+}
+
+/** `(has(field[key]) && <comparison|methodCall|membership on the same field[key], possibly negated>)`. */
+function isGuardedLeaf(node: CelNode): boolean {
+  if (node.type !== 'and' || node.children.length !== 2) return false
+  const guard = node.children[0]!
+  const inner = node.children[1]!
+  if (guard.type !== 'has') return false
+  const innerNode = inner.type === 'not' ? inner.child : inner
+  if (!('field' in innerNode) || innerNode.field !== guard.field || innerNode.key !== guard.key) return false
+  return innerNode.type === 'comparison' || innerNode.type === 'methodCall' || innerNode.type === 'membership'
+}
+
+/** Extracts the `has(...)` guard and the (possibly `not`-wrapped) inner comparison from a node `isGuardedLeaf` already confirmed. */
+function unwrapGuardedLeaf(node: Extract<CelNode, { type: 'and' }>): {
+  guard: Extract<CelNode, { type: 'has' }>
+  comparisonNegated: boolean
+  comparison: CelNode
+} {
+  const guard = node.children[0] as Extract<CelNode, { type: 'has' }>
+  const inner = node.children[1]!
+  const comparisonNegated = inner.type === 'not'
+  const comparison = comparisonNegated ? (inner as Extract<CelNode, { type: 'not' }>).child : inner
+  return { guard, comparisonNegated, comparison }
+}
+
+/** A leaf is a single condition: any recognized comparison shape, the ip-multi-value OR, the guarded shape, or a `not` wrapping one of those. */
+function isLeaf(node: CelNode): boolean {
+  if (
+    node.type === 'has' ||
+    node.type === 'comparison' ||
+    node.type === 'methodCall' ||
+    node.type === 'membership' ||
+    node.type === 'inIpRange'
+  ) {
+    return true
+  }
+  if (isIpOrGroup(node)) return true
+  if (isGuardedLeaf(node)) return true
+  if (node.type === 'not') {
+    const inner = node.child
+    return (
+      inner.type === 'has' ||
+      inner.type === 'comparison' ||
+      inner.type === 'methodCall' ||
+      inner.type === 'membership' ||
+      inner.type === 'inIpRange' ||
+      isIpOrGroup(inner)
+    )
+  }
+  return false
+}
+
+/** Maps a CEL field(+key) reference to doorman's unified field name, or `null` if unrecognized. */
+function mapFieldToUnified(
+  field: string,
+  key: string | undefined,
+): { unifiedField: string; unifiedKey?: string } | null {
+  if (field === 'origin.ip') return { unifiedField: 'ip' }
+  const simple = SIMPLE_CEL_FIELD_TO_UNIFIED[field]
+  if (simple) return { unifiedField: simple }
+  if (field === 'request.headers' && key !== undefined) {
+    const backed = HEADER_KEY_TO_UNIFIED_FIELD[key]
+    if (backed) return { unifiedField: backed }
+    return { unifiedField: 'header', unifiedKey: key }
+  }
+  return null
+}
+
+function leafToCondition(node: CelNode, group: number): UnifiedCondition | null {
+  const negated = node.type === 'not'
+  const inner = node.type === 'not' ? node.child : node
+
+  if (isIpOrGroup(inner)) {
+    const values = inner.children.map((c) => ipCheckValue(c as Extract<CelNode, { type: 'inIpRange' | 'comparison' }>))
+    return { field: 'ip', operator: negated ? 'not_in' : 'in', value: values, group }
+  }
+
+  if (inner.type === 'inIpRange' || (inner.type === 'comparison' && inner.field === 'origin.ip')) {
+    const value = inner.type === 'inIpRange' ? inner.value : String(inner.value)
+    return { field: 'ip', operator: negated ? 'ne' : 'eq', value, group }
+  }
+
+  if (inner.type === 'and' && isGuardedLeaf(inner)) {
+    // The outer `negated` (a `not` wrapping the whole guarded AND) never
+    // happens from CelExpressionBuilder — negation for these lives *inside*
+    // the guard (`has(x) && !comparison`) — so a guarded leaf reached with
+    // `negated: true` here is outside the grammar subset this parser
+    // understands.
+    if (negated) return null
+    const { guard, comparisonNegated, comparison } = unwrapGuardedLeaf(inner)
+    if (comparison.type !== 'comparison' && comparison.type !== 'methodCall' && comparison.type !== 'membership') {
+      return null
+    }
+    return comparisonToCondition(comparison, comparisonNegated, guard.field, guard.key, group)
+  }
+
+  if (inner.type === 'comparison' || inner.type === 'methodCall' || inner.type === 'membership') {
+    return comparisonToCondition(inner, negated, inner.field, inner.key, group)
+  }
+
+  if (inner.type === 'has') {
+    const mapped = mapFieldToUnified(inner.field, inner.key)
+    if (!mapped) return null
+    return {
+      field: mapped.unifiedField,
+      operator: negated ? 'not_exists' : 'exists',
+      value: '',
+      key: mapped.unifiedKey,
+      group,
+    }
+  }
+
+  return null
+}
+
+function comparisonToCondition(
+  node: Extract<CelNode, { type: 'comparison' | 'methodCall' | 'membership' }>,
+  negated: boolean,
+  refField: string,
+  refKey: string | undefined,
+  group: number,
+): UnifiedCondition | null {
+  const mapped = mapFieldToUnified(refField, refKey)
+  if (!mapped) return null
+
+  let operator: UnifiedCondition['operator']
+  let value: string | number | string[] | number[]
+
+  if (node.type === 'comparison') {
+    operator = negated ? negateSimpleOperator(node.operator) : node.operator
+    value = node.value
+  } else if (node.type === 'methodCall') {
+    const base = METHOD_TO_OPERATOR[node.method]
+    if (!base) return null
+    operator = negated ? (`not_${base}` as UnifiedCondition['operator']) : base
+    // Only 'contains'/'not_contains' have a dedicated negative form in the
+    // unified operator set — the builder never negates startsWith/endsWith/
+    // matches, so this is unreachable for those methods in practice.
+    if (negated && operator !== 'not_contains') return null
+    value = node.value
+  } else {
+    operator = negated ? 'not_in' : 'in'
+    value = node.values as string[] | number[]
+  }
+
+  return {
+    field: mapped.unifiedField,
+    operator,
+    value,
+    key: mapped.unifiedKey,
+    group,
+  }
+}
+
+function negateSimpleOperator(op: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le'): UnifiedCondition['operator'] {
+  // CelExpressionBuilder never emits a `not`-wrapped bare comparison (`eq`
+  // negates to the native `!=` operator, not `!(field == x)`) — reachable
+  // only for a hand-authored expression using this codebase's grammar
+  // subset in a way the builder itself wouldn't. `ne` is the sole case with
+  // an obvious inverse; anything else has no single-operator negation.
+  if (op === 'eq') return 'ne'
+  if (op === 'ne') return 'eq'
+  throw new ParseError(`No negated form for comparison operator '${op}'`)
+}
+
+/**
+ * Converts a parsed AST into `UnifiedCondition[]`, restricted to the shapes
+ * `CelExpressionBuilder` itself produces: a flat AND, a flat OR, or a
+ * top-level OR of AND-groups. Anything else is outside that subset and
+ * reported as `null`.
+ */
+function astToConditions(node: CelNode): { conditions: UnifiedCondition[]; conditionLogic: 'AND' | 'OR' } | null {
+  if (isLeaf(node)) {
+    const condition = leafToCondition(node, 0)
+    return condition ? { conditions: [condition], conditionLogic: 'AND' } : null
+  }
+
+  if (node.type === 'and') {
+    const conditions: UnifiedCondition[] = []
+    for (const child of node.children) {
+      if (!isLeaf(child)) return null
+      const condition = leafToCondition(child, 0)
+      if (!condition) return null
+      conditions.push(condition)
+    }
+    return { conditions, conditionLogic: 'AND' }
+  }
+
+  if (node.type === 'or') {
+    const conditions: UnifiedCondition[] = []
+    node.children.forEach((child, groupIndex) => {
+      if (isLeaf(child)) {
+        const condition = leafToCondition(child, groupIndex)
+        if (condition) conditions.push(condition)
+        return
+      }
+      if (child.type === 'and') {
+        for (const grandchild of child.children) {
+          if (!isLeaf(grandchild)) return
+          const condition = leafToCondition(grandchild, groupIndex)
+          if (condition) conditions.push(condition)
+        }
+      }
+    })
+    const expectedGroups = node.children.length
+    const actualGroups = new Set(conditions.map((c) => c.group)).size
+    if (actualGroups !== expectedGroups) return null
+    return { conditions, conditionLogic: 'OR' }
+  }
+
+  return null
+}
+
+export interface CelParseResult {
+  conditions: UnifiedCondition[]
+  conditionLogic: 'AND' | 'OR'
+}
+
+/**
+ * Parses a Cloud Armor CEL expression into `UnifiedCondition[]`, or returns
+ * `null` if the expression falls outside the grammar subset this parser
+ * understands. Never throws.
+ */
+export function parseCelExpression(expression: string): CelParseResult | null {
+  if (!expression || !expression.trim()) {
+    return null
+  }
+  try {
+    const ast = parseExpression(expression)
+    return astToConditions(ast)
+  } catch {
+    return null
+  }
+}

--- a/src/lib/translators/__tests__/CelExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/CelExpressionBuilder.test.ts
@@ -1,0 +1,285 @@
+import { CelExpressionBuilder } from '../CelExpressionBuilder'
+import type { UnifiedCondition } from '../../types/unified'
+
+describe('CelExpressionBuilder', () => {
+  describe('fromUnifiedCondition — simple fields', () => {
+    it('builds a path eq comparison', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'eq', value: '/api' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path == '/api'")
+    })
+
+    it('builds a path contains comparison', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'contains', value: 'admin' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path.contains('admin')")
+    })
+
+    it('builds a path starts_with comparison', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'starts_with', value: '/api' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path.startsWith('/api')")
+    })
+
+    it('builds a path ends_with comparison', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'ends_with', value: '.php' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path.endsWith('.php')")
+    })
+
+    it('builds a path matches (regex) comparison', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'matches', value: '/user/[0-9]+' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path.matches('/user/[0-9]+')")
+    })
+
+    it('builds a method eq comparison', () => {
+      const c: UnifiedCondition = { field: 'method', operator: 'eq', value: 'POST' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.method == 'POST'")
+    })
+
+    it('builds a method in-list comparison', () => {
+      const c: UnifiedCondition = { field: 'method', operator: 'in', value: ['GET', 'POST'] }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.method in ['GET', 'POST']")
+    })
+
+    it('builds a method not_in-list comparison', () => {
+      const c: UnifiedCondition = { field: 'method', operator: 'not_in', value: ['GET', 'POST'] }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("!(request.method in ['GET', 'POST'])")
+    })
+
+    it('builds a country eq comparison against origin.region_code', () => {
+      const c: UnifiedCondition = { field: 'country', operator: 'eq', value: 'US' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("origin.region_code == 'US'")
+    })
+
+    it('builds a numeric asn comparison, unquoted', () => {
+      const c: UnifiedCondition = { field: 'asn', operator: 'eq', value: 15169 }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe('origin.asn == 15169')
+    })
+
+    it('builds asn gt/ge/lt/le comparisons', () => {
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'asn', operator: 'gt', value: 1000 })).toBe(
+        'origin.asn > 1000',
+      )
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'asn', operator: 'ge', value: 1000 })).toBe(
+        'origin.asn >= 1000',
+      )
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'asn', operator: 'lt', value: 1000 })).toBe(
+        'origin.asn < 1000',
+      )
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'asn', operator: 'le', value: 1000 })).toBe(
+        'origin.asn <= 1000',
+      )
+    })
+
+    it('builds a query condition against the raw query string, no guard', () => {
+      const c: UnifiedCondition = { field: 'query', operator: 'contains', value: 'debug=true' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.query.contains('debug=true')")
+    })
+
+    it('throws when asn is given a non-numeric value', () => {
+      expect(() =>
+        CelExpressionBuilder.fromUnifiedCondition({ field: 'asn', operator: 'eq', value: 'not-a-number' }),
+      ).toThrow(/numeric/i)
+    })
+  })
+
+  describe('fromUnifiedCondition — header-backed fields (has() guard)', () => {
+    it('guards a host comparison with has()', () => {
+      const c: UnifiedCondition = { field: 'host', operator: 'eq', value: 'example.com' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['host']) && request.headers['host'] == 'example.com')",
+      )
+    })
+
+    it('guards a user_agent contains with has()', () => {
+      const c: UnifiedCondition = { field: 'user_agent', operator: 'contains', value: 'bot' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['user-agent']) && request.headers['user-agent'].contains('bot'))",
+      )
+    })
+
+    it('guards a referer comparison with has()', () => {
+      const c: UnifiedCondition = { field: 'referer', operator: 'eq', value: 'evil.example' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['referer']) && request.headers['referer'] == 'evil.example')",
+      )
+    })
+
+    it('builds host exists as a bare has() with no comparison', () => {
+      const c: UnifiedCondition = { field: 'host', operator: 'exists', value: '' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("has(request.headers['host'])")
+    })
+
+    it('builds host not_exists as a negated has()', () => {
+      const c: UnifiedCondition = { field: 'host', operator: 'not_exists', value: '' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("!has(request.headers['host'])")
+    })
+
+    it('negates not_contains inside the guard, not around it', () => {
+      const c: UnifiedCondition = { field: 'user_agent', operator: 'not_contains', value: 'bot' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['user-agent']) && !request.headers['user-agent'].contains('bot'))",
+      )
+    })
+
+    it('builds an arbitrary header condition by key', () => {
+      const c: UnifiedCondition = { field: 'header', key: 'x-custom-header', operator: 'eq', value: 'yes' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['x-custom-header']) && request.headers['x-custom-header'] == 'yes')",
+      )
+    })
+
+    it('throws for a header condition with no key', () => {
+      expect(() =>
+        CelExpressionBuilder.fromUnifiedCondition({ field: 'header', operator: 'eq', value: 'yes' }),
+      ).toThrow(/requires a key/i)
+    })
+  })
+
+  describe('fromUnifiedCondition — cookie', () => {
+    it('composes a key=value substring check for a keyed eq condition', () => {
+      const c: UnifiedCondition = { field: 'cookie', key: 'session', operator: 'eq', value: 'abc123' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['cookie']) && request.headers['cookie'].contains('session=abc123'))",
+      )
+    })
+
+    it('negates a keyed not_contains condition inside the guard', () => {
+      const c: UnifiedCondition = { field: 'cookie', key: 'session', operator: 'not_contains', value: 'abc123' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['cookie']) && !request.headers['cookie'].contains('session=abc123'))",
+      )
+    })
+
+    it('checks the whole cookie header when no key is given', () => {
+      const c: UnifiedCondition = { field: 'cookie', operator: 'contains', value: 'admin=true' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['cookie']) && request.headers['cookie'].contains('admin=true'))",
+      )
+    })
+
+    it('throws for a keyed cookie condition using an operator with no unambiguous substring meaning', () => {
+      expect(() =>
+        CelExpressionBuilder.fromUnifiedCondition({
+          field: 'cookie',
+          key: 'session',
+          operator: 'starts_with',
+          value: 'abc',
+        }),
+      ).toThrow(/no unambiguous CEL representation/i)
+    })
+
+    it('builds cookie exists/not_exists as a bare guard, same as header', () => {
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'cookie', operator: 'exists', value: '' })).toBe(
+        "has(request.headers['cookie'])",
+      )
+      expect(CelExpressionBuilder.fromUnifiedCondition({ field: 'cookie', operator: 'not_exists', value: '' })).toBe(
+        "!has(request.headers['cookie'])",
+      )
+    })
+  })
+
+  describe('fromUnifiedCondition — ip', () => {
+    it('builds a plain equality check for a bare IP', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'eq', value: '203.0.113.9' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("origin.ip == '203.0.113.9'")
+    })
+
+    it('builds inIpRange() for a CIDR value', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'eq', value: '198.51.100.0/24' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("inIpRange(origin.ip, '198.51.100.0/24')")
+    })
+
+    it('ORs multiple CIDR/IP values together for an "in" condition', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'in', value: ['198.51.100.0/24', '203.0.113.9'] }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(inIpRange(origin.ip, '198.51.100.0/24') || origin.ip == '203.0.113.9')",
+      )
+    })
+
+    it('negates a single inIpRange() check directly (function call — no precedence hazard)', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'ne', value: '198.51.100.0/24' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("!inIpRange(origin.ip, '198.51.100.0/24')")
+    })
+
+    it('parenthesizes a negated single bare-IP equality (precedence-safe — regression guard)', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'ne', value: '203.0.113.9' }
+      const result = CelExpressionBuilder.fromUnifiedCondition(c)
+      expect(result).toBe("!(origin.ip == '203.0.113.9')")
+      // The un-parenthesized form `!origin.ip == 'x'` would parse in CEL as
+      // `(!origin.ip) == 'x'` — a type error against a string. This is the
+      // bug this test guards against.
+      expect(result).not.toBe("!origin.ip == '203.0.113.9'")
+    })
+
+    it('negates a multi-value "not_in" as a wrapped OR group', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'not_in', value: ['198.51.100.0/24', '203.0.113.9'] }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "!(inIpRange(origin.ip, '198.51.100.0/24') || origin.ip == '203.0.113.9')",
+      )
+    })
+
+    it('throws for an invalid IP/CIDR value', () => {
+      expect(() =>
+        CelExpressionBuilder.fromUnifiedCondition({ field: 'ip', operator: 'eq', value: 'not-an-ip' }),
+      ).toThrow(/Invalid IP/i)
+    })
+  })
+
+  describe('fromUnifiedCondition — unsupported fields', () => {
+    it.each(['region', 'city', 'port', 'scheme'])(
+      'throws a clear error for "%s" (no Cloud Armor CEL equivalent)',
+      (field) => {
+        expect(() => CelExpressionBuilder.fromUnifiedCondition({ field, operator: 'eq', value: 'x' })).toThrow(
+          /no CEL equivalent/i,
+        )
+      },
+    )
+  })
+
+  describe('fromUnifiedConditions — grouping', () => {
+    it('joins a flat set of conditions with &&', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/api' },
+        { field: 'method', operator: 'eq', value: 'POST' },
+      ]
+      expect(CelExpressionBuilder.fromUnifiedConditions(conditions, 'AND')).toBe(
+        "(request.path == '/api' && request.method == 'POST')",
+      )
+    })
+
+    it('joins a flat set of conditions with ||', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/api' },
+        { field: 'path', operator: 'eq', value: '/admin' },
+      ]
+      expect(CelExpressionBuilder.fromUnifiedConditions(conditions, 'OR')).toBe(
+        "(request.path == '/api' || request.path == '/admin')",
+      )
+    })
+
+    it('builds AND-within-group, OR-across-groups from a grouped condition set', () => {
+      const conditions: UnifiedCondition[] = [
+        { field: 'path', operator: 'eq', value: '/a', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+        { field: 'path', operator: 'eq', value: '/b', group: 1 },
+      ]
+      expect(CelExpressionBuilder.fromUnifiedConditions(conditions)).toBe(
+        "((request.path == '/a' && request.method == 'POST') || request.path == '/b')",
+      )
+    })
+
+    it('throws for an empty condition list', () => {
+      expect(() => CelExpressionBuilder.fromUnifiedConditions([])).toThrow(/at least one condition/i)
+    })
+  })
+
+  describe('escaping', () => {
+    it('escapes a single quote in a string value', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'eq', value: "/it's" }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path == '/it\\'s'")
+    })
+
+    it('escapes a backslash before quote-escaping (regression guard for the same class of bug wirefilterEscape documents)', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'eq', value: '/a\\' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.path == '/a\\\\'")
+    })
+  })
+})

--- a/src/lib/translators/__tests__/CelParser.test.ts
+++ b/src/lib/translators/__tests__/CelParser.test.ts
@@ -1,0 +1,244 @@
+import { parseCelExpression } from '../CelParser'
+import { CelExpressionBuilder } from '../CelExpressionBuilder'
+import type { UnifiedCondition } from '../../types/unified'
+
+describe('parseCelExpression', () => {
+  it('parses a single simple comparison', () => {
+    const result = parseCelExpression("request.path == '/api'")
+
+    expect(result).not.toBeNull()
+    expect(result!.conditions).toHaveLength(1)
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api', group: 0 })
+    expect(result!.conditionLogic).toBe('AND')
+  })
+
+  it('parses a flat AND of multiple conditions into a single group', () => {
+    const result = parseCelExpression("(request.path == '/api' && request.method == 'POST')")
+
+    expect(result).not.toBeNull()
+    expect(result!.conditionLogic).toBe('AND')
+    expect(result!.conditions).toHaveLength(2)
+    expect(result!.conditions.every((c) => c.group === 0)).toBe(true)
+  })
+
+  it('parses a flat OR of single-condition groups, one group per branch', () => {
+    const result = parseCelExpression("(request.path == '/api' || request.path == '/admin')")
+
+    expect(result).not.toBeNull()
+    expect(result!.conditionLogic).toBe('OR')
+    expect(result!.conditions).toHaveLength(2)
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', value: '/api', group: 0 })
+    expect(result!.conditions[1]).toMatchObject({ field: 'path', value: '/admin', group: 1 })
+  })
+
+  it('parses a numeric comparison', () => {
+    const result = parseCelExpression('origin.asn == 15169')
+    expect(result!.conditions[0]).toMatchObject({ field: 'asn', operator: 'eq', value: 15169 })
+  })
+
+  it('parses gt/ge/lt/le', () => {
+    expect(parseCelExpression('origin.asn > 1000')!.conditions[0]).toMatchObject({ operator: 'gt', value: 1000 })
+    expect(parseCelExpression('origin.asn >= 1000')!.conditions[0]).toMatchObject({ operator: 'ge', value: 1000 })
+    expect(parseCelExpression('origin.asn < 1000')!.conditions[0]).toMatchObject({ operator: 'lt', value: 1000 })
+    expect(parseCelExpression('origin.asn <= 1000')!.conditions[0]).toMatchObject({ operator: 'le', value: 1000 })
+  })
+
+  it('parses an "in" list into an array value', () => {
+    const result = parseCelExpression("request.method in ['GET', 'POST']")
+    expect(result!.conditions[0]).toMatchObject({ field: 'method', operator: 'in', value: ['GET', 'POST'] })
+  })
+
+  it('parses a negated "in" list as not_in', () => {
+    const result = parseCelExpression("!(request.method in ['GET', 'POST'])")
+    expect(result!.conditions[0]).toMatchObject({ field: 'method', operator: 'not_in', value: ['GET', 'POST'] })
+  })
+
+  describe('has()-guarded (header-backed) conditions', () => {
+    it('parses a guarded host comparison', () => {
+      const result = parseCelExpression("(has(request.headers['host']) && request.headers['host'] == 'example.com')")
+      expect(result!.conditions[0]).toMatchObject({ field: 'host', operator: 'eq', value: 'example.com' })
+    })
+
+    it('parses a guarded, negated contains as not_contains', () => {
+      const result = parseCelExpression(
+        "(has(request.headers['user-agent']) && !request.headers['user-agent'].contains('bot'))",
+      )
+      expect(result!.conditions[0]).toMatchObject({ field: 'user_agent', operator: 'not_contains', value: 'bot' })
+    })
+
+    it('parses a bare has() as exists', () => {
+      const result = parseCelExpression("has(request.headers['host'])")
+      expect(result!.conditions[0]).toMatchObject({ field: 'host', operator: 'exists' })
+    })
+
+    it('parses a negated bare has() as not_exists', () => {
+      const result = parseCelExpression("!has(request.headers['host'])")
+      expect(result!.conditions[0]).toMatchObject({ field: 'host', operator: 'not_exists' })
+    })
+
+    it('parses an arbitrary header key as the generic "header" field', () => {
+      const result = parseCelExpression(
+        "(has(request.headers['x-custom-header']) && request.headers['x-custom-header'] == 'yes')",
+      )
+      expect(result!.conditions[0]).toMatchObject({ field: 'header', key: 'x-custom-header', value: 'yes' })
+    })
+  })
+
+  describe('ip', () => {
+    it('parses a bare-IP equality', () => {
+      const result = parseCelExpression("origin.ip == '203.0.113.9'")
+      expect(result!.conditions[0]).toMatchObject({ field: 'ip', operator: 'eq', value: '203.0.113.9' })
+    })
+
+    it('parses inIpRange() as an eq condition', () => {
+      const result = parseCelExpression("inIpRange(origin.ip, '198.51.100.0/24')")
+      expect(result!.conditions[0]).toMatchObject({ field: 'ip', operator: 'eq', value: '198.51.100.0/24' })
+    })
+
+    it('parses a negated single inIpRange() as ne', () => {
+      const result = parseCelExpression("!inIpRange(origin.ip, '198.51.100.0/24')")
+      expect(result!.conditions[0]).toMatchObject({ field: 'ip', operator: 'ne', value: '198.51.100.0/24' })
+    })
+
+    it('parses a negated parenthesized bare-IP equality as ne', () => {
+      const result = parseCelExpression("!(origin.ip == '203.0.113.9')")
+      expect(result!.conditions[0]).toMatchObject({ field: 'ip', operator: 'ne', value: '203.0.113.9' })
+    })
+
+    it('parses an OR of ip checks as a single "in" condition with multiple values, not two groups', () => {
+      const result = parseCelExpression("(inIpRange(origin.ip, '198.51.100.0/24') || origin.ip == '203.0.113.9')")
+      expect(result!.conditions).toHaveLength(1)
+      expect(result!.conditions[0]).toMatchObject({
+        field: 'ip',
+        operator: 'in',
+        value: ['198.51.100.0/24', '203.0.113.9'],
+      })
+    })
+
+    it('parses a negated OR of ip checks as not_in', () => {
+      const result = parseCelExpression("!(inIpRange(origin.ip, '198.51.100.0/24') || origin.ip == '203.0.113.9')")
+      expect(result!.conditions[0]).toMatchObject({
+        field: 'ip',
+        operator: 'not_in',
+        value: ['198.51.100.0/24', '203.0.113.9'],
+      })
+    })
+  })
+
+  it('decodes escaped quotes and backslashes inside string values', () => {
+    const result = parseCelExpression("request.path == '/say \\'hi\\' \\\\ bye'")
+    expect(result!.conditions[0]!.value).toBe("/say 'hi' \\ bye")
+  })
+
+  it('returns null for an expression with an unmapped field', () => {
+    expect(parseCelExpression("request.body.raw.contains('x')")).toBeNull()
+  })
+
+  it('returns null for an OR nested inside an AND (a shape CelExpressionBuilder never generates)', () => {
+    expect(
+      parseCelExpression("request.path == '/api' && (request.method == 'GET' || request.method == 'POST')"),
+    ).toBeNull()
+  })
+
+  it('returns null for malformed syntax', () => {
+    expect(parseCelExpression('request.path ==')).toBeNull()
+    expect(parseCelExpression("(request.path == '/api'")).toBeNull()
+    expect(parseCelExpression('')).toBeNull()
+  })
+
+  describe('round-trip fidelity against CelExpressionBuilder', () => {
+    const roundTrip = (conditions: UnifiedCondition[], logic: 'AND' | 'OR' = 'AND') => {
+      const expression = CelExpressionBuilder.fromUnifiedConditions(conditions, logic)
+      const parsed = parseCelExpression(expression)
+      return { expression, parsed }
+    }
+
+    it('round-trips a flat single condition', () => {
+      const { parsed } = roundTrip([{ field: 'path', operator: 'eq', value: '/api' }])
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions).toHaveLength(1)
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api' })
+    })
+
+    it('round-trips a flat AND of conditions', () => {
+      const { parsed } = roundTrip([
+        { field: 'path', operator: 'eq', value: '/api' },
+        { field: 'method', operator: 'eq', value: 'POST' },
+      ])
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditionLogic).toBe('AND')
+      expect(parsed!.conditions).toHaveLength(2)
+    })
+
+    it('round-trips a multi-group (AND-within/OR-across) condition set', () => {
+      const { parsed } = roundTrip([
+        { field: 'path', operator: 'eq', value: '/a', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+        { field: 'path', operator: 'eq', value: '/b', group: 1 },
+      ])
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditionLogic).toBe('OR')
+      expect(parsed!.conditions).toHaveLength(3)
+      expect(parsed!.conditions.filter((c) => c.group === 0)).toHaveLength(2)
+      expect(parsed!.conditions.filter((c) => c.group === 1)).toHaveLength(1)
+    })
+
+    it('round-trips a not_contains condition on a header-backed field', () => {
+      const { parsed } = roundTrip([{ field: 'user_agent', operator: 'not_contains', value: 'bot' }])
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'user_agent', operator: 'not_contains', value: 'bot' })
+    })
+
+    it('round-trips an arbitrary header condition with a key', () => {
+      const { parsed } = roundTrip([{ field: 'header', key: 'x-custom-header', operator: 'eq', value: 'yes' }])
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'header', key: 'x-custom-header', value: 'yes' })
+    })
+
+    it('round-trips an "in" condition with an array value', () => {
+      const { parsed } = roundTrip([{ field: 'method', operator: 'in', value: ['GET', 'HEAD'] }])
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'method', operator: 'in', value: ['GET', 'HEAD'] })
+    })
+
+    it('round-trips a bare-IP eq condition', () => {
+      const { parsed } = roundTrip([{ field: 'ip', operator: 'eq', value: '203.0.113.9' }])
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'ip', operator: 'eq', value: '203.0.113.9' })
+    })
+
+    it('round-trips a multi-value ip "in" condition', () => {
+      const { parsed } = roundTrip([{ field: 'ip', operator: 'in', value: ['198.51.100.0/24', '203.0.113.9'] }])
+      expect(parsed!.conditions[0]).toMatchObject({
+        field: 'ip',
+        operator: 'in',
+        value: ['198.51.100.0/24', '203.0.113.9'],
+      })
+    })
+
+    it('round-trips a negated single ip condition', () => {
+      const { parsed } = roundTrip([{ field: 'ip', operator: 'ne', value: '203.0.113.9' }])
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'ip', operator: 'ne', value: '203.0.113.9' })
+    })
+
+    // A keyed cookie condition is CEL's one inherently lossy case (see
+    // CelParser.ts's file-level doc comment) — there is no CEL shape that
+    // distinguishes "this specific cookie" from "this substring appears in
+    // the header", so it comes back reshaped rather than identical. What
+    // matters is that the reshaped condition, fed back through the builder,
+    // produces the *same* CEL both times (idempotent from here on) — not
+    // that the UnifiedCondition shape matches the original.
+    it('round-trips a keyed cookie condition to an equivalent (reshaped, idempotent) contains condition', () => {
+      const original: UnifiedCondition = { field: 'cookie', key: 'session', operator: 'eq', value: 'abc123' }
+      const firstPass = CelExpressionBuilder.fromUnifiedConditions([original], 'AND')
+      const parsed = parseCelExpression(firstPass)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions[0]).toMatchObject({ field: 'cookie', operator: 'contains', value: 'session=abc123' })
+
+      const secondPass = CelExpressionBuilder.fromUnifiedConditions(parsed!.conditions, parsed!.conditionLogic)
+      expect(secondPass).toBe(firstPass)
+    })
+
+    it('round-trips a value containing a quote and a backslash', () => {
+      const { parsed } = roundTrip([{ field: 'path', operator: 'eq', value: "/it's a\\test" }])
+      expect(parsed!.conditions[0]!.value).toBe("/it's a\\test")
+    })
+  })
+})

--- a/src/lib/translators/__tests__/celEscape.test.ts
+++ b/src/lib/translators/__tests__/celEscape.test.ts
@@ -1,0 +1,37 @@
+import { escapeCelString, unescapeCelString } from '../celEscape'
+
+describe('escapeCelString', () => {
+  it('returns strings with no special characters unchanged', () => {
+    expect(escapeCelString('Authorization')).toBe('Authorization')
+  })
+
+  it('escapes single quotes', () => {
+    expect(escapeCelString("say 'hi'")).toBe("say \\'hi\\'")
+  })
+
+  it('escapes backslashes', () => {
+    expect(escapeCelString('a\\b')).toBe('a\\\\b')
+  })
+
+  it('escapes backslashes before quotes, so a trailing backslash cannot consume a wrapping close-quote', () => {
+    const result = escapeCelString('a\\')
+    expect(result).toBe('a\\\\')
+    expect(`'${result}'`).toBe("'a\\\\'")
+  })
+
+  it('escapes an embedded quote so it cannot break out of a field reference', () => {
+    const maliciousKey = "x'] || true || request.headers['x"
+    const result = escapeCelString(maliciousKey)
+    const fieldRef = `request.headers['${result}']`
+    expect(fieldRef).not.toMatch(/headers\['[^'\\]*'\] \|\|/)
+  })
+})
+
+describe('unescapeCelString', () => {
+  it('is the exact inverse of escapeCelString', () => {
+    const values = ["it's", 'a\\b', "a\\'b", "''", '\\\\', 'plain']
+    for (const value of values) {
+      expect(unescapeCelString(escapeCelString(value))).toBe(value)
+    }
+  })
+})

--- a/src/lib/translators/celEscape.ts
+++ b/src/lib/translators/celEscape.ts
@@ -1,0 +1,33 @@
+/**
+ * Escapes a string for safe interpolation into a single-quoted CEL string
+ * literal (Cloud Armor's `rule.match.expr.expression`), e.g.
+ * `request.headers['<key>']` or a condition value like `'<value>'`.
+ *
+ * Backslashes must be escaped *before* quotes — same reasoning as
+ * `escapeWirefilterString`: a value ending in a backslash would otherwise
+ * consume the literal's closing quote instead of terminating the string, and
+ * an unescaped quote in a header key or condition value could break out of
+ * the string literal and inject arbitrary CEL syntax.
+ */
+export function escapeCelString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
+ * Inverse of `escapeCelString` — decodes `\\` and `\'` escape sequences in
+ * the *contents* of a CEL single-quoted string literal (the caller strips
+ * the surrounding quotes before calling this). Any other backslash sequence
+ * is left as-is; this codebase's CEL string literals only ever use these two.
+ */
+export function unescapeCelString(value: string): string {
+  let result = ''
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === '\\' && (value[i + 1] === '\\' || value[i + 1] === "'")) {
+      result += value[i + 1]
+      i++
+    } else {
+      result += value[i]
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

Second slice of the GCP Cloud Armor epic (#187) — the expression-DSL layer, built and tested standalone before any provider wiring depends on it (first slice: #232, async auth). Cloud Armor's `rule.match.expr.expression` is CEL (Common Expression Language), an expression-string DSL like Cloudflare's wirefilter, not structured JSON like Vercel/Fastly — confirmed by reading Fastly's translator as a contrast before starting. Mirrors `ExpressionBuilder`/`WirefilterParser`'s structure and "invert our own generator" discipline (#178): `CelParser` understands exactly the CEL subset `CelExpressionBuilder` emits, returning `null` for anything else rather than guessing.

## Field/operator mapping

Researched directly against Cloud Armor's own `rules-language-reference` and `common-use-cases` docs, not guessed:

- **ip** → `origin.ip` (`inIpRange()` for CIDR, `==` for a bare IP; multiple values in one condition become an OR of individual checks, since CEL has no wirefilter-style "in a set of ranges" operator)
- **country** → `origin.region_code`, **asn** → `origin.asn` (numeric)
- **path/method/query** → `request.path`/`request.method`/`request.query`
- **host/user_agent/referer/header(by key)** → `request.headers[...]`, every access guarded by `has(...)` first (indexing an absent key is a CEL runtime error, confirmed against Cloud Armor's own examples, which uniformly guard this way)
- **cookie** → `request.headers['cookie']` — Cloud Armor has no parsed per-cookie map, only the raw header, so a keyed cookie condition composes a `'key=value'` substring search (the closest faithful representation of "is this cookie set to this value"); restricted to `eq`/`ne`/`contains`/`not_contains`, where that composition is unambiguous
- **region, city, port, scheme**: no CEL equivalent exists (confirmed — Cloud Armor has no continent/region/city-level geo attribute, no per-request port, and no confirmed scheme field) — these throw a clear error rather than being silently dropped or approximated, per #187's own acceptance criteria ("explicit, warned failure, never silent corruption")

## A real bug caught during implementation

Negating a single non-CIDR ip equality check naively produces `!origin.ip == 'x'`, which CEL parses as `(!origin.ip) == 'x'` — a type error against a string, since `!` binds tighter than `==`. Fixed by parenthesizing the comparison before negating (`!(origin.ip == 'x')`); a function call like `inIpRange(...)` has no such ambiguity and is negated directly. Covered by an explicit regression test and mutation-verified below.

The parser's one intentionally lossy case, documented in its own file comment: a keyed cookie condition round-trips to a reshaped-but-behaviorally-identical `contains` condition, since CEL genuinely has no way to distinguish "this specific cookie" from "this substring appears in the header" — not a bug, a real boundary of what Cloud Armor can express. Verified idempotent (the reshaped condition re-builds to the exact same CEL) rather than identical to the original.

## Verification

- `pnpm exec tsc --noEmit && pnpm jest && pnpm eslint .` clean — 86 suites, 1589 tests (+82 new: builder unit tests for every field/operator combination including the unsupported-field errors, parser unit tests, and round-trip fidelity tests against the builder for every condition shape, mirroring `WirefilterParser.test.ts`'s structure).
- **Mutation-verify**, three targeted mutations on the most structurally novel logic (nothing here has a wirefilter equivalent to lean on):
  - Disabled the ip-multi-value OR-group recognition in `CelParser` → 3 tests failed exactly as expected (a multi-CIDR condition incorrectly split into two separate OR-groups instead of one condition with multiple values).
  - Disabled the `has()`-guard-collapsing recognition (the `(has(x) && comparison)` → one condition shape, which every header/cookie condition uses) → 6 tests failed exactly as expected.
  - Reverted the `!origin.ip == 'x'` precedence fix → the dedicated regression test failed with the exact predicted (broken) output string, confirming it actually guards the bug.

  All three restored, full suite green again.

## Test plan

- [x] Unit tests pass (`pnpm jest`)
- [x] Typecheck + lint clean
- [x] Mutation-verify on the three most structurally novel pieces of new logic