### PR TITLE
fix: translate exists/not_exists conditions to Fastly correctly

### DIFF
--- a/src/lib/providers/fastly/__tests__/translator.test.ts
+++ b/src/lib/providers/fastly/__tests__/translator.test.ts
@@ -114,6 +114,51 @@ describe('fastly translator round-trip fidelity', () => {
     expect(result.conditions[0]).toMatchObject({ field, operator: 'eq', value: 'expected-value', key: 'X-Test' })
   })
 
+  it.each(['exists', 'not_exists'] as const)(
+    'round-trips a keyed %s condition as a pure Fastly existence check, not a value match against "undefined"',
+    (operator) => {
+      const rule: UnifiedRule = {
+        id: 'r4b',
+        name: `Cookie ${operator}`,
+        enabled: true,
+        conditions: [{ field: 'cookie', operator, key: 'supabase_auth', group: 0 }],
+        action: { type: 'bypass' },
+      }
+
+      const { result: input } = unifiedToFastly(rule)
+      expect(input.multival_conditions).toHaveLength(1)
+      const multival = input.multival_conditions![0]!
+      expect(multival.operator).toBe(operator === 'exists' ? 'exists' : 'does_not_exist')
+      // Exactly the name sub-condition — no value sub-condition at all, so
+      // there's nothing that could serialize as the literal string "undefined".
+      expect(multival.conditions).toEqual([
+        { type: 'single', field: 'name', operator: 'equals', value: 'supabase_auth' },
+      ])
+
+      const result = roundTrip(rule)
+      expect(result.conditions[0]).toMatchObject({ field: 'cookie', operator, key: 'supabase_auth' })
+      expect(result.conditions[0]).not.toHaveProperty('value')
+    },
+  )
+
+  it('drops an exists/not_exists condition on a non-keyed field, with a warning, rather than matching literal "undefined"', () => {
+    const rule: UnifiedRule = {
+      id: 'r4c',
+      name: 'Path existence (unsupported)',
+      enabled: true,
+      conditions: [
+        { field: 'path', operator: 'not_exists', group: 0 },
+        { field: 'method', operator: 'eq', value: 'POST', group: 0 },
+      ],
+      action: { type: 'block' },
+    }
+
+    const { result, warnings } = unifiedToFastly(rule)
+    expect(result.conditions).toHaveLength(1)
+    expect(result.conditions?.[0]).toMatchObject({ field: 'method' })
+    expect(warnings.some((w) => w.message.includes('not_exists') && w.message.includes('path'))).toBe(true)
+  })
+
   it('drops a condition field Fastly has no equivalent for, with a warning, rather than mistranslating it', () => {
     const rule: UnifiedRule = {
       id: 'r5',

--- a/src/lib/providers/fastly/translator.ts
+++ b/src/lib/providers/fastly/translator.ts
@@ -301,10 +301,25 @@ function pushUnifiedCondition(
   const valueCondition = item.conditions.find((c) => c.field === 'value' || c.field === 'value_string')
 
   if (!valueCondition) {
+    // A name-only multival (no value sub-condition) is a pure existence
+    // check — the outbound half of this pair (buildFastlyConditions, above)
+    // now emits exactly this shape for a unified exists/not_exists
+    // condition, using the multival's own operator ('exists'/
+    // 'does_not_exist') to carry the check. See #236.
+    if (nameCondition) {
+      conditions.push({
+        field: unifiedField,
+        operator: item.operator === 'does_not_exist' ? 'not_exists' : 'exists',
+        key: nameCondition.value,
+        group,
+      })
+      return
+    }
+
     warnings.push(
       logicWarning(
         ruleId,
-        `Multival condition on '${item.field}' has no value sub-condition doorman could extract (only a 'name' existence check) — skipped.`,
+        `Multival condition on '${item.field}' has no value or name sub-condition doorman could extract — skipped.`,
       ),
     )
     return
@@ -476,6 +491,26 @@ function buildFastlyConditions(
         )
         return null
       }
+      // A pure existence check (Vercel's ex/nex, unified exists/not_exists)
+      // has no value to compare — only whether an entry named `condition.key`
+      // is present at all. Fastly's multival `operator` (FastlyMultivalOperator,
+      // 'exists' | 'does_not_exist') already models exactly that at the group
+      // level, so this case needs only the `name` sub-condition. Previously
+      // this branch always hardcoded `operator: 'exists'` and always added a
+      // value sub-condition via `String(condition.value)` — for exists/
+      // not_exists that meant `String(undefined)`, i.e. a condition matching
+      // the literal text "undefined", with the not_exists case additionally
+      // never flipping to `does_not_exist` at all. See #236.
+      if (condition.operator === 'exists' || condition.operator === 'not_exists') {
+        return {
+          type: 'multival',
+          field: multivalField,
+          operator: condition.operator === 'exists' ? 'exists' : 'does_not_exist',
+          group_operator: 'all',
+          conditions: [{ type: 'single', field: 'name', operator: 'equals', value: condition.key }],
+        }
+      }
+
       const valueField =
         multivalField === 'request_header' || multivalField === 'response_header' ? 'value_string' : 'value'
       return {
@@ -493,6 +528,24 @@ function buildFastlyConditions(
           },
         ],
       }
+    }
+
+    // Non-multival fields (path, method, host, etc.) always exist on every
+    // request — Fastly has no per-field existence check to translate an
+    // exists/not_exists condition into outside the keyed multival model
+    // above. Warn and drop rather than silently emitting a condition that
+    // matches the literal string "undefined" (see #236).
+    if (condition.operator === 'exists' || condition.operator === 'not_exists') {
+      warnings.push(
+        TranslationWarningSystem.createUnsupportedFeatureWarning(
+          `"${condition.operator}" on field '${condition.field}'`,
+          'unified config',
+          'Fastly',
+          ruleId,
+          condition.field,
+        ),
+      )
+      return null
     }
 
     const field = mapUnifiedFieldToFastly(condition.field)


### PR DESCRIPTION
## Summary
Closes #236 — `unifiedToFastly` coerced an `exists`/`not_exists` condition's missing `value` into the literal string `"undefined"` via `String(condition.value)`, and the multival group operator was hardcoded to `'exists'` regardless of which one was meant. Net effect: an existence-check condition (e.g. "cookie X doesn't exist") silently became a Fastly rule matching the literal text `"undefined"` — no error, no warning, just a broken rule.

Fixed both translation directions so this round-trips cleanly, not just outbound:
- **Outbound** (`buildFastlyConditions`): an `exists`/`not_exists` condition on a keyed field (header/query/cookie) now produces a name-only multival block with `operator: 'exists'` / `'does_not_exist'` — no value sub-condition at all, since there's nothing to compare. A non-keyed field (`path`, `method`, etc.) has no Fastly existence-check equivalent to translate into, so it's dropped with an explicit unsupported-feature warning instead of silently emitting the broken condition.
- **Inbound** (`pushUnifiedCondition`): this function already had a branch for "multival with no value sub-condition" — but it warned and dropped the whole condition rather than reading it back correctly. It already anticipated exactly this shape (the existing comment literally said "only a 'name' existence check"), just didn't act on it. Now converts it to `exists`/`not_exists` based on the multival's own operator, so the outbound fix actually round-trips instead of vanishing on the way back.

## Test plan
- [x] Two new `it.each(['exists', 'not_exists'])` tests asserting the outbound multival shape (operator flip, no value sub-condition) and full round-trip fidelity
- [x] One new test confirming a non-keyed field's exists/not_exists condition is dropped with a warning naming both the operator and field, while a sibling condition survives
- [x] `pnpm test:ci` — 87/87 suites, 1596/1596 tests
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean
- Not tested against a live Fastly workspace (no credentials available) — verified via the existing round-trip unit-test harness instead, same approach the repo already uses for its other Fastly translator coverage