### PR TITLE
fix: diff-symmetry bugs — conditionLogic default not applied, value:undefined on ex/nex

### DIFF
--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -457,12 +457,25 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
       // time via `rules.insert`, so insertion order is the only ordering
       // lever available here. See syncRules for why that's best-effort
       // rather than a guarantee.
-      const { toAdd, toUpdate, toDelete } = this.diffRules(sortRulesByPriority(config.rules), remoteRules)
+      //
+      // Diff against `configValidation.data`, not the raw `config` param —
+      // `diffRules`/`diffIPRules` both require already-normalized input (see
+      // their docstrings), but the raw config a user writes by hand is
+      // allowed to omit fields the schema defaults for them (e.g. a rule's
+      // `conditionLogic`). Reading from the unparsed `config` silently
+      // violated that contract: a local rule relying on the documented
+      // default had one fewer key than the always-explicit translated
+      // remote side, so `isDeepEqual` (which compares key count) flagged it
+      // as a phantom "update" forever. See #225.
+      const { toAdd, toUpdate, toDelete } = this.diffRules(
+        sortRulesByPriority(configValidation.data.rules),
+        remoteRules,
+      )
 
       const remoteIPs: UnifiedIPRule[] = activeConfig.ips.map((ip) => RuleTranslator.vercelIPToUnified(ip))
 
       // Handle IP blocking rules
-      const { ipsToAdd, ipsToUpdate, ipsToDelete } = this.diffIPRules(config.ips || [], remoteIPs)
+      const { ipsToAdd, ipsToUpdate, ipsToDelete } = this.diffIPRules(configValidation.data.ips || [], remoteIPs)
 
       return {
         version: activeConfig.version,

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -898,12 +898,94 @@ describe('VercelFirewallService', () => {
             // and `conditionLogic: 'AND'` are included because
             // vercelToUnified legitimately always sets both (source group
             // index; single-group default) — they're not part of the
-            // undefined-vs-absent bug this test targets, and omitting them
-            // here would fail the comparison for an unrelated reason
-            // (getChanges compares configRule as-authored, without applying
-            // unifiedRuleSchema's conditionLogic default first — a separate,
-            // real gap, filed as its own issue rather than folded in here).
+            // undefined-vs-absent bug this test targets. (`conditionLogic`
+            // can be omitted safely too now — see the #225 regression test
+            // below — but it's kept explicit here to isolate this test to
+            // the one bug it targets.)
             conditionLogic: 'AND',
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot', group: 0 }],
+            action: { type: 'deny' },
+          },
+        ],
+        ips: [],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('should detect no changes for an ex/nex condition with no value (regression test for #231)', async () => {
+      // Same bug class as #203 above, one field over: vercelToUnified wrote
+      // `value: condition.value` unconditionally, which is `undefined` for
+      // an `ex`/`nex` condition by design (#213) — so the in-memory
+      // translated remote rule had a real `value: undefined` key that a
+      // local config (loaded from disk, where JSON.stringify already
+      // dropped it) could never match structurally.
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [
+          {
+            id: 'rule_3',
+            name: 'Allow Supabase Cookies',
+            active: true,
+            conditionGroup: [{ conditions: [{ type: 'cookie' as const, op: 'nex' as const, key: 'supabase_auth' }] }],
+            action: { mitigate: { action: 'bypass' as const } },
+          },
+        ],
+        ips: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_3',
+            name: 'Allow Supabase Cookies',
+            enabled: true,
+            conditionLogic: 'AND',
+            // No `value` key — matches what vercelToUnified now produces,
+            // and what a real ex/nex rule looks like once saved to disk.
+            conditions: [{ field: 'cookie', operator: 'not_exists', key: 'supabase_auth', group: 0 }],
+            action: { type: 'bypass' },
+          },
+        ],
+        ips: [],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('should detect no changes for a local rule that omits conditionLogic (regression test for #225)', async () => {
+      // getChanges previously diffed the raw `config` parameter rather than
+      // `unifiedConfigSchema.safeParse(config).data` — so a local rule
+      // relying on the documented `conditionLogic` default ('AND') never
+      // actually got it applied before comparison, while the translated
+      // remote side (vercelToUnified) always sets it explicitly. One fewer
+      // key on the local side made isDeepEqual flag every such rule as a
+      // phantom "update".
+      jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
+        ...mockVercelConfig,
+        rules: [mockVercelConfig.rules[0]!],
+        ips: [],
+      })
+
+      const config: UnifiedConfig = {
+        version: '2.0',
+        provider: 'vercel',
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bots',
+            description: 'Block bad bots',
+            enabled: true,
+            // No `conditionLogic` key at all — relies entirely on the
+            // schema's documented default.
             conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot', group: 0 }],
             action: { type: 'deny' },
           },

--- a/src/lib/providers/vercel/translator.ts
+++ b/src/lib/providers/vercel/translator.ts
@@ -39,14 +39,14 @@ export function vercelToUnified(rule: VercelCustomRule): TranslationResult<Unifi
       conditions.push({
         field: mapVercelTypeToUnified(condition.type),
         operator,
-        value: condition.value as string | number | string[] | number[],
-        // Conditional spread, not `negated: condition.neg` — an unconditional
-        // assignment creates a `negated: undefined` key for an ordinary
-        // condition, which isDeepEqual treats as a different shape than the
-        // key being absent entirely (the local-config-loaded-from-disk case,
-        // since JSON.stringify drops undefined). That mismatch makes every
-        // non-negated rule show up as a phantom "update" on every sync. Same
-        // bug, same fix, as Fastly's pushUnifiedCondition. See #203.
+        // Conditional spread, not `value: condition.value` — an unconditional
+        // assignment creates a `value: undefined` key for an `ex`/`nex`
+        // condition (whose Vercel-native value is always undefined by
+        // design, #213), which isDeepEqual treats as a different shape than
+        // the key being absent entirely (the local-config-loaded-from-disk
+        // case, since JSON.stringify drops undefined). Same bug, same fix,
+        // as `negated` right below. See #203, #231.
+        ...(condition.value !== undefined ? { value: condition.value as string | number | string[] | number[] } : {}),
         ...(condition.neg ? { negated: true } : {}),
         ...(condition.key ? { key: condition.key } : {}),
         group: groupIndex,

--- a/src/lib/schemas/unifiedSchemas.ts
+++ b/src/lib/schemas/unifiedSchemas.ts
@@ -25,6 +25,15 @@ export const unifiedConditionSchema = z
     value: z.union([z.string(), z.number(), z.array(z.string()), z.array(z.number())]).optional(),
     negated: z.boolean().optional(),
     key: z.string().optional(), // For header, query, cookie
+    // AND-group index (see UnifiedCondition.group in types/unified.ts). Zod
+    // strips unrecognized keys by default, so before this was added,
+    // running a condition through this schema silently dropped `group` —
+    // fine as a one-off, but a live regression the moment any caller
+    // switches from reading raw config to reading the parsed/defaulted
+    // result (see #225's fix in VercelFirewallService.getChanges: every
+    // multi-group rule, and every rule diffed against vercelToUnified's
+    // always-present `group`, would show a phantom "update" otherwise).
+    group: z.number().optional(),
   })
   .refine(
     // `exists`/`not_exists` (unified's equivalent of Vercel's `ex`/`nex` —


### PR DESCRIPTION
## Summary
- Closes #231 — `vercelToUnified` assigned `value: condition.value` unconditionally, which is `undefined` for `ex`/`nex` conditions by design (#213). Same undefined-vs-absent-key mismatch as #226's `negated` fix, missed on the field right above it — `isDeepEqual` compares key count, so any ex/nex rule (e.g. a cookie-existence bypass rule) showed up as a phantom "update" forever. Checked Fastly's `pushUnifiedCondition` too (flagged in the issue as sharing the same shape) — but `FastlySingleCondition`/`FastlyMultivalSubCondition` both type `value` as a required `string`, never optional, so it isn't actually reachable there. Left unchanged; noting this as a correction to the issue.
- Closes #225 — `getChanges` called `unifiedConfigSchema.safeParse(config)` only to validate, then diffed the original unparsed `config.rules`/`config.ips` instead of `configValidation.data` — so a local rule relying on the `conditionLogic` schema default never got it applied before comparison, while the translated remote side always sets it explicitly. `diffRules`/`diffIPRules` already document that both arguments must be pre-normalized; the call site wasn't honoring that.
- **Latent regression caught while fixing #225**: switching to the parsed config exposed that `unifiedConditionSchema` never defined `group` — Zod's default key-stripping silently dropped it once parsed input replaced raw input, which would have broken every multi-group rule and every diff against `vercelToUnified`'s always-present `group`. Added `group: z.number().optional()` to the schema to match `UnifiedCondition`. Caught by the full test suite, not by reasoning alone — worth calling out in review.

## Test plan
- [x] Added 2 new regression tests to `VercelFirewallService.test.ts` (`getChanges` describe block) exercising both bugs end-to-end via mocked fetch + real diff
- [x] `pnpm test:ci` — 84/84 suites, 1511/1511 tests passing (one `CloudflarePerformanceBenchmarks` flake observed under host CPU load, unrelated to this change — passes in isolation and on repeat full-suite runs)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean
- [x] Empirically verified both fixes against a real production Vercel firewall: exported the live unified config (which includes a genuine `ex`/`nex` bypass rule) and diffed it against itself — clean. Then stripped `conditionLogic` from one rule to simulate a hand-authored config relying on the default — still clean (previously reported a phantom update).