### PR TITLE
feat: add GCP Cloud Armor provider

### DIFF
--- a/demos/cloudarmor-mock-server.mjs
+++ b/demos/cloudarmor-mock-server.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Minimal local stand-in for Google Cloud Armor's `securityPolicies` REST API
+// (https://compute.googleapis.com/compute/v1/projects/{project}/global/securityPolicies/...),
+// used for demo/VHS capture and exercising CloudArmorClient's request shapes
+// end-to-end (see DOORMAN_GCP_API_BASE_URL in
+// src/lib/providers/gcp/CloudArmorClient.ts). Never used against real traffic.
+//
+// Models the real REST shape confirmed against the Compute v1 API reference:
+// addRule/patchRule/removeRule are POST (patchRule/removeRule address the
+// target rule via a `?priority=` query param, not a path segment — there is
+// no per-rule resource path the way Fastly/Vercel have one), and every
+// mutator returns a long-running Operation rather than the updated resource,
+// which CloudArmorClient polls via GET .../operations/{name}. This mock
+// always reports an operation as immediately DONE — there's no async
+// processing to actually wait on locally.
+//
+// One real limitation, unlike the Vercel/Cloudflare/Fastly mock servers:
+// GoogleAuth's token flow (service-account JWT exchanged for an OAuth2
+// access token at Google's real oauth2.googleapis.com) requires reaching
+// Google's real infrastructure with real, working credentials — there's no
+// way to fake that locally the way a static bearer token can be. This mock
+// server exercises CloudArmorClient's request/response handling once a
+// caller already has a real, working GoogleAuth setup; it cannot provide a
+// fully offline end-to-end path the way the other three providers' mock
+// servers can.
+import { createServer } from 'node:http'
+import { readFileSync } from 'node:fs'
+
+const args = process.argv.slice(2)
+const getArg = (name, fallback) => {
+  const idx = args.indexOf(`--${name}`)
+  return idx !== -1 ? args[idx + 1] : fallback
+}
+
+const port = Number(getArg('port', '4867'))
+const fixturePath = getArg('fixture')
+
+if (!fixturePath) {
+  console.error('Usage: cloudarmor-mock-server.mjs --port <port> --fixture <path-to-json>')
+  process.exit(1)
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'))
+const projectId = fixture.projectId ?? 'demo-project'
+const policyName = fixture.policyName ?? 'doorman-demo-policy'
+
+const state = {
+  policy: {
+    id: fixture.policyId ?? '1234567890',
+    name: policyName,
+    description: fixture.policyDescription ?? 'Managed by doorman',
+    rules: fixture.rules ?? [],
+    fingerprint: 'ZmluZ2VycHJpbnQ=',
+    selfLink: `https://compute.googleapis.com/compute/v1/projects/${projectId}/global/securityPolicies/${policyName}`,
+    creationTimestamp: '2026-01-15T12:00:00.000-08:00',
+  },
+}
+
+let operationCounter = 0
+
+async function readBody(req) {
+  let body = ''
+  for await (const chunk of req) body += chunk
+  return body ? JSON.parse(body) : {}
+}
+
+/** Every mutator returns this shape — CloudArmorClient.waitForOperation sees status DONE on the very first poll. */
+function doneOperation() {
+  operationCounter += 1
+  return {
+    kind: 'compute#operation',
+    name: `operation-${operationCounter}`,
+    status: 'DONE',
+    progress: 100,
+  }
+}
+
+const server = createServer(async (req, res) => {
+  const send = (status, body) => {
+    res.writeHead(status, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(body))
+  }
+
+  const url = new URL(req.url, `http://localhost:${port}`)
+  const policyPath = `/projects/${projectId}/global/securityPolicies/${policyName}`
+
+  try {
+    // getPolicy
+    if (url.pathname === policyPath && req.method === 'GET') {
+      return send(200, state.policy)
+    }
+
+    // addRule — priority lives in the request body, not the URL
+    if (url.pathname === `${policyPath}/addRule` && req.method === 'POST') {
+      const rule = await readBody(req)
+      if (state.policy.rules.some((r) => r.priority === rule.priority)) {
+        return send(400, { error: { code: 400, message: `priority ${rule.priority} already in use` } })
+      }
+      state.policy.rules.push(rule)
+      return send(200, doneOperation())
+    }
+
+    // patchRule — target rule addressed by ?priority=, replaces it wholesale
+    if (url.pathname === `${policyPath}/patchRule` && req.method === 'POST') {
+      const priority = Number(url.searchParams.get('priority'))
+      const index = state.policy.rules.findIndex((r) => r.priority === priority)
+      if (index === -1) {
+        return send(404, { error: { code: 404, message: `no rule at priority ${priority}` } })
+      }
+      const rule = await readBody(req)
+      state.policy.rules[index] = rule
+      return send(200, doneOperation())
+    }
+
+    // removeRule — same addressing as patchRule, no body
+    if (url.pathname === `${policyPath}/removeRule` && req.method === 'POST') {
+      const priority = Number(url.searchParams.get('priority'))
+      state.policy.rules = state.policy.rules.filter((r) => r.priority !== priority)
+      return send(200, doneOperation())
+    }
+
+    // Operation polling — always already DONE by the time CloudArmorClient asks.
+    if (url.pathname.startsWith(`/projects/${projectId}/global/operations/`) && req.method === 'GET') {
+      const name = url.pathname.slice(`/projects/${projectId}/global/operations/`.length)
+      return send(200, { kind: 'compute#operation', name, status: 'DONE', progress: 100 })
+    }
+
+    return send(404, { error: { code: 404, message: 'not found' } })
+  } catch (error) {
+    return send(500, { error: { code: 500, message: error instanceof Error ? error.message : String(error) } })
+  }
+})
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`cloudarmor-mock-server listening on 127.0.0.1:${port} (fixture: ${fixturePath})`)
+})

--- a/demos/fixtures/cloudarmor-sync-local.doorman.json
+++ b/demos/fixtures/cloudarmor-sync-local.doorman.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://doorman.griffen.codes/schema.json",
+  "version": "2.0",
+  "provider": "gcp",
+  "providers": {
+    "gcp": { "projectId": "demo-project", "policyName": "doorman-demo-policy" }
+  },
+  "rules": [
+    {
+      "id": "1000",
+      "name": "Block Bad Bots",
+      "enabled": true,
+      "conditions": [{ "field": "user_agent", "operator": "contains", "value": "bot" }],
+      "action": { "type": "deny" },
+      "priority": 1000
+    },
+    {
+      "name": "Block Admin Path",
+      "enabled": true,
+      "conditions": [{ "field": "path", "operator": "contains", "value": "/admin" }],
+      "action": { "type": "deny" }
+    }
+  ],
+  "ips": [
+    { "ip": "198.51.100.7", "action": "deny" },
+    { "ip": "203.0.113.9", "action": "deny" }
+  ]
+}

--- a/demos/fixtures/cloudarmor-sync-remote.json
+++ b/demos/fixtures/cloudarmor-sync-remote.json
@@ -1,0 +1,21 @@
+{
+  "projectId": "demo-project",
+  "policyName": "doorman-demo-policy",
+  "policyId": "1234567890",
+  "rules": [
+    {
+      "priority": 1000,
+      "description": "Block Bad Bots",
+      "match": {
+        "expr": { "expression": "(has(request.headers['user-agent']) && request.headers['user-agent'].contains('bot'))" }
+      },
+      "action": "deny(403)"
+    },
+    {
+      "priority": 2000,
+      "description": "IP deny: 198.51.100.7",
+      "match": { "expr": { "expression": "origin.ip == '198.51.100.7'" } },
+      "action": "deny(403)"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "consola": "^3.4.2",
     "dotenv": "^16.4.5",
     "find-up": "^6.3.0",
+    "google-auth-library": "^11.0.2",
     "yargs": "^17.7.2",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
+      google-auth-library:
+        specifier: ^11.0.2
+        version: 11.0.2
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1514,6 +1517,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -1539,6 +1545,9 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1800,6 +1809,10 @@ packages:
     resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
     engines: {node: '>= 10'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
     engines: {node: '>= 0.4'}
@@ -1896,6 +1909,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
@@ -2110,6 +2126,9 @@ packages:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -2143,6 +2162,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -2219,6 +2242,10 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
@@ -2251,6 +2278,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@9.0.3:
+    resolution: {integrity: sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==}
+    engines: {node: '>=22'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2344,6 +2379,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@11.0.2:
+    resolution: {integrity: sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==}
+    engines: {node: '>=22'}
+
+  google-logging-utils@2.0.1:
+    resolution: {integrity: sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==}
+    engines: {node: '>=22'}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -2835,6 +2878,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2863,6 +2909,12 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3063,9 +3115,18 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -4025,6 +4086,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -5605,6 +5670,8 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -5636,6 +5703,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -5899,6 +5968,8 @@ snapshots:
       - '@types/node'
       - typescript
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.1:
     dependencies:
       call-bind: 1.0.7
@@ -5974,6 +6045,10 @@ snapshots:
       readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.349: {}
 
@@ -6275,6 +6350,8 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
+  extend@3.0.2: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -6300,6 +6377,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   figures@2.0.0:
     dependencies:
@@ -6385,6 +6467,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   from2@2.3.0:
     dependencies:
       inherits: 2.0.4
@@ -6420,6 +6506,22 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.4
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@9.0.3:
+    dependencies:
+      gaxios: 7.3.1
+      google-logging-utils: 2.0.1
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -6530,6 +6632,19 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.0.1
+
+  google-auth-library@11.0.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 9.0.3
+      google-logging-utils: 2.0.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@2.0.1: {}
 
   gopd@1.0.1:
     dependencies:
@@ -7156,6 +7271,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -7177,6 +7296,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -7347,12 +7477,20 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
       char-regex: 1.0.2
       emojilib: 2.4.0
       skin-tone: 2.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -8309,6 +8447,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -16,7 +16,7 @@
  * The registry remains the source of truth for provider *instances*; this
  * is the source of truth for the closed set of known provider *types*.
  */
-export const PROVIDER_TYPES = ['vercel', 'cloudflare', 'fastly'] as const
+export const PROVIDER_TYPES = ['vercel', 'cloudflare', 'fastly', 'gcp'] as const
 
 /**
  * Provider type discriminator

--- a/src/lib/providers/__tests__/ProviderDetector.test.ts
+++ b/src/lib/providers/__tests__/ProviderDetector.test.ts
@@ -18,6 +18,9 @@ describe('ProviderDetector', () => {
     delete process.env.VERCEL_TOKEN
     delete process.env.FASTLY_WORKSPACE_ID
     delete process.env.FASTLY_API_TOKEN
+    delete process.env.GOOGLE_CLOUD_PROJECT
+    delete process.env.GCP_POLICY_NAME
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS
   })
 
   afterAll(() => {
@@ -137,6 +140,30 @@ describe('ProviderDetector', () => {
       process.env.FASTLY_API_TOKEN = 'token-123'
       const result = ProviderDetector.detect()
       expect(result.provider).toBe('fastly')
+      expect(result.confidence).toBe('medium')
+    })
+
+    it('detects GCP from providers.gcp.projectId', () => {
+      const result = ProviderDetector.detect({
+        providers: { gcp: { projectId: 'my-gcp-project' } },
+      })
+      expect(result.provider).toBe('gcp')
+      expect(result.confidence).toBe('high')
+      expect(result.reasons).toContainEqual(expect.stringContaining('GCP Project ID'))
+    })
+
+    it('detects GCP from GOOGLE_CLOUD_PROJECT env var alone', () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'my-gcp-project'
+      const result = ProviderDetector.detect()
+      expect(result.provider).toBe('gcp')
+      expect(result.confidence).toBe('medium')
+    })
+
+    it('detects GCP from GOOGLE_CLOUD_PROJECT + GCP_POLICY_NAME env vars', () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'my-gcp-project'
+      process.env.GCP_POLICY_NAME = 'my-policy'
+      const result = ProviderDetector.detect()
+      expect(result.provider).toBe('gcp')
       expect(result.confidence).toBe('medium')
     })
 

--- a/src/lib/providers/__tests__/conformance.test.ts
+++ b/src/lib/providers/__tests__/conformance.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../ui/prompt', () => ({
 jest.mock('../vercel/VercelClient')
 jest.mock('../cloudflare/CloudflareClient')
 jest.mock('../fastly/FastlyClient')
+jest.mock('../gcp/CloudArmorClient')
 
 import { PROVIDER_TYPES, type ProviderType, type FeatureSet } from '../IFirewallProvider'
 import { CREDENTIAL_DESCRIPTORS, resolveCredentials } from '../credentials'
@@ -56,14 +57,17 @@ import { getProviderInstance, type ProviderOptions } from '../../utils/providerH
 import { VercelProvider } from '../vercel'
 import { CloudflareProvider } from '../cloudflare'
 import { FastlyProvider } from '../fastly'
+import { CloudArmorProvider } from '../gcp'
 import { VercelClient } from '../vercel/VercelClient'
 import { CloudflareClient } from '../cloudflare/CloudflareClient'
 import { FastlyClient } from '../fastly/FastlyClient'
+import { CloudArmorClient } from '../gcp/CloudArmorClient'
 import { OperationSafety } from '../../utils/operationSafety'
 import {
   mockVercelClientPrototype,
   mockCloudflareClientPrototype,
   mockFastlyClientPrototype,
+  mockCloudArmorClientPrototype,
   emptyVercelConfig,
   emptyCloudflareRuleset,
 } from '../../../tests/testHelpers/providerMocks'
@@ -72,6 +76,7 @@ import type { UnifiedConfig } from '../../types/unified'
 const MockedVercelClient = VercelClient as jest.MockedClass<typeof VercelClient>
 const MockedCloudflareClient = CloudflareClient as jest.MockedClass<typeof CloudflareClient>
 const MockedFastlyClient = FastlyClient as jest.MockedClass<typeof FastlyClient>
+const MockedCloudArmorClient = CloudArmorClient as jest.MockedClass<typeof CloudArmorClient>
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -175,6 +180,17 @@ const CREDENTIAL_CONFORMANCE_CASES: Array<{ providerType: ProviderType; options:
       config: { providers: { fastly: { workspaceId: 'config-workspace' } } } as UnifiedConfig,
     },
   },
+  {
+    providerType: 'gcp',
+    options: {
+      provider: 'gcp',
+      // serviceAccountKeyPath is optional (falls through to Application
+      // Default Credentials, see gcp/credentials.ts) — projectId/policyName
+      // are the two required, config-declarable fields.
+      interactive: false,
+      config: { providers: { gcp: { projectId: 'config-project', policyName: 'config-policy' } } } as UnifiedConfig,
+    },
+  },
 ]
 
 describe('provider conformance: config-declared credentials resolve without needing env vars', () => {
@@ -222,6 +238,14 @@ describe('provider conformance: getSupportedFeatures returns a complete FeatureS
       expect(typeof features[key]).toBe('boolean')
     }
   })
+
+  it('gcp: every required key is present and boolean', () => {
+    const provider = CloudArmorProvider.fromConfig({ projectId: 'p', policyName: 'pol' })
+    const features = provider.getSupportedFeatures()
+    for (const key of REQUIRED_BOOLEAN_KEYS) {
+      expect(typeof features[key]).toBe('boolean')
+    }
+  })
 })
 
 describe('provider conformance: validateConfig rejects a config with no rules array', () => {
@@ -247,6 +271,13 @@ describe('provider conformance: validateConfig rejects a config with no rules ar
 
   it('fastly', () => {
     const provider = FastlyProvider.fromConfig({ apiToken: 't', workspaceId: 'w' })
+    const result = provider.validateConfig(configWithNoRules)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.code === 'RULES_REQUIRED')).toBe(true)
+  })
+
+  it('gcp', () => {
+    const provider = CloudArmorProvider.fromConfig({ projectId: 'p', policyName: 'pol' })
     const result = provider.validateConfig(configWithNoRules)
     expect(result.valid).toBe(false)
     expect(result.errors.some((e) => e.code === 'RULES_REQUIRED')).toBe(true)
@@ -305,5 +336,16 @@ describe('provider conformance: syncRules never issues a mutating call when dryR
     expect(MockedFastlyClient.prototype.deleteRule).not.toHaveBeenCalled()
     expect(MockedFastlyClient.prototype.getOrCreateList).not.toHaveBeenCalled()
     expect(MockedFastlyClient.prototype.updateListEntries).not.toHaveBeenCalled()
+  })
+
+  it('gcp', async () => {
+    mockCloudArmorClientPrototype(MockedCloudArmorClient, { rules: [] })
+    const provider = CloudArmorProvider.fromConfig({ projectId: 'p', policyName: 'pol' })
+
+    await provider.syncRules(makeLocalConfig('gcp'), { dryRun: true })
+
+    expect(MockedCloudArmorClient.prototype.addRule).not.toHaveBeenCalled()
+    expect(MockedCloudArmorClient.prototype.patchRule).not.toHaveBeenCalled()
+    expect(MockedCloudArmorClient.prototype.removeRule).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/providers/credentials.ts
+++ b/src/lib/providers/credentials.ts
@@ -2,6 +2,7 @@ import type { ProviderType } from './IFirewallProvider'
 import { vercelCredentials } from './vercel/credentials'
 import { cloudflareCredentials } from './cloudflare/credentials'
 import { fastlyCredentials } from './fastly/credentials'
+import { gcpCredentials } from './gcp/credentials'
 
 /**
  * One credential a provider needs, described rather than hardcoded at each
@@ -116,6 +117,7 @@ export const CREDENTIAL_DESCRIPTORS: Record<ProviderType, CredentialDescriptor> 
   vercel: vercelCredentials,
   cloudflare: cloudflareCredentials,
   fastly: fastlyCredentials,
+  gcp: gcpCredentials,
 }
 
 /** The credential descriptor for a provider. */

--- a/src/lib/providers/gcp/CloudArmorClient.ts
+++ b/src/lib/providers/gcp/CloudArmorClient.ts
@@ -1,0 +1,134 @@
+import { GoogleAuth } from 'google-auth-library'
+import { logger } from '../../logger'
+import { BaseFirewallClient } from '../BaseFirewallClient'
+import type { CloudArmorOperation, CloudArmorRule, CloudArmorSecurityPolicy } from '../../types/gcp'
+
+// Overridable for testing/demos against a local mock server — never set this
+// in production. Same seam as DOORMAN_VERCEL_API_BASE_URL/
+// DOORMAN_FASTLY_API_BASE_URL; demos/cloudarmor-mock-server.mjs relies on it.
+export const GCP_COMPUTE_API_BASE_URL =
+  process.env.DOORMAN_GCP_API_BASE_URL || 'https://compute.googleapis.com/compute/v1'
+
+const COMPUTE_SCOPE = 'https://www.googleapis.com/auth/compute'
+
+// How long to keep polling a long-running Operation before giving up. Cloud
+// Armor rule mutations are typically sub-second in practice, but global
+// Compute operations can occasionally take longer under load — capped well
+// short of makeRequest's own per-request timeout stacking indefinitely.
+const OPERATION_POLL_INTERVAL_MS = 1000
+const OPERATION_POLL_TIMEOUT_MS = 60000
+
+/**
+ * A client for Google Cloud Armor's `securityPolicies` REST API
+ * (`https://compute.googleapis.com/compute/v1/projects/{project}/global/...`).
+ * REST-with-header-auth, so this extends `BaseFirewallClient` like
+ * Vercel/Cloudflare/Fastly's clients — the one real difference is that
+ * `getAuthHeaders()` is genuinely async here (see BaseFirewallClient's own
+ * doc comment on why that method is async at all): GCP's OAuth2 access
+ * token is short-lived and fetched fresh per request via `google-auth-
+ * library`'s `GoogleAuth`, which handles caching/refresh internally.
+ *
+ * Every mutating `securityPolicies` method (`addRule`/`patchRule`/
+ * `removeRule`) returns a long-running Operation rather than the updated
+ * resource — `waitForOperation` polls it internally so every public method
+ * here still presents the same "await and it's done" shape the other three
+ * providers' clients already have, rather than leaking GCP's async-operation
+ * model into the service layer.
+ */
+export class CloudArmorClient extends BaseFirewallClient {
+  private readonly auth: GoogleAuth
+  /** Exposed (unlike policyName) — CloudArmorFirewallService.fetchConfig needs it for the providers.gcp config block. */
+  public readonly projectId: string
+  private readonly policyName: string
+
+  constructor(projectId: string, policyName: string, serviceAccountKeyPath?: string) {
+    super(`${GCP_COMPUTE_API_BASE_URL}/projects/${projectId}/global`, 'gcp')
+    this.projectId = projectId
+    this.policyName = policyName
+    this.auth = new GoogleAuth({
+      scopes: [COMPUTE_SCOPE],
+      // Omitting keyFile entirely (rather than passing undefined) lets
+      // GoogleAuth run its own full Application Default Credentials
+      // resolution (GOOGLE_APPLICATION_CREDENTIALS env var, gcloud user
+      // creds, or the GCE/Cloud Run metadata server) exactly as it would
+      // with no config at all — confirmed via research on #187.
+      ...(serviceAccountKeyPath ? { keyFile: serviceAccountKeyPath } : {}),
+    })
+  }
+
+  protected async getAuthHeaders(): Promise<Record<string, string>> {
+    const client = await this.auth.getClient()
+    const headers = await client.getRequestHeaders()
+    // google-auth-library types this as a plain header record already;
+    // the cast is only to satisfy BaseFirewallClient's Record<string,
+    // string> contract against the library's own (structurally identical)
+    // Headers-like type.
+    return headers as unknown as Record<string, string>
+  }
+
+  private policyPath(...segments: string[]): string {
+    return ['/securityPolicies', this.policyName, ...segments].join('/')
+  }
+
+  async getPolicy(): Promise<CloudArmorSecurityPolicy> {
+    return this.get<CloudArmorSecurityPolicy>(this.policyPath())
+  }
+
+  async addRule(rule: CloudArmorRule): Promise<void> {
+    const operation = await this.post<CloudArmorOperation>(this.policyPath('addRule'), rule)
+    await this.waitForOperation(operation)
+  }
+
+  async patchRule(priority: number, rule: CloudArmorRule): Promise<void> {
+    const operation = await this.post<CloudArmorOperation>(`${this.policyPath('patchRule')}?priority=${priority}`, rule)
+    await this.waitForOperation(operation)
+  }
+
+  async removeRule(priority: number): Promise<void> {
+    const operation = await this.post<CloudArmorOperation>(`${this.policyPath('removeRule')}?priority=${priority}`)
+    await this.waitForOperation(operation)
+  }
+
+  /**
+   * Polls a long-running Operation until it reaches `DONE`, then throws if
+   * it completed with an error. `securityPolicies` mutators are project-
+   * scoped, so the operation lives at `/global/operations/{name}` — the
+   * same base path every other method here already targets.
+   */
+  private async waitForOperation(operation: CloudArmorOperation): Promise<void> {
+    const deadline = Date.now() + OPERATION_POLL_TIMEOUT_MS
+    let current = operation
+
+    while (current.status !== 'DONE') {
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `gcp operation "${current.name}" did not complete within ${OPERATION_POLL_TIMEOUT_MS}ms (last status: ${current.status})`,
+        )
+      }
+      await this.delay(OPERATION_POLL_INTERVAL_MS)
+      current = await this.get<CloudArmorOperation>(`/operations/${current.name}`)
+    }
+
+    if (current.httpErrorStatusCode || current.error) {
+      const messages = current.error?.errors?.map((e) => e.message).join(', ') || current.httpErrorMessage
+      throw new Error(`gcp operation "${current.name}" failed: ${messages || 'unknown error'}`)
+    }
+
+    if (current.warnings?.length) {
+      current.warnings.forEach((w) => logger.warn(`gcp operation "${current.name}" warning: ${w.message}`))
+    }
+  }
+
+  /**
+   * Verify credentials are valid by attempting to fetch the policy.
+   */
+  async verifyCredentials(): Promise<boolean> {
+    try {
+      await this.getPolicy()
+      return true
+    } catch (error) {
+      logger.debug('Credential verification failed:', error)
+      return false
+    }
+  }
+}

--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -1,0 +1,404 @@
+import { logger } from '../../logger'
+import { BaseFirewallService } from '../BaseFirewallService'
+import { CloudArmorClient } from './CloudArmorClient'
+import { RuleTranslator } from '../../translators'
+import { isDeepEqual } from '../../utils/isDeepEqual'
+import { omitId } from '../../utils/omitId'
+import { unifiedConfigSchema } from '../../schemas/unifiedSchemas'
+import type {
+  IFirewallProvider,
+  ProviderType,
+  SyncOptions,
+  SyncResult,
+  ChangeSet,
+  FeatureSet,
+  HealthScore,
+  ValidationResult,
+} from '../IFirewallProvider'
+import type { UnifiedConfig, UnifiedRule, UnifiedIPRule } from '../../types/unified'
+import type { CloudArmorRule } from '../../types/gcp'
+
+/** A rule's Cloud Armor priority also acts as its doorman `id` (stringified) — see translator.ts's file comment. */
+function priorityOf(id: string | undefined): number | undefined {
+  return id !== undefined && /^\d+$/.test(id) ? Number(id) : undefined
+}
+
+/**
+ * GCP Cloud Armor Firewall Service. Implements `IFirewallProvider` for
+ * Cloud Armor's `securityPolicies` API.
+ *
+ * Structurally closest to Vercel's write model — individual per-rule
+ * create/update/delete (`addRule`/`patchRule`/`removeRule`), not
+ * Cloudflare's atomic whole-ruleset replace — but with one real difference
+ * from every other provider: there is no separate, server-assigned rule id.
+ * A rule's `priority` **is** its id, its evaluation order, and its
+ * addressing key all at once (see translator.ts and `priorityOf` above).
+ * There is also no dedicated IP-blocking resource — an IP rule is just
+ * another entry in the same flat `rules[]` array, classified on fetch via
+ * `looksLikeIpRule` (see translator.ts's file comment).
+ *
+ * New local rules/IPs with no priority yet get one assigned by
+ * `assignPriorities` before translation — spaced 1000 apart, matching
+ * common Cloud Armor/gcloud convention, and never colliding with a
+ * priority already in use (locally or remotely).
+ */
+export class CloudArmorFirewallService extends BaseFirewallService implements IFirewallProvider {
+  public readonly name: ProviderType = 'gcp'
+
+  constructor(private client: CloudArmorClient) {
+    super()
+  }
+
+  async fetchConfig(): Promise<UnifiedConfig> {
+    try {
+      logger.debug('Fetching Cloud Armor security policy')
+      const policy = await this.client.getPolicy()
+      const { rules, ips } = this.translatePolicy(policy)
+
+      return {
+        version: '2.0',
+        provider: 'gcp',
+        // Must match the other providers' fetchConfig — see the comment on
+        // VercelFirewallService.fetchConfig for why providers.<provider>
+        // has to be set alongside `provider`.
+        providers: {
+          gcp: {
+            projectId: this.client.projectId,
+            policyName: this.client['policyName'],
+          },
+        },
+        rules,
+        ips,
+      }
+    } catch (error) {
+      logger.error('Error fetching Cloud Armor configuration:', error)
+      throw new Error('Failed to fetch Cloud Armor security policy')
+    }
+  }
+
+  private translatePolicy(policy: { rules: CloudArmorRule[] }): { rules: UnifiedRule[]; ips: UnifiedIPRule[] } {
+    const rules: UnifiedRule[] = []
+    const ips: UnifiedIPRule[] = []
+
+    for (const rule of policy.rules) {
+      if (RuleTranslator.gcpLooksLikeIpRule(rule)) {
+        ips.push(RuleTranslator.gcpToUnifiedIP(rule))
+        continue
+      }
+      const translation = RuleTranslator.gcpToUnified(rule)
+      if (translation.warnings.length > 0) {
+        translation.warnings.forEach((w) => {
+          const { TranslationWarningSystem } = require('../../translators/TranslationWarningSystem')
+          logger.warn(`Rule ${rule.description || rule.priority}:\n${TranslationWarningSystem.formatWarning(w)}`)
+        })
+      }
+      rules.push(translation.result)
+    }
+
+    return { rules, ips }
+  }
+
+  async syncRules(config: UnifiedConfig, options: SyncOptions = {}): Promise<SyncResult> {
+    const { dryRun = false } = options
+
+    try {
+      const { OperationSafety } = require('../../utils/operationSafety')
+
+      const dryRunResult = await OperationSafety.performDryRunValidation(
+        config,
+        'sync rules',
+        async (cfg: UnifiedConfig) => this.getChanges(cfg),
+      )
+
+      if (!dryRunResult.valid) {
+        throw new Error(`Dry-run validation failed: ${dryRunResult.issues.join(', ')}`)
+      }
+
+      const changes = dryRunResult.changes as ChangeSet
+      const { rulesToAdd, rulesToUpdate, rulesToDelete } = changes
+      const ipsToAdd = changes.ipsToAdd || []
+      const ipsToUpdate = changes.ipsToUpdate || []
+      const ipsToDelete = changes.ipsToDelete || []
+
+      if (dryRun) {
+        logger.info('Dry run mode. The following changes would be made:')
+        logger.info(
+          `Custom Rules - Add: ${rulesToAdd.length}, Update: ${rulesToUpdate.length}, Delete: ${rulesToDelete.length}`,
+        )
+        logger.info(`IP Rules - Add: ${ipsToAdd.length}, Update: ${ipsToUpdate.length}, Delete: ${ipsToDelete.length}`)
+        return {
+          success: true,
+          rulesAdded: 0,
+          rulesUpdated: 0,
+          rulesDeleted: 0,
+          ipsAdded: 0,
+          ipsUpdated: 0,
+          ipsDeleted: 0,
+          warnings: dryRunResult.warnings,
+        }
+      }
+
+      const riskLevel = OperationSafety.assessOperationRisk(changes, config)
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: `Cloud Armor policy ${this.client['policyName']}`,
+        changes,
+        riskLevel,
+        skipConfirmation: options.force || false,
+        dryRun: false,
+        allowDeletions: options.allowDeletions || false,
+      })
+
+      if (!confirmed) {
+        throw new Error('Operation cancelled by user')
+      }
+
+      const warnings: string[] = []
+      const errors: string[] = []
+      const describeError = (context: string, error: unknown): string =>
+        `${context}: ${error instanceof Error ? error.message : String(error)}`
+
+      // Priorities occupied by anything staying as-is (unchanged, updating,
+      // or being deleted after this sync — deleting frees a priority, but
+      // reusing it in the *same* sync risks racing the delete) plus every
+      // remote rule this sync doesn't touch at all. Fetching fresh here
+      // (rather than reusing getChanges' snapshot) avoids assigning a
+      // priority that collided with something added between the diff and
+      // this point.
+      const remotePolicy = await this.client.getPolicy()
+      const occupied = new Set(remotePolicy.rules.map((r) => r.priority))
+
+      let nextCandidate = 1000
+      const assignPriority = (): number => {
+        while (occupied.has(nextCandidate)) nextCandidate += 1000
+        occupied.add(nextCandidate)
+        return nextCandidate
+      }
+
+      const idRemappings: NonNullable<SyncResult['idRemappings']> = []
+
+      // Delete before add/update, same ordering rationale as Vercel/Fastly.
+      for (const rule of [...rulesToDelete, ...ipsToDelete]) {
+        const priority = priorityOf(rule.id)
+        if (priority === undefined) continue
+        try {
+          logger.debug(`Removing Cloud Armor rule at priority ${priority}`)
+          await this.client.removeRule(priority)
+        } catch (error) {
+          logger.error(`Failed to remove Cloud Armor rule at priority ${priority}:`, error)
+          errors.push(describeError(`Failed to delete rule at priority ${priority}`, error))
+        }
+      }
+
+      let rulesAdded = 0
+      for (const rule of rulesToAdd) {
+        const priority = rule.priority ?? assignPriority()
+        const translation = RuleTranslator.unifiedToGcp({ ...rule, priority })
+        translation.warnings.forEach((w) => warnings.push(w.message))
+        try {
+          logger.debug(`Adding Cloud Armor rule at priority ${priority}: ${translation.result.description}`)
+          await this.client.addRule(translation.result)
+          rulesAdded++
+          idRemappings.push({ oldId: rule.id, newId: String(priority), name: rule.name })
+        } catch (error) {
+          logger.error(`Failed to add Cloud Armor rule "${rule.name}":`, error)
+          errors.push(describeError(`Failed to add rule "${rule.name}"`, error))
+        }
+      }
+
+      let rulesUpdated = 0
+      for (const rule of rulesToUpdate) {
+        const priority = priorityOf(rule.id)
+        if (priority === undefined) continue
+        const translation = RuleTranslator.unifiedToGcp(rule)
+        translation.warnings.forEach((w) => warnings.push(w.message))
+        try {
+          logger.debug(`Updating Cloud Armor rule at priority ${priority}`)
+          await this.client.patchRule(priority, translation.result)
+          rulesUpdated++
+        } catch (error) {
+          logger.error(`Failed to update Cloud Armor rule at priority ${priority}:`, error)
+          errors.push(describeError(`Failed to update rule at priority ${priority}`, error))
+        }
+      }
+
+      let ipsAdded = 0
+      for (const ip of ipsToAdd) {
+        const priority = priorityOf(ip.id) ?? assignPriority()
+        const translated = RuleTranslator.unifiedIPToGcp(ip, priority)
+        try {
+          logger.debug(`Adding Cloud Armor IP rule at priority ${priority}: ${ip.ip}`)
+          await this.client.addRule(translated)
+          ipsAdded++
+          idRemappings.push({ oldId: ip.id, newId: String(priority), name: ip.ip })
+        } catch (error) {
+          logger.error(`Failed to add Cloud Armor IP rule for ${ip.ip}:`, error)
+          errors.push(describeError(`Failed to add IP rule for ${ip.ip}`, error))
+        }
+      }
+
+      let ipsUpdated = 0
+      for (const ip of ipsToUpdate) {
+        const priority = priorityOf(ip.id)
+        if (priority === undefined) continue
+        try {
+          logger.debug(`Updating Cloud Armor IP rule at priority ${priority}: ${ip.ip}`)
+          await this.client.patchRule(priority, RuleTranslator.unifiedIPToGcp(ip, priority))
+          ipsUpdated++
+        } catch (error) {
+          logger.error(`Failed to update Cloud Armor IP rule at priority ${priority}:`, error)
+          errors.push(describeError(`Failed to update IP rule at priority ${priority}`, error))
+        }
+      }
+
+      logger.debug(`Custom Rules: Added: ${rulesAdded}, Updated: ${rulesUpdated}, Deleted: ${rulesToDelete.length}`)
+      logger.debug(`IP Rules: Added: ${ipsAdded}, Updated: ${ipsUpdated}, Deleted: ${ipsToDelete.length}`)
+
+      return {
+        success: errors.length === 0,
+        rulesAdded,
+        rulesUpdated,
+        rulesDeleted: rulesToDelete.length,
+        ipsAdded,
+        ipsUpdated,
+        ipsDeleted: ipsToDelete.length,
+        idRemappings: idRemappings.length > 0 ? idRemappings : undefined,
+        errors: errors.length > 0 ? errors : undefined,
+        warnings: warnings.length > 0 ? warnings : undefined,
+      }
+    } catch (error) {
+      logger.error('Error during sync:', error)
+      throw new Error(
+        `Failed to synchronize firewall rules: ${error instanceof Error ? error.message : String(error)}`,
+        {
+          cause: error,
+        },
+      )
+    }
+  }
+
+  async getChanges(config: UnifiedConfig): Promise<ChangeSet> {
+    const configValidation = unifiedConfigSchema.safeParse(config)
+    if (!configValidation.success) {
+      throw new Error(`Invalid firewall configuration: ${configValidation.error.message}`)
+    }
+
+    try {
+      logger.debug('Fetching existing Cloud Armor configuration')
+      const policy = await this.client.getPolicy()
+      const { rules: remoteRules, ips: remoteIPs } = this.translatePolicy(policy)
+
+      // Diff in unified space, normalizing both sides through gcpToUnified —
+      // same reasoning as every other provider's getChanges: comparing a
+      // translated local rule against an untranslated remote one produces
+      // spurious diffs from defaults unifiedToGcp fills in that the remote
+      // rule never had. Rules without a priority yet (brand-new local
+      // rules) never collide with a real remote id, so they always land in
+      // toAdd, exactly as intended.
+      const {
+        toAdd: rulesToAdd,
+        toUpdate: rulesToUpdate,
+        toDelete: rulesToDelete,
+      } = this.diffItems<UnifiedRule>(config.rules, remoteRules, (a, b) => isDeepEqual(omitId(a), omitId(b)))
+      const {
+        toAdd: ipsToAdd,
+        toUpdate: ipsToUpdate,
+        toDelete: ipsToDelete,
+      } = this.diffItems<UnifiedIPRule>(config.ips || [], remoteIPs, (a, b) => isDeepEqual(omitId(a), omitId(b)))
+
+      return {
+        rulesToAdd,
+        rulesToUpdate,
+        rulesToDelete,
+        ipsToAdd,
+        ipsToUpdate,
+        ipsToDelete,
+        hasChanges:
+          rulesToAdd.length > 0 ||
+          rulesToUpdate.length > 0 ||
+          rulesToDelete.length > 0 ||
+          ipsToAdd.length > 0 ||
+          ipsToUpdate.length > 0 ||
+          ipsToDelete.length > 0,
+      }
+    } catch (error) {
+      logger.error('Error fetching existing Cloud Armor configuration:', error)
+      throw new Error('Failed to fetch existing Cloud Armor configuration')
+    }
+  }
+
+  getSupportedFeatures(): FeatureSet {
+    return {
+      supportsCustomRules: true,
+      supportsIPBlocking: true,
+      supportsRateLimiting: true,
+      // Preconfigured WAF rules (evaluatePreconfiguredWaf()) exist on the
+      // real API but doorman has no config surface to enable/configure them
+      // yet (see #183, reserved for all providers) — same as every other
+      // provider, this stays false until that surface exists.
+      supportsManagedRules: false,
+      supportsGeoBlocking: true,
+      supportsRedirect: true,
+      // No standalone challenge action for ordinary custom rules — see
+      // CompatibilityMatrix's `gcp` entry for `challenge`.
+      supportsChallenge: false,
+    }
+  }
+
+  async verifyCredentials(): Promise<boolean> {
+    return this.client.verifyCredentials()
+  }
+
+  public validateConfig(config: UnifiedConfig): ValidationResult {
+    const baseValidation = super.validateConfig(config)
+    const errors = [...baseValidation.errors]
+    const warnings = [...baseValidation.warnings]
+
+    if (config.provider && config.provider !== 'gcp') {
+      errors.push({
+        path: 'provider',
+        message: `Provider must be 'gcp' for CloudArmorFirewallService`,
+        code: 'INVALID_PROVIDER',
+      })
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    }
+  }
+
+  public getHealthScore(config: UnifiedConfig): HealthScore {
+    const baseScore = super.getHealthScore(config)
+    const issues = [...baseScore.issues]
+    let score = baseScore.score
+
+    const rateLimitRules = config.rules.filter((r) => r.action?.type === 'rate_limit')
+    if (rateLimitRules.length === 0) {
+      score -= 10
+      issues.push({
+        severity: 'info',
+        category: 'security',
+        message: 'No rate limiting rules configured',
+        suggestion: 'Consider adding rate limiting to protect against abuse',
+      })
+    }
+
+    if (!config.ips || config.ips.length === 0) {
+      issues.push({
+        severity: 'info',
+        category: 'security',
+        message: 'No IP blocking rules configured',
+        suggestion: 'Consider blocking known malicious IPs',
+      })
+    }
+
+    return {
+      score: Math.max(0, score),
+      grade: baseScore.grade,
+      issues,
+      recommendations: baseScore.recommendations,
+    }
+  }
+}

--- a/src/lib/providers/gcp/CloudArmorProvider.ts
+++ b/src/lib/providers/gcp/CloudArmorProvider.ts
@@ -1,0 +1,65 @@
+import { logger } from '../../logger'
+import { CloudArmorClient } from './CloudArmorClient'
+import { CloudArmorFirewallService } from './CloudArmorFirewallService'
+import type { IFirewallProvider } from '../IFirewallProvider'
+
+export interface CloudArmorProviderConfig {
+  projectId?: string
+  policyName?: string
+  /** Optional — omitted, GoogleAuth falls through to Application Default Credentials. See credentials.ts. */
+  serviceAccountKeyPath?: string
+}
+
+/**
+ * GCP Cloud Armor Provider Factory.
+ * Creates and configures Cloud Armor firewall provider instances — mirrors
+ * `VercelProvider`/`CloudflareProvider`/`FastlyProvider`.
+ */
+export class CloudArmorProvider {
+  /**
+   * Create provider from environment variables.
+   */
+  static fromEnv(): IFirewallProvider {
+    const projectId = process.env.GOOGLE_CLOUD_PROJECT
+    const policyName = process.env.GCP_POLICY_NAME
+    const serviceAccountKeyPath = process.env.GOOGLE_APPLICATION_CREDENTIALS
+
+    if (!projectId) {
+      throw new Error('GOOGLE_CLOUD_PROJECT environment variable is required')
+    }
+    if (!policyName) {
+      throw new Error('GCP_POLICY_NAME environment variable is required')
+    }
+
+    const client = new CloudArmorClient(projectId, policyName, serviceAccountKeyPath)
+    return new CloudArmorFirewallService(client)
+  }
+
+  /**
+   * Create provider from explicit configuration.
+   */
+  static fromConfig(config: CloudArmorProviderConfig): IFirewallProvider {
+    const projectId = config.projectId || process.env.GOOGLE_CLOUD_PROJECT
+    const policyName = config.policyName || process.env.GCP_POLICY_NAME
+    const serviceAccountKeyPath = config.serviceAccountKeyPath || process.env.GOOGLE_APPLICATION_CREDENTIALS
+
+    if (!projectId) {
+      throw new Error('GCP project ID is required (provide projectId or set GOOGLE_CLOUD_PROJECT env var)')
+    }
+    if (!policyName) {
+      throw new Error('Cloud Armor policy name is required (provide policyName or set GCP_POLICY_NAME env var)')
+    }
+
+    logger.debug('Creating Cloud Armor provider with config:', { projectId, policyName })
+
+    const client = new CloudArmorClient(projectId, policyName, serviceAccountKeyPath)
+    return new CloudArmorFirewallService(client)
+  }
+
+  /**
+   * Create provider with explicit credentials.
+   */
+  static create(projectId: string, policyName: string, serviceAccountKeyPath?: string): IFirewallProvider {
+    return this.fromConfig({ projectId, policyName, serviceAccountKeyPath })
+  }
+}

--- a/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
@@ -1,0 +1,372 @@
+import { CloudArmorFirewallService } from '../CloudArmorFirewallService'
+import { CloudArmorClient } from '../CloudArmorClient'
+import type { CloudArmorRule, CloudArmorSecurityPolicy } from '../../../types/gcp'
+import type { UnifiedConfig } from '../../../types/unified'
+
+jest.mock('../../../logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}))
+
+import { OperationSafety } from '../../../utils/operationSafety'
+
+function policy(rules: CloudArmorRule[] = []): CloudArmorSecurityPolicy {
+  return { id: 'policy-1', name: 'doorman-policy', rules, fingerprint: 'fp-1' }
+}
+
+const blockAdminRule: CloudArmorRule = {
+  priority: 1000,
+  description: 'Block admin',
+  match: { expr: { expression: "request.path == '/admin'" } },
+  action: 'deny(403)',
+}
+
+describe('CloudArmorFirewallService', () => {
+  let service: CloudArmorFirewallService
+  let client: CloudArmorClient
+
+  beforeEach(() => {
+    client = new CloudArmorClient('my-project', 'doorman-policy')
+    service = new CloudArmorFirewallService(client)
+    jest.clearAllMocks()
+    jest.spyOn(OperationSafety, 'confirmDestructiveOperation').mockResolvedValue(true)
+  })
+
+  describe('name', () => {
+    it('is "gcp"', () => {
+      expect(service.name).toBe('gcp')
+    })
+  })
+
+  describe('fetchConfig', () => {
+    it('fetches and converts custom rules to UnifiedConfig', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+
+      const result = await service.fetchConfig()
+
+      expect(result.version).toBe('2.0')
+      expect(result.provider).toBe('gcp')
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0]!.name).toBe('Block admin')
+      expect(result.ips).toHaveLength(0)
+    })
+
+    it('sets providers.gcp alongside provider', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+
+      const result = await service.fetchConfig()
+
+      expect(result.providers?.gcp).toEqual({ projectId: 'my-project', policyName: 'doorman-policy' })
+    })
+
+    it('classifies an IP-shaped rule into ips, not rules', async () => {
+      const ipRule: CloudArmorRule = {
+        priority: 2000,
+        match: { expr: { expression: "origin.ip == '203.0.113.9'" } },
+        action: 'deny(403)',
+      }
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule, ipRule]))
+
+      const result = await service.fetchConfig()
+
+      expect(result.rules).toHaveLength(1)
+      expect(result.ips).toHaveLength(1)
+      expect(result.ips![0]).toMatchObject({ ip: '203.0.113.9', action: 'deny' })
+    })
+  })
+
+  describe('getChanges', () => {
+    const baseConfig: UnifiedConfig = { version: '2.0', provider: 'gcp', rules: [], ips: [] }
+
+    it('reports no changes when local and remote match exactly', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            id: '1000',
+            name: 'Block admin',
+            description: 'Block admin',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/admin' }],
+            action: { type: 'deny' },
+            priority: 1000,
+          },
+        ],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.hasChanges).toBe(false)
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.rulesToDelete).toHaveLength(0)
+    })
+
+    it('reports a rule with no priority yet as an add, not a false-positive update', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            name: 'Block signup abuse',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/signup' }],
+            action: { type: 'deny' },
+          },
+        ],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToAdd).toHaveLength(1)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      // The existing remote rule doorman doesn't have a local match for is a delete.
+      expect(changes.rulesToDelete).toHaveLength(1)
+    })
+
+    it('reports a changed condition on an existing rule as an update', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            id: '1000',
+            name: 'Block admin',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/admin-panel' }],
+            action: { type: 'deny' },
+            priority: 1000,
+          },
+        ],
+      }
+
+      const changes = await service.getChanges(config)
+
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(1)
+      expect(changes.rulesToDelete).toHaveLength(0)
+    })
+  })
+
+  describe('syncRules', () => {
+    const baseConfig: UnifiedConfig = { version: '2.0', provider: 'gcp', rules: [], ips: [] }
+
+    it('dry run makes no client calls beyond the diff', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+      const addRuleSpy = jest.spyOn(client, 'addRule')
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            name: 'New rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/x' }],
+            action: { type: 'deny' },
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config, { dryRun: true })
+
+      expect(result.success).toBe(true)
+      expect(addRuleSpy).not.toHaveBeenCalled()
+    })
+
+    it('assigns a priority to a brand-new rule with none set, avoiding remote collisions', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule])) // occupies 1000
+      const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          blockAdminRuleAsUnified(),
+          {
+            name: 'New rule',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/x' }],
+            action: { type: 'deny' },
+            // no priority — must be assigned, and must not collide with 1000
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(true)
+      expect(result.rulesAdded).toBe(1)
+      expect(addRuleSpy).toHaveBeenCalledTimes(1)
+      const addedRule = addRuleSpy.mock.calls[0]![0] as CloudArmorRule
+      expect(addedRule.priority).not.toBe(1000)
+      expect(addedRule.priority).toBeGreaterThan(0)
+    })
+
+    it('assigns non-colliding priorities to two new rules added in the same sync', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+      const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            name: 'Rule A',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+          {
+            name: 'Rule B',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+            action: { type: 'deny' },
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      expect(result.rulesAdded).toBe(2)
+      const priorities = addRuleSpy.mock.calls.map((call) => (call[0] as CloudArmorRule).priority)
+      expect(new Set(priorities).size).toBe(2)
+    })
+
+    it('deletes a rule removed from local config', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+      const removeRuleSpy = jest.spyOn(client, 'removeRule').mockResolvedValue(undefined)
+
+      const result = await service.syncRules(baseConfig)
+
+      expect(result.rulesDeleted).toBe(1)
+      expect(removeRuleSpy).toHaveBeenCalledWith(1000)
+    })
+
+    it('updates a changed rule at its existing priority, without reassigning one', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+      const patchRuleSpy = jest.spyOn(client, 'patchRule').mockResolvedValue(undefined)
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            id: '1000',
+            name: 'Block admin',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/admin-v2' }],
+            action: { type: 'deny' },
+            priority: 1000,
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      expect(result.rulesUpdated).toBe(1)
+      expect(patchRuleSpy).toHaveBeenCalledWith(1000, expect.objectContaining({ priority: 1000 }))
+    })
+
+    it('adds a new IP rule with an assigned priority', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+      const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)
+
+      const config: UnifiedConfig = { ...baseConfig, ips: [{ ip: '203.0.113.9', action: 'deny' }] }
+
+      const result = await service.syncRules(config)
+
+      expect(result.ipsAdded).toBe(1)
+      expect(addRuleSpy).toHaveBeenCalledTimes(1)
+      const addedRule = addRuleSpy.mock.calls[0]![0] as CloudArmorRule
+      expect(addedRule.match.expr.expression).toBe("origin.ip == '203.0.113.9'")
+    })
+
+    it('reports a per-rule failure in errors[] without aborting the rest of the sync', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+      jest
+        .spyOn(client, 'addRule')
+        .mockRejectedValueOnce(new Error('gcp API error: 400 Bad Request - boom'))
+        .mockResolvedValueOnce(undefined)
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            name: 'Rule A',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+          {
+            name: 'Rule B',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/b' }],
+            action: { type: 'deny' },
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(false)
+      expect(result.rulesAdded).toBe(1)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors![0]).toContain('boom')
+    })
+
+    it('does not call addRule/patchRule/removeRule when the user cancels the confirmation', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
+      jest.spyOn(OperationSafety, 'confirmDestructiveOperation').mockResolvedValue(false)
+      const removeRuleSpy = jest.spyOn(client, 'removeRule')
+
+      await expect(service.syncRules(baseConfig)).rejects.toThrow(/cancelled/i)
+      expect(removeRuleSpy).not.toHaveBeenCalled()
+    })
+
+    function blockAdminRuleAsUnified() {
+      return {
+        id: '1000',
+        name: 'Block admin',
+        description: 'Block admin',
+        enabled: true,
+        conditions: [{ field: 'path' as const, operator: 'eq' as const, value: '/admin' }],
+        action: { type: 'deny' as const },
+        priority: 1000,
+      }
+    }
+  })
+
+  describe('getSupportedFeatures', () => {
+    it('reports no standalone challenge action', () => {
+      expect(service.getSupportedFeatures().supportsChallenge).toBe(false)
+    })
+
+    it('reports custom rules, IP blocking, rate limiting, geo blocking, and redirect as supported', () => {
+      const features = service.getSupportedFeatures()
+      expect(features.supportsCustomRules).toBe(true)
+      expect(features.supportsIPBlocking).toBe(true)
+      expect(features.supportsRateLimiting).toBe(true)
+      expect(features.supportsGeoBlocking).toBe(true)
+      expect(features.supportsRedirect).toBe(true)
+    })
+  })
+
+  describe('verifyCredentials', () => {
+    it('delegates to the client', async () => {
+      jest.spyOn(client, 'verifyCredentials').mockResolvedValue(true)
+      expect(await service.verifyCredentials()).toBe(true)
+    })
+  })
+
+  describe('validateConfig', () => {
+    it('rejects a config whose provider is not gcp', () => {
+      const result = service.validateConfig({
+        version: '2.0',
+        provider: 'vercel',
+        rules: [],
+      } as unknown as UnifiedConfig)
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.code === 'INVALID_PROVIDER')).toBe(true)
+    })
+  })
+})

--- a/src/lib/providers/gcp/__tests__/translator.test.ts
+++ b/src/lib/providers/gcp/__tests__/translator.test.ts
@@ -1,0 +1,232 @@
+import { unifiedToGcp, gcpToUnified, unifiedIPToGcp, gcpToUnifiedIP, looksLikeIpRule } from '../translator'
+import type { UnifiedRule, UnifiedIPRule } from '../../../types/unified'
+import type { CloudArmorRule } from '../../../types/gcp'
+
+describe('unifiedToGcp', () => {
+  const baseRule: UnifiedRule = {
+    name: 'Block admin',
+    enabled: true,
+    conditions: [{ field: 'path', operator: 'eq', value: '/admin' }],
+    action: { type: 'deny' },
+    priority: 1000,
+  }
+
+  it('throws when the rule has no priority assigned', () => {
+    expect(() => unifiedToGcp({ ...baseRule, priority: undefined })).toThrow(/no priority assigned/i)
+  })
+
+  it('builds a CEL match expression from conditions', () => {
+    const { result } = unifiedToGcp(baseRule)
+    expect(result.match.expr.expression).toBe("request.path == '/admin'")
+    expect(result.priority).toBe(1000)
+  })
+
+  it('maps deny to deny(403)', () => {
+    expect(unifiedToGcp(baseRule).result.action).toBe('deny(403)')
+  })
+
+  it('maps allow to allow', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'allow' } }
+    expect(unifiedToGcp(rule).result.action).toBe('allow')
+  })
+
+  it('maps log to allow + preview: true, with no warning', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'log' } }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('allow')
+    expect(result.preview).toBe(true)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('maps challenge to deny(403) with an unsupported-feature warning', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'challenge' } }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('deny(403)')
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]!.message).toMatch(/challenge/i)
+  })
+
+  it('maps bypass to allow', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'bypass' } }
+    expect(unifiedToGcp(rule).result.action).toBe('allow')
+  })
+
+  it('builds rateLimitOptions for a rate_limit action with a rateLimit block', () => {
+    const rule: UnifiedRule = {
+      ...baseRule,
+      action: { type: 'rate_limit', rateLimit: { requests: 100, window: '60s' } },
+    }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('throttle')
+    expect(result.rateLimitOptions).toMatchObject({
+      rateLimitThreshold: { count: 100, intervalSec: 60 },
+      conformAction: 'allow',
+    })
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('warns when a rate_limit action declares no rateLimit block', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'rate_limit' } }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('throttle')
+    expect(result.rateLimitOptions).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('builds redirectOptions for a redirect action with a target', () => {
+    const rule: UnifiedRule = {
+      ...baseRule,
+      action: { type: 'redirect', redirect: { location: 'https://example.com' } },
+    }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('redirect')
+    expect(result.redirectOptions).toEqual({ type: 'EXTERNAL_302', target: 'https://example.com' })
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('warns when a redirect action declares no target', () => {
+    const rule: UnifiedRule = { ...baseRule, action: { type: 'redirect' } }
+    const { result, warnings } = unifiedToGcp(rule)
+    expect(result.action).toBe('redirect')
+    expect(result.redirectOptions).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('truncates the description to 64 chars (Cloud Armor limit)', () => {
+    const rule: UnifiedRule = { ...baseRule, name: 'x'.repeat(100) }
+    expect(unifiedToGcp(rule).result.description!.length).toBeLessThanOrEqual(64)
+  })
+})
+
+describe('gcpToUnified', () => {
+  const baseGcpRule: CloudArmorRule = {
+    priority: 2000,
+    description: 'Block admin',
+    match: { expr: { expression: "request.path == '/admin'" } },
+    action: 'deny(403)',
+  }
+
+  it('sets id and priority to the rule priority, stringified/numeric respectively', () => {
+    const { result } = gcpToUnified(baseGcpRule)
+    expect(result.id).toBe('2000')
+    expect(result.priority).toBe(2000)
+  })
+
+  it('parses the CEL expression back into conditions', () => {
+    const { result, warnings } = gcpToUnified(baseGcpRule)
+    expect(result.conditions).toEqual([{ field: 'path', operator: 'eq', value: '/admin' }])
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('warns and returns empty conditions for an unparseable expression', () => {
+    const rule: CloudArmorRule = { ...baseGcpRule, match: { expr: { expression: 'not valid cel!!' } } }
+    const { result, warnings } = gcpToUnified(rule)
+    expect(result.conditions).toEqual([])
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('maps deny(403)/deny(404)/deny(502) all to the unified "deny" action', () => {
+    expect(gcpToUnified({ ...baseGcpRule, action: 'deny(403)' }).result.action.type).toBe('deny')
+    expect(gcpToUnified({ ...baseGcpRule, action: 'deny(404)' }).result.action.type).toBe('deny')
+    expect(gcpToUnified({ ...baseGcpRule, action: 'deny(502)' }).result.action.type).toBe('deny')
+  })
+
+  it('maps throttle/rate_based_ban to the unified "rate_limit" action', () => {
+    expect(gcpToUnified({ ...baseGcpRule, action: 'throttle' }).result.action.type).toBe('rate_limit')
+    expect(gcpToUnified({ ...baseGcpRule, action: 'rate_based_ban' }).result.action.type).toBe('rate_limit')
+  })
+
+  it('a previewed rule translates to enabled: false', () => {
+    expect(gcpToUnified({ ...baseGcpRule, preview: true }).result.enabled).toBe(false)
+    expect(gcpToUnified({ ...baseGcpRule, preview: false }).result.enabled).toBe(true)
+    expect(gcpToUnified(baseGcpRule).result.enabled).toBe(true)
+  })
+
+  it('recovers rateLimit from rateLimitOptions', () => {
+    const rule: CloudArmorRule = {
+      ...baseGcpRule,
+      action: 'throttle',
+      rateLimitOptions: {
+        rateLimitThreshold: { count: 50, intervalSec: 60 },
+        conformAction: 'allow',
+        exceedAction: 'deny(429)',
+      },
+    }
+    expect(gcpToUnified(rule).result.action.rateLimit).toEqual({ requests: 50, window: '60s' })
+  })
+
+  it('recovers redirect from redirectOptions', () => {
+    const rule: CloudArmorRule = {
+      ...baseGcpRule,
+      action: 'redirect',
+      redirectOptions: { type: 'EXTERNAL_302', target: 'https://example.com' },
+    }
+    expect(gcpToUnified(rule).result.action.redirect).toEqual({ location: 'https://example.com' })
+  })
+})
+
+describe('looksLikeIpRule / unifiedIPToGcp / gcpToUnifiedIP', () => {
+  const ip: UnifiedIPRule = { ip: '203.0.113.9', notes: 'known bad actor', action: 'deny' }
+
+  it('unifiedIPToGcp produces a rule looksLikeIpRule recognizes', () => {
+    const rule = unifiedIPToGcp(ip, 3000)
+    expect(looksLikeIpRule(rule)).toBe(true)
+  })
+
+  it('round-trips a deny IP rule', () => {
+    const rule = unifiedIPToGcp(ip, 3000)
+    const recovered = gcpToUnifiedIP(rule)
+    expect(recovered).toEqual({ id: '3000', ip: '203.0.113.9', notes: 'known bad actor', action: 'deny' })
+  })
+
+  it('round-trips an allow IP rule', () => {
+    const allowIp: UnifiedIPRule = { ip: '198.51.100.0/24', action: 'allow' }
+    const rule = unifiedIPToGcp(allowIp, 3001)
+    expect(looksLikeIpRule(rule)).toBe(true)
+    expect(gcpToUnifiedIP(rule).action).toBe('allow')
+  })
+
+  it('uses inIpRange() for a CIDR value', () => {
+    const rule = unifiedIPToGcp({ ip: '198.51.100.0/24', action: 'deny' }, 3002)
+    expect(rule.match.expr.expression).toBe("inIpRange(origin.ip, '198.51.100.0/24')")
+  })
+
+  it('throws for an invalid IP value', () => {
+    expect(() => unifiedIPToGcp({ ip: 'not-an-ip', action: 'deny' }, 3003)).toThrow(/Invalid IP/i)
+  })
+
+  it('does not classify a custom rule with an extra condition as an IP rule, even if it checks ip', () => {
+    const rule: CloudArmorRule = {
+      priority: 4000,
+      match: { expr: { expression: "(origin.ip == '203.0.113.9' && request.path == '/admin')" } },
+      action: 'deny(403)',
+    }
+    expect(looksLikeIpRule(rule)).toBe(false)
+  })
+
+  it('does not classify a preview (log-only) rule as an IP rule', () => {
+    const rule = unifiedIPToGcp(ip, 3004)
+    expect(looksLikeIpRule({ ...rule, preview: true })).toBe(false)
+  })
+
+  it('does not classify a redirect/throttle-action ip check as an IP rule', () => {
+    const rule = unifiedIPToGcp(ip, 3005)
+    expect(looksLikeIpRule({ ...rule, action: 'redirect' })).toBe(false)
+  })
+
+  it('does not classify a multi-value ip "in" condition wrapped with extra conditions', () => {
+    const rule: CloudArmorRule = {
+      priority: 4001,
+      match: {
+        expr: {
+          expression: "(origin.ip in ['203.0.113.9'] && request.method == 'POST')",
+        },
+      },
+      action: 'deny(403)',
+    }
+    // Not actually parseable as a single ip condition by the real CEL
+    // grammar this parser understands (it's an AND of two leaves) — belt
+    // and suspenders check that this never misclassifies.
+    expect(looksLikeIpRule(rule)).toBe(false)
+  })
+})

--- a/src/lib/providers/gcp/credentials.ts
+++ b/src/lib/providers/gcp/credentials.ts
@@ -1,0 +1,53 @@
+import type { CredentialDescriptor } from '../credentials'
+
+/**
+ * GCP Cloud Armor's credentials, declared once here — same pattern as
+ * `vercelCredentials`/`cloudflareCredentials`/`fastlyCredentials`, with one
+ * deliberate departure: `serviceAccountKeyPath` and `projectId` use GCP's
+ * own ecosystem-standard env var names (`GOOGLE_APPLICATION_CREDENTIALS`,
+ * `GOOGLE_CLOUD_PROJECT`) rather than a doorman-prefixed one like the other
+ * three providers. Every GCP client library, `gcloud`, and most IaC tools
+ * already respect these exact names — a user with GCP already configured
+ * for anything else almost certainly has them set, and doorman should pick
+ * them up for free rather than requiring a redundant, doorman-specific
+ * duplicate. `policyName` has no such ecosystem convention (there's no
+ * universal "which security policy" concept outside doorman), so it follows
+ * the usual `GCP_*` pattern instead.
+ *
+ * `serviceAccountKeyPath` is optional and not a `secret` — it's a *path* to
+ * a key file, not the key material itself, and it's the one credential
+ * `CloudArmorClient` doesn't strictly require: when absent, `google-auth-
+ * library`'s `GoogleAuth` falls through to Application Default Credentials
+ * (gcloud user creds, or the GCE/Cloud Run metadata server) on its own —
+ * confirmed via research on #187, every realistic non-interactive auth path
+ * resolves through the same `GoogleAuth` machinery regardless. No
+ * `configKey`: a filesystem path is environment-specific, not something
+ * that belongs in a config file meant to be shared/committed.
+ */
+export const gcpCredentials: CredentialDescriptor = {
+  provider: 'gcp',
+  fields: [
+    {
+      key: 'serviceAccountKeyPath',
+      envVar: 'GOOGLE_APPLICATION_CREDENTIALS',
+      label: 'GCP Service Account Key Path',
+      required: false,
+      promptMessage:
+        'Path to a GCP service account JSON key file (leave blank to use Application Default Credentials — gcloud auth application-default login, or the GCE/Cloud Run metadata server): ',
+    },
+    {
+      key: 'projectId',
+      envVar: 'GOOGLE_CLOUD_PROJECT',
+      label: 'GCP Project ID',
+      required: true,
+      configKey: 'projectId',
+    },
+    {
+      key: 'policyName',
+      envVar: 'GCP_POLICY_NAME',
+      label: 'Cloud Armor Security Policy Name',
+      required: true,
+      configKey: 'policyName',
+    },
+  ],
+}

--- a/src/lib/providers/gcp/index.ts
+++ b/src/lib/providers/gcp/index.ts
@@ -1,0 +1,11 @@
+/**
+ * GCP Cloud Armor Firewall Provider
+ * Implements firewall rule management for Google Cloud Armor security policies
+ */
+
+export { CloudArmorClient, GCP_COMPUTE_API_BASE_URL } from './CloudArmorClient'
+
+export { CloudArmorFirewallService } from './CloudArmorFirewallService'
+
+export { CloudArmorProvider } from './CloudArmorProvider'
+export type { CloudArmorProviderConfig } from './CloudArmorProvider'

--- a/src/lib/providers/gcp/translator.ts
+++ b/src/lib/providers/gcp/translator.ts
@@ -1,0 +1,283 @@
+import type { CloudArmorAction, CloudArmorRule } from '../../types/gcp'
+import type { UnifiedRule, UnifiedIPRule, UnifiedAction } from '../../types/unified'
+import type { ActionType } from '../../types/common'
+import type { TranslationResult, TranslationWarning } from '../../translators/TranslationTypes'
+import { TranslationWarningSystem } from '../../translators/TranslationWarningSystem'
+import { CelExpressionBuilder } from '../../translators/CelExpressionBuilder'
+import { parseCelExpression } from '../../translators/CelParser'
+import { ipAddressSchema } from '../../schemas/commonSchemas'
+
+/**
+ * GCP Cloud Armor's half of the Cloud Armor <-> Unified translation. Thin —
+ * matches `cloudflare/translator.ts`'s shape, since CEL (like wirefilter) is
+ * an expression-string DSL, not structured JSON: expression build/parse is
+ * fully delegated to `CelExpressionBuilder`/`CelParser`, and this file only
+ * handles priority/action/rate-limit/redirect mapping and the IP-rule
+ * classification described below.
+ *
+ * Cloud Armor has no dedicated IP-blocking resource — unlike Vercel/
+ * Cloudflare/Fastly, an IP rule is just another entry in the same flat
+ * `rules[]` array a custom rule lives in. `looksLikeIpRule` classifies a
+ * fetched rule as IP-blocking only if it has *exactly* the shape
+ * `unifiedIPToGcp` itself produces (single `ip` condition, `allow`/`deny`
+ * action, nothing else) — the same "parse exactly what we emit" discipline
+ * `CelParser` already applies to expressions, extended to rule shape.
+ */
+
+/**
+ * `rule.priority` is required — Cloud Armor's priority space doubles as
+ * both evaluation order and the rule's addressing key, so unlike every
+ * other provider's translator there is no client-generated id to fall back
+ * on. Assigning one to a brand-new local rule that doesn't have one yet is
+ * `CloudArmorFirewallService`'s job (it needs visibility across every rule
+ * at once, to avoid collisions) — by the time a rule reaches this function,
+ * it must already have one.
+ */
+export function unifiedToGcp(rule: UnifiedRule): TranslationResult<CloudArmorRule> {
+  if (rule.priority === undefined) {
+    throw new Error(
+      `Rule "${rule.name}" has no priority assigned — CloudArmorFirewallService must assign one before calling unifiedToGcp`,
+    )
+  }
+
+  const warnings: TranslationWarning[] = []
+  const expression = CelExpressionBuilder.fromUnifiedConditions(rule.conditions, rule.conditionLogic)
+  const { action, actionWarning } = mapUnifiedActionToGcp(rule.action.type, rule.name, rule.id)
+  if (actionWarning) warnings.push(actionWarning)
+
+  const gcpRule: CloudArmorRule = {
+    priority: rule.priority,
+    description: (rule.description || rule.name).slice(0, 64),
+    match: { expr: { expression } },
+    action,
+    preview: rule.action.type === 'log' ? true : undefined,
+  }
+
+  if ((action === 'throttle' || action === 'rate_based_ban') && rule.action.rateLimit) {
+    const intervalSec = parseWindowToSeconds(rule.action.rateLimit.window)
+    gcpRule.rateLimitOptions = {
+      rateLimitThreshold: { count: rule.action.rateLimit.requests, intervalSec },
+      conformAction: 'allow',
+      exceedAction: 'deny(429)',
+      enforceOnKey: 'IP',
+    }
+  } else if (action === 'throttle' && !rule.action.rateLimit) {
+    warnings.push(
+      TranslationWarningSystem.createWarning(
+        'lossy_conversion',
+        rule.id,
+        'action.rateLimit',
+        `Rule "${rule.name}" maps to Cloud Armor's "throttle" action but declares no rateLimit block — Cloud Armor requires rateLimitOptions for this action; the rule will likely be rejected by the API.`,
+      ),
+    )
+  }
+
+  if (action === 'redirect') {
+    if (rule.action.redirect) {
+      gcpRule.redirectOptions = { type: 'EXTERNAL_302', target: rule.action.redirect.location }
+    } else {
+      warnings.push(
+        TranslationWarningSystem.createWarning(
+          'lossy_conversion',
+          rule.id,
+          'action.redirect',
+          `Rule "${rule.name}" maps to Cloud Armor's "redirect" action but declares no redirect target — Cloud Armor requires redirectOptions for this action; the rule will likely be rejected by the API.`,
+        ),
+      )
+    }
+  }
+
+  return { result: gcpRule, warnings }
+}
+
+export function gcpToUnified(rule: CloudArmorRule): TranslationResult<UnifiedRule> {
+  const warnings: TranslationWarning[] = []
+
+  // doorman only ever *writes* CEL itself, so CelParser understands exactly
+  // the grammar subset it can produce — anything else (hand-authored, or
+  // from another tool) is reported as unparseable (`null`) rather than
+  // guessed at, same as WirefilterParser's own precedent (#178).
+  const parsed = parseCelExpression(rule.match.expr.expression)
+
+  let conditions: UnifiedRule['conditions'] = []
+  let conditionLogic: UnifiedRule['conditionLogic']
+  if (parsed) {
+    conditions = parsed.conditions
+    conditionLogic = parsed.conditionLogic
+  } else {
+    warnings.push(
+      TranslationWarningSystem.createWarning(
+        'complex_expressions',
+        String(rule.priority),
+        'match.expr.expression',
+        'CEL expression could not be parsed back into structured conditions — it may be hand-authored or use syntax outside what doorman itself generates.',
+        'Review the translated rule and add missing conditions manually if needed.',
+      ),
+    )
+  }
+
+  // Every optional field below is conditionally spread rather than always
+  // present with a possibly-`undefined` value — `{ x: undefined }` and
+  // omitting `x` entirely are different object shapes to isDeepEqual's
+  // Object.keys().length check (it counts keys, not defined-ness), so an
+  // unconditional `undefined` here would make getChanges report a phantom
+  // "update" for every ordinary rule, on every sync, forever, since a local
+  // config loaded from disk never carries a key it was never given a value
+  // for. Same bug class the Fastly translator was fixed to avoid — see
+  // #203 and .kiro/steering/adding-a-provider.md's "diffing gotcha" note.
+  const action: UnifiedAction = {
+    type: mapGcpActionToUnified(rule.action),
+    ...(rule.rateLimitOptions
+      ? {
+          rateLimit: {
+            requests: rule.rateLimitOptions.rateLimitThreshold.count,
+            window: `${rule.rateLimitOptions.rateLimitThreshold.intervalSec}s`,
+          },
+        }
+      : {}),
+    ...(rule.redirectOptions ? { redirect: { location: rule.redirectOptions.target } } : {}),
+  }
+
+  const unifiedRule: UnifiedRule = {
+    id: String(rule.priority),
+    name: rule.description || `Rule ${rule.priority}`,
+    ...(rule.description ? { description: rule.description } : {}),
+    enabled: !rule.preview,
+    conditions,
+    // 'AND' is UnifiedRule.conditionLogic's own documented default — a
+    // local config expressing a plain AND (the common case) never spells
+    // it out, so only the non-default 'OR' (or an unparseable expression's
+    // `undefined`, itself omitted) is worth carrying as an explicit key.
+    ...(conditionLogic === 'OR' ? { conditionLogic } : {}),
+    action,
+    priority: rule.priority,
+  }
+
+  return { result: unifiedRule, warnings }
+}
+
+/**
+ * A rule with exactly the shape `unifiedIPToGcp` produces — one `ip`
+ * condition, an allow/deny action, nothing else layered on. Anything else
+ * (extra conditions, a different action, rate limiting) is a custom rule
+ * that happens to reference `ip`, not an IP-blocking entry.
+ */
+export function looksLikeIpRule(rule: CloudArmorRule): boolean {
+  if (rule.action !== 'allow' && rule.action !== 'deny(403)') return false
+  if (rule.preview) return false
+  const parsed = parseCelExpression(rule.match.expr.expression)
+  if (!parsed || parsed.conditions.length !== 1) return false
+  const condition = parsed.conditions[0]!
+  return condition.field === 'ip' && (condition.operator === 'eq' || condition.operator === 'in') && !condition.key
+}
+
+export function gcpToUnifiedIP(rule: CloudArmorRule): UnifiedIPRule {
+  const condition = parseCelExpression(rule.match.expr.expression)!.conditions[0]!
+  const value = condition.value
+  return {
+    id: String(rule.priority),
+    ip: Array.isArray(value) ? String(value[0]) : String(value),
+    // Conditionally spread, not unconditionally-possibly-undefined — same
+    // isDeepEqual key-count reasoning as gcpToUnified above.
+    ...(rule.description ? { notes: rule.description } : {}),
+    action: rule.action === 'allow' ? 'allow' : 'deny',
+  }
+}
+
+/**
+ * Translate a unified IP rule to a Cloud Armor rule. `priority` must
+ * already be assigned by the caller (same requirement as `unifiedToGcp`,
+ * and for the same reason).
+ */
+export function unifiedIPToGcp(ip: UnifiedIPRule, priority: number): CloudArmorRule {
+  if (!ipAddressSchema.safeParse(ip.ip).success) {
+    throw new Error(`Invalid IP address or CIDR range: ${ip.ip}`)
+  }
+
+  const expression = CelExpressionBuilder.fromUnifiedCondition({ field: 'ip', operator: 'eq', value: ip.ip })
+
+  return {
+    priority,
+    description: (ip.notes || `IP ${ip.action}: ${ip.ip}${ip.hostname ? ` (${ip.hostname})` : ''}`).slice(0, 64),
+    match: { expr: { expression } },
+    action: ip.action === 'allow' ? 'allow' : 'deny(403)',
+  }
+}
+
+function mapGcpActionToUnified(action: CloudArmorAction): ActionType {
+  const mapping: Record<CloudArmorAction, ActionType> = {
+    allow: 'allow',
+    'deny(403)': 'deny',
+    'deny(404)': 'deny',
+    'deny(502)': 'deny',
+    rate_based_ban: 'rate_limit',
+    throttle: 'rate_limit',
+    redirect: 'redirect',
+  }
+  return mapping[action] || 'deny'
+}
+
+/**
+ * Maps a unified action to a Cloud Armor action, warning when the closest
+ * available action is a fallback rather than a faithful match (see
+ * `CompatibilityMatrix`'s `gcp` entries for `log`/`challenge`/`bypass`,
+ * which this mirrors).
+ */
+function mapUnifiedActionToGcp(
+  action: string,
+  ruleName: string,
+  ruleId: string | undefined,
+): { action: CloudArmorAction; actionWarning?: TranslationWarning } {
+  switch (action) {
+    case 'log':
+      // No dedicated log action — represented as `allow` + `preview: true`
+      // (evaluates and logs without enforcing). See unifiedToGcp's caller.
+      return { action: 'allow' }
+    case 'deny':
+    case 'block':
+      return { action: 'deny(403)' }
+    case 'challenge':
+      return {
+        action: 'deny(403)',
+        actionWarning: TranslationWarningSystem.createUnsupportedFeatureWarning(
+          'challenge action',
+          'unified config',
+          'Cloud Armor',
+          ruleId,
+          'action',
+        ),
+      }
+    case 'bypass':
+      return { action: 'allow' }
+    case 'rate_limit':
+      return { action: 'throttle' }
+    case 'redirect':
+      return { action: 'redirect' }
+    case 'allow':
+      return { action: 'allow' }
+    default:
+      return {
+        action: 'deny(403)',
+        actionWarning: TranslationWarningSystem.createWarning(
+          'lossy_conversion',
+          ruleId,
+          'action',
+          `Rule "${ruleName}" has unrecognized action "${action}" — defaulted to Cloud Armor's "deny(403)".`,
+        ),
+      }
+  }
+}
+
+function parseWindowToSeconds(window: string): number {
+  const match = window.match(/^(\d+)([smhd])$/)
+  if (!match || !match[1] || !match[2]) {
+    throw new Error(`Invalid window format: ${window}`)
+  }
+  const value = parseInt(match[1], 10)
+  const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 }
+  const multiplier = multipliers[match[2]]
+  if (multiplier === undefined) {
+    throw new Error(`Invalid time unit: ${match[2]}`)
+  }
+  return value * multiplier
+}

--- a/src/lib/providers/initProviders.ts
+++ b/src/lib/providers/initProviders.ts
@@ -2,6 +2,7 @@ import { getProviderRegistry } from './ProviderRegistry'
 import { CloudflareProvider } from './cloudflare'
 import { VercelProvider } from './vercel'
 import { FastlyProvider } from './fastly'
+import { CloudArmorProvider } from './gcp'
 import { logger } from '../logger'
 import type { ProviderType } from './IFirewallProvider'
 
@@ -28,6 +29,12 @@ export function initProviders(): void {
   registry.register('fastly', () => {
     logger.debug('Initializing Fastly provider')
     return FastlyProvider.fromEnv()
+  })
+
+  // Register GCP Cloud Armor provider factory
+  registry.register('gcp', () => {
+    logger.debug('Initializing GCP Cloud Armor provider')
+    return CloudArmorProvider.fromEnv()
   })
 
   logger.debug('Provider registry initialized')
@@ -63,6 +70,12 @@ export async function getProvider(
   if (providerType === 'fastly' && config) {
     const fastlyConfig = config as { apiToken?: string; workspaceId?: string }
     return FastlyProvider.fromConfig(fastlyConfig)
+  }
+
+  // For GCP with custom config
+  if (providerType === 'gcp' && config) {
+    const gcpConfig = config as { projectId?: string; policyName?: string; serviceAccountKeyPath?: string }
+    return CloudArmorProvider.fromConfig(gcpConfig)
   }
 
   // Get from registry

--- a/src/lib/schemas/commonSchemas.ts
+++ b/src/lib/schemas/commonSchemas.ts
@@ -131,6 +131,12 @@ export const providersConfigSchema = z.object({
       workspaceId: z.string().optional(),
     })
     .optional(),
+  gcp: z
+    .object({
+      projectId: z.string().optional(),
+      policyName: z.string().optional(),
+    })
+    .optional(),
 }) satisfies z.ZodType<ProvidersConfig>
 
 // Base config schema

--- a/src/lib/translators/CelParser.ts
+++ b/src/lib/translators/CelParser.ts
@@ -500,18 +500,23 @@ function mapFieldToUnified(
   return null
 }
 
-function leafToCondition(node: CelNode, group: number): UnifiedCondition | null {
+function leafToCondition(node: CelNode, group: number | undefined): UnifiedCondition | null {
   const negated = node.type === 'not'
   const inner = node.type === 'not' ? node.child : node
 
   if (isIpOrGroup(inner)) {
     const values = inner.children.map((c) => ipCheckValue(c as Extract<CelNode, { type: 'inIpRange' | 'comparison' }>))
-    return { field: 'ip', operator: negated ? 'not_in' : 'in', value: values, group }
+    return {
+      field: 'ip',
+      operator: negated ? 'not_in' : 'in',
+      value: values,
+      ...(group !== undefined ? { group } : {}),
+    }
   }
 
   if (inner.type === 'inIpRange' || (inner.type === 'comparison' && inner.field === 'origin.ip')) {
     const value = inner.type === 'inIpRange' ? inner.value : String(inner.value)
-    return { field: 'ip', operator: negated ? 'ne' : 'eq', value, group }
+    return { field: 'ip', operator: negated ? 'ne' : 'eq', value, ...(group !== undefined ? { group } : {}) }
   }
 
   if (inner.type === 'and' && isGuardedLeaf(inner)) {
@@ -539,8 +544,8 @@ function leafToCondition(node: CelNode, group: number): UnifiedCondition | null 
       field: mapped.unifiedField,
       operator: negated ? 'not_exists' : 'exists',
       value: '',
-      key: mapped.unifiedKey,
-      group,
+      ...(mapped.unifiedKey !== undefined ? { key: mapped.unifiedKey } : {}),
+      ...(group !== undefined ? { group } : {}),
     }
   }
 
@@ -552,7 +557,7 @@ function comparisonToCondition(
   negated: boolean,
   refField: string,
   refKey: string | undefined,
-  group: number,
+  group: number | undefined,
 ): UnifiedCondition | null {
   const mapped = mapFieldToUnified(refField, refKey)
   if (!mapped) return null
@@ -581,8 +586,8 @@ function comparisonToCondition(
     field: mapped.unifiedField,
     operator,
     value,
-    key: mapped.unifiedKey,
-    group,
+    ...(mapped.unifiedKey !== undefined ? { key: mapped.unifiedKey } : {}),
+    ...(group !== undefined ? { group } : {}),
   }
 }
 
@@ -604,8 +609,17 @@ function negateSimpleOperator(op: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le'): Unif
  * reported as `null`.
  */
 function astToConditions(node: CelNode): { conditions: UnifiedCondition[]; conditionLogic: 'AND' | 'OR' } | null {
+  // isLeaf/flat-AND both describe a single implicit group — `group` carries
+  // no information there (there's only ever one), so it's omitted entirely
+  // rather than hardcoded to 0. Only the `or` branch below has more than
+  // one group to actually distinguish, and passes a real index. Matters for
+  // round-tripping: a local config never sets `group` on an ungrouped
+  // condition (there's nothing to distinguish it from), so an unconditional
+  // `group: 0` here would make every such rule look changed on every sync,
+  // forever — the same isDeepEqual key-count issue documented on
+  // gcpToUnified.
   if (isLeaf(node)) {
-    const condition = leafToCondition(node, 0)
+    const condition = leafToCondition(node, undefined)
     return condition ? { conditions: [condition], conditionLogic: 'AND' } : null
   }
 
@@ -613,7 +627,7 @@ function astToConditions(node: CelNode): { conditions: UnifiedCondition[]; condi
     const conditions: UnifiedCondition[] = []
     for (const child of node.children) {
       if (!isLeaf(child)) return null
-      const condition = leafToCondition(child, 0)
+      const condition = leafToCondition(child, undefined)
       if (!condition) return null
       conditions.push(condition)
     }

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -6,6 +6,13 @@ import {
   fastlyListEntriesToUnified,
   unifiedIPsToFastlyEntries,
 } from '../providers/fastly/translator'
+import {
+  gcpToUnified,
+  unifiedToGcp,
+  gcpToUnifiedIP,
+  unifiedIPToGcp,
+  looksLikeIpRule as gcpLooksLikeIpRule,
+} from '../providers/gcp/translator'
 
 export type {
   TranslationWarningSeverity,
@@ -44,4 +51,10 @@ export class RuleTranslator {
   static unifiedToFastly = unifiedToFastly
   static fastlyListEntriesToUnified = fastlyListEntriesToUnified
   static unifiedIPsToFastlyEntries = unifiedIPsToFastlyEntries
+
+  static gcpToUnified = gcpToUnified
+  static unifiedToGcp = unifiedToGcp
+  static gcpToUnifiedIP = gcpToUnifiedIP
+  static unifiedIPToGcp = unifiedIPToGcp
+  static gcpLooksLikeIpRule = gcpLooksLikeIpRule
 }

--- a/src/lib/translators/__tests__/CelParser.test.ts
+++ b/src/lib/translators/__tests__/CelParser.test.ts
@@ -8,8 +8,20 @@ describe('parseCelExpression', () => {
 
     expect(result).not.toBeNull()
     expect(result!.conditions).toHaveLength(1)
-    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api', group: 0 })
+    expect(result!.conditions[0]).toMatchObject({ field: 'path', operator: 'eq', value: '/api' })
     expect(result!.conditionLogic).toBe('AND')
+  })
+
+  it('omits group on an ungrouped condition rather than defaulting it to 0 (regression guard)', () => {
+    // A single implicit group carries no information in `group` — a real
+    // local config never sets it for the common ungrouped case, so an
+    // unconditional `group: 0` here would make isDeepEqual see an extra key
+    // that isn't there locally and report a phantom "changed" on every
+    // sync. See translator.ts's gcpToUnified for the same fix applied one
+    // level up (rateLimit/redirect/conditionLogic).
+    const result = parseCelExpression("request.path == '/api'")
+    expect(result!.conditions[0]!.group).toBeUndefined()
+    expect(Object.keys(result!.conditions[0]!)).not.toContain('group')
   })
 
   it('parses a flat AND of multiple conditions into a single group', () => {
@@ -18,7 +30,7 @@ describe('parseCelExpression', () => {
     expect(result).not.toBeNull()
     expect(result!.conditionLogic).toBe('AND')
     expect(result!.conditions).toHaveLength(2)
-    expect(result!.conditions.every((c) => c.group === 0)).toBe(true)
+    expect(result!.conditions.every((c) => c.group === undefined)).toBe(true)
   })
 
   it('parses a flat OR of single-condition groups, one group per branch', () => {

--- a/src/lib/types/common.ts
+++ b/src/lib/types/common.ts
@@ -119,4 +119,8 @@ export interface ProvidersConfig {
   fastly?: {
     workspaceId?: string
   }
+  gcp?: {
+    projectId?: string
+    policyName?: string
+  }
 }

--- a/src/lib/types/gcp.ts
+++ b/src/lib/types/gcp.ts
@@ -1,0 +1,118 @@
+/**
+ * Google Cloud Armor specific types. These map to the `securityPolicies`
+ * resource family of the Compute Engine v1 API
+ * (`https://compute.googleapis.com/compute/v1/projects/{project}/global/securityPolicies`)
+ * — confirmed against the REST API reference and the v1 discovery document,
+ * global policies only (regional/`regionSecurityPolicies` is a separate,
+ * out-of-scope resource — see `credentials.ts`'s doc comment).
+ *
+ * Every mutating method (`insert`/`patch`/`addRule`/`patchRule`/
+ * `removeRule`) returns a long-running `Operation`, not the updated
+ * resource directly — `CloudArmorClient` polls `globalOperations.get`
+ * internally so callers see a synchronous-feeling API, matching
+ * Vercel/Cloudflare/Fastly's clients.
+ */
+
+export type CloudArmorAction =
+  | 'allow'
+  | 'deny(403)'
+  | 'deny(404)'
+  | 'deny(502)'
+  | 'rate_based_ban'
+  | 'redirect'
+  | 'throttle'
+
+/**
+ * A CEL-based rule's match — `expr.expression` is the only shape doorman's
+ * translator produces or accepts (via `CelExpressionBuilder`/`CelParser`).
+ * The alternative `versionedExpr`/`config.srcIpRanges` shape (basic,
+ * non-CEL IP-list matching, capped at 10 ranges) exists on the real API but
+ * is deliberately not used here — CEL's `inIpRange()`/`==` (already built
+ * for custom rules) represents IP conditions with no range cap and no
+ * separate code path to maintain.
+ */
+export interface CloudArmorMatch {
+  expr: {
+    expression: string
+    title?: string
+    description?: string
+  }
+}
+
+export interface CloudArmorRateLimitOptions {
+  rateLimitThreshold: { count: number; intervalSec: number }
+  /** Always "allow" — the only value the API accepts. */
+  conformAction: 'allow'
+  exceedAction: string
+  enforceOnKey?:
+    | 'ALL'
+    | 'IP'
+    | 'HTTP_HEADER'
+    | 'XFF_IP'
+    | 'HTTP_COOKIE'
+    | 'HTTP_PATH'
+    | 'SNI'
+    | 'REGION_CODE'
+    | 'USER_IP'
+  enforceOnKeyName?: string
+  banThreshold?: { count: number; intervalSec: number }
+  banDurationSec?: number
+}
+
+/**
+ * A single rule within a security policy. `priority` is simultaneously the
+ * rule's evaluation order, its uniqueness constraint (server-rejected if it
+ * collides with another rule in the same policy), and its addressing key
+ * for `getRule`/`patchRule`/`removeRule` — there is no separate opaque id
+ * the way Vercel/Cloudflare/Fastly assign one. Confirmed effectively
+ * immutable once created (no "change priority" operation exists; relocating
+ * a rule is remove + add under a new priority).
+ */
+export interface CloudArmorRule {
+  priority: number
+  description?: string
+  match: CloudArmorMatch
+  action: CloudArmorAction
+  preview?: boolean
+  rateLimitOptions?: CloudArmorRateLimitOptions
+  redirectOptions?: { type: 'EXTERNAL_302'; target: string }
+  preconfiguredWafConfig?: {
+    exclusions?: Array<{
+      targetRuleSet: string
+      targetRuleIds?: string[]
+    }>
+  }
+}
+
+export interface CloudArmorSecurityPolicy {
+  id?: string
+  name: string
+  description?: string
+  rules: CloudArmorRule[]
+  /** base64 bytes; required (from a prior GET) on `patch` for optimistic-concurrency, else the API returns 412. */
+  fingerprint?: string
+  selfLink?: string
+  creationTimestamp?: string
+}
+
+/** `securityPolicies.list`'s response envelope. */
+export interface CloudArmorSecurityPolicyListResponse {
+  items?: CloudArmorSecurityPolicy[]
+  nextPageToken?: string
+}
+
+/**
+ * A long-running operation, returned by every mutating `securityPolicies`
+ * method in place of the resource itself. `CloudArmorClient` polls this
+ * internally via `globalOperations.get` until `status === 'DONE'`.
+ */
+export interface CloudArmorOperation {
+  name: string
+  status: 'PENDING' | 'RUNNING' | 'DONE'
+  httpErrorStatusCode?: number
+  httpErrorMessage?: string
+  error?: {
+    errors: Array<{ code: string; message: string; location?: string }>
+  }
+  warnings?: Array<{ code: string; message: string }>
+}

--- a/src/lib/utils/__tests__/credentialOptions.test.ts
+++ b/src/lib/utils/__tests__/credentialOptions.test.ts
@@ -2,11 +2,23 @@ import { credentialOptions, pickCredentialOptions } from '../credentialOptions'
 
 describe('credentialOptions', () => {
   it('declares exactly one yargs option per distinct credential key across every provider', () => {
-    // vercel: token, projectId, teamId — cloudflare: apiToken, zoneId, accountId
-    // — fastly: apiToken (shared with cloudflare's), workspaceId. 7 distinct
-    // keys total; apiToken must not appear twice.
+    // vercel: token, projectId, teamId — cloudflare: apiToken, zoneId,
+    // accountId — fastly: apiToken (shared with cloudflare's), workspaceId
+    // — gcp: serviceAccountKeyPath, projectId (shared with vercel's),
+    // policyName. 9 distinct keys total; apiToken/projectId must not appear
+    // twice each despite each being declared by two providers.
     expect(Object.keys(credentialOptions).sort()).toEqual(
-      ['accountId', 'apiToken', 'projectId', 'teamId', 'token', 'workspaceId', 'zoneId'].sort(),
+      [
+        'accountId',
+        'apiToken',
+        'policyName',
+        'projectId',
+        'serviceAccountKeyPath',
+        'teamId',
+        'token',
+        'workspaceId',
+        'zoneId',
+      ].sort(),
     )
   })
 
@@ -20,9 +32,29 @@ describe('credentialOptions', () => {
     expect(credentialOptions.workspaceId?.alias).toBeUndefined()
   })
 
+  it('keeps projectId\'s "-p" alias even though a second provider (gcp) shares the key and declares no alias of its own', () => {
+    // Regression guard: the alias lookup must scan every colliding
+    // provider's field for one that declares cliAlias, not just check
+    // whichever provider happens to be first/only — dropping an existing
+    // shortcut the moment a second provider reuses the key would be a real,
+    // easy-to-miss regression (this was actually caught by this exact
+    // scenario when GCP was added, since GCP's projectId has no alias).
+    expect(credentialOptions.projectId?.alias).toBe('p')
+  })
+
   it('mentions every env var for a key shared by more than one provider (apiToken)', () => {
     expect(credentialOptions.apiToken?.description).toContain('CLOUDFLARE_API_TOKEN')
     expect(credentialOptions.apiToken?.description).toContain('FASTLY_API_TOKEN')
+  })
+
+  it('accurately describes projectId as shared between Vercel and GCP, not as an API token', () => {
+    // Regression guard: describeField's merge branch used to hardcode the
+    // phrase "API token" for *any* shared key, which was fine when apiToken
+    // was the only real collision but became actively wrong once projectId
+    // (Vercel + GCP, semantically unrelated to a token) also collided.
+    expect(credentialOptions.projectId?.description).toContain('Vercel Project ID')
+    expect(credentialOptions.projectId?.description).toContain('GCP Project ID')
+    expect(credentialOptions.projectId?.description).not.toContain('API token')
   })
 
   it('describes a single-provider field with its label and env var', () => {
@@ -30,14 +62,13 @@ describe('credentialOptions', () => {
     expect(credentialOptions.zoneId?.description).toContain('CLOUDFLARE_ZONE_ID')
   })
 
-  it('flags an optional field as such in its description', () => {
+  it('flags an optional single-provider field as such in its description', () => {
     expect(credentialOptions.accountId?.description).toContain('(optional)')
     expect(credentialOptions.teamId?.description).toContain('(optional)')
   })
 
-  it('does not flag a required field as optional', () => {
+  it('does not flag a required single-provider field as optional', () => {
     expect(credentialOptions.zoneId?.description).not.toContain('(optional)')
-    expect(credentialOptions.projectId?.description).not.toContain('(optional)')
   })
 
   describe('pickCredentialOptions', () => {
@@ -52,6 +83,8 @@ describe('credentialOptions', () => {
           zoneId: 'z',
           accountId: 'acc',
           workspaceId: 'w',
+          policyName: 'pn',
+          serviceAccountKeyPath: 'skp',
         }),
       ).toEqual({
         token: 't',
@@ -61,6 +94,8 @@ describe('credentialOptions', () => {
         zoneId: 'z',
         accountId: 'acc',
         workspaceId: 'w',
+        policyName: 'pn',
+        serviceAccountKeyPath: 'skp',
       })
     })
 
@@ -73,6 +108,8 @@ describe('credentialOptions', () => {
         zoneId: undefined,
         accountId: undefined,
         workspaceId: undefined,
+        policyName: undefined,
+        serviceAccountKeyPath: undefined,
       })
     })
   })

--- a/src/lib/utils/compatibility.ts
+++ b/src/lib/utils/compatibility.ts
@@ -33,26 +33,39 @@ export class CompatibilityMatrix {
         notes: 'No dedicated action; maps to "allow"',
         limitations: ['request_logging is set at the rule level, not per-action'],
       },
+      gcp: {
+        level: 'partial',
+        notes: 'No dedicated log action; represented via preview: true on a rule',
+        limitations: ['A previewed rule evaluates and logs but never enforces, regardless of its actual action'],
+      },
     },
     deny: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'Maps to "block" action' },
       fastly: { level: 'full', notes: 'Maps to "block" action' },
+      gcp: { level: 'full', notes: 'Maps to "deny(403)"' },
     },
     block: {
       vercel: { level: 'not-supported' },
       cloudflare: { level: 'full' },
       fastly: { level: 'full' },
+      gcp: { level: 'full', notes: 'Maps to "deny(403)"' },
     },
     challenge: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'Maps to "managed_challenge" for better accuracy' },
       fastly: { level: 'full', notes: 'Maps to "browser_challenge" action' },
+      gcp: {
+        level: 'not-supported',
+        notes:
+          'Cloud Armor has reCAPTCHA integration via redirectOptions/rateLimitOptions.exceedRedirectOptions, but no standalone challenge action for ordinary custom rules',
+      },
     },
     bypass: {
       vercel: { level: 'full' },
       cloudflare: { level: 'partial', notes: 'Maps to "skip" action', limitations: ['Limited skip options'] },
       fastly: { level: 'partial', notes: 'No equivalent action; maps to "allow"' },
+      gcp: { level: 'partial', notes: 'No dedicated bypass action; maps to "allow"' },
     },
     rate_limit: {
       vercel: { level: 'full' },
@@ -66,16 +79,22 @@ export class CompatibilityMatrix {
         notes: 'Uses a distinct rule type ("rate_limit") with its own rate_limit block',
         limitations: ['Requires a pre-existing custom signal to count against'],
       },
+      gcp: {
+        level: 'full',
+        notes: 'Uses "throttle" or "rate_based_ban" action with a rateLimitOptions block',
+      },
     },
     redirect: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full' },
       fastly: { level: 'full' },
+      gcp: { level: 'full', notes: 'Uses "redirect" action with a redirectOptions block' },
     },
     allow: {
       vercel: { level: 'not-supported' },
       cloudflare: { level: 'full' },
       fastly: { level: 'full' },
+      gcp: { level: 'full' },
     },
   }
 
@@ -87,96 +106,123 @@ export class CompatibilityMatrix {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.host' },
       fastly: { level: 'full', notes: 'Maps to the "domain" condition field' },
+      gcp: { level: 'full', notes: "request.headers['host'], guarded by has()" },
     },
     path: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.request.uri.path' },
       fastly: { level: 'full' },
+      gcp: { level: 'full', notes: 'request.path' },
     },
     method: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.request.method' },
       fastly: { level: 'full' },
+      gcp: { level: 'full', notes: 'request.method' },
     },
     header: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.request.headers["name"]' },
       fastly: { level: 'full', notes: 'Maps to a "request_header" multival condition' },
+      gcp: { level: 'full', notes: "request.headers['name'], guarded by has()" },
     },
     query: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.request.uri.query' },
       fastly: { level: 'full', notes: 'Maps to a "query_parameter" multival condition' },
+      gcp: { level: 'full', notes: 'request.query — raw, undecoded query string, same shape as Cloudflare’s' },
     },
     cookie: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.cookie' },
       fastly: { level: 'full', notes: 'Maps to a "request_cookie" multival condition' },
+      gcp: {
+        level: 'partial',
+        notes:
+          "No parsed cookie map — a keyed condition composes a 'key=value' substring search against the raw Cookie header",
+        limitations: ['Only eq/ne/contains/not_contains are representable for a condition naming a specific cookie'],
+      },
     },
     target_path: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'Maps to http.request.uri.path' },
       fastly: { level: 'not-supported', notes: 'No Fastly equivalent condition field' },
+      gcp: { level: 'not-supported', notes: "Not currently mapped by doorman's Cloud Armor translator" },
     },
     ip_address: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.src' },
       fastly: { level: 'full', notes: 'Maps to the "ip" condition field' },
+      gcp: { level: 'full', notes: 'origin.ip / inIpRange(origin.ip, cidr)' },
     },
     region: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.subdivision_1' },
       fastly: { level: 'not-supported', notes: 'Fastly only exposes country-level geo matching' },
+      gcp: { level: 'not-supported', notes: 'Cloud Armor has no region/subdivision-level geo attribute' },
     },
     protocol: {
       vercel: { level: 'full' },
       cloudflare: { level: 'partial', notes: 'Maps to ssl boolean', limitations: ['Only checks HTTPS vs HTTP'] },
       fastly: { level: 'not-supported', notes: 'No Fastly equivalent condition field' },
+      gcp: { level: 'not-supported', notes: 'No confirmed Cloud Armor CEL field for scheme/protocol' },
     },
     scheme: {
       vercel: { level: 'full' },
       cloudflare: { level: 'partial', notes: 'Maps to ssl boolean', limitations: ['Only checks HTTPS vs HTTP'] },
       fastly: { level: 'full', notes: 'Maps to the "scheme" condition field' },
+      gcp: { level: 'not-supported', notes: 'No confirmed Cloud Armor CEL field for scheme/protocol' },
     },
     environment: {
       vercel: { level: 'full' },
       cloudflare: { level: 'not-supported', notes: 'Vercel-specific feature' },
       fastly: { level: 'not-supported', notes: 'Vercel-specific feature' },
+      gcp: { level: 'not-supported', notes: 'Vercel-specific feature' },
     },
     user_agent: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'http.user_agent' },
       fastly: { level: 'full' },
+      gcp: { level: 'full', notes: "request.headers['user-agent'], guarded by has()" },
     },
     geo_continent: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.continent' },
       fastly: { level: 'not-supported', notes: 'Fastly only exposes country-level geo matching' },
+      gcp: { level: 'not-supported', notes: 'Cloud Armor has no continent-level geo attribute' },
     },
     geo_country: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.country' },
       fastly: { level: 'full', notes: 'Maps to the "country" condition field' },
+      gcp: { level: 'full', notes: 'origin.region_code' },
     },
     geo_country_region: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.subdivision_1' },
       fastly: { level: 'not-supported', notes: 'Fastly only exposes country-level geo matching' },
+      gcp: { level: 'not-supported', notes: 'Cloud Armor has no region/subdivision-level geo attribute' },
     },
     geo_city: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.city' },
       fastly: { level: 'not-supported', notes: 'Fastly only exposes country-level geo matching' },
+      gcp: { level: 'not-supported', notes: 'Cloud Armor has no city-level geo attribute' },
     },
     geo_as_number: {
       vercel: { level: 'full' },
       cloudflare: { level: 'full', notes: 'ip.geoip.asnum' },
       fastly: { level: 'not-supported', notes: 'No Fastly equivalent condition field' },
+      gcp: { level: 'full', notes: 'origin.asn' },
     },
     ja4_digest: {
       vercel: { level: 'full' },
       cloudflare: { level: 'not-supported', notes: 'Vercel-specific feature' },
       fastly: { level: 'not-supported', notes: "Not currently mapped by doorman's Fastly translator" },
+      gcp: {
+        level: 'not-supported',
+        notes: "Cloud Armor exposes origin.tls_ja4_fingerprint, but it is not currently mapped by doorman's translator",
+      },
     },
     ja3_digest: {
       vercel: { level: 'full' },
@@ -186,11 +232,16 @@ export class CompatibilityMatrix {
         notes:
           "Fastly exposes a JA3 fingerprint condition field, but it is not currently mapped by doorman's translator",
       },
+      gcp: {
+        level: 'not-supported',
+        notes: "Cloud Armor exposes origin.tls_ja3_fingerprint, but it is not currently mapped by doorman's translator",
+      },
     },
     rate_limit_api_id: {
       vercel: { level: 'full' },
       cloudflare: { level: 'not-supported', notes: 'Vercel-specific feature' },
       fastly: { level: 'not-supported', notes: 'Vercel-specific feature' },
+      gcp: { level: 'not-supported', notes: 'Vercel-specific feature' },
     },
   }
 

--- a/src/lib/utils/credentialOptions.ts
+++ b/src/lib/utils/credentialOptions.ts
@@ -1,7 +1,6 @@
 import { PROVIDER_TYPES, type ProviderType } from '../providers/IFirewallProvider'
 import { CREDENTIAL_DESCRIPTORS } from '../providers/credentials'
 import type { CredentialField } from '../providers/credentials'
-import { getProviderDisplayName } from './providerHelper'
 
 /**
  * Every provider's credential flags, flattened onto one options shape.
@@ -11,11 +10,16 @@ import { getProviderDisplayName } from './providerHelper'
  * `accountId`, `workspaceId`) in its own local options interface — pure
  * duplication with a real chance of one being missed when a provider's
  * credentials changed (see #182). `apiToken` is deliberately shared by both
- * Cloudflare and Fastly (one flag, resolved against whichever provider is
- * active), the same way it always has been.
+ * Cloudflare and Fastly, and `projectId` by both Vercel and GCP — one flag
+ * each, resolved against whichever provider is active — the same way
+ * `apiToken` always has been; two providers happening to use the same
+ * credential *key* doesn't imply their values mean the same thing (a Vercel
+ * project ID and a GCP project ID are unrelated strings), only that they
+ * share a CLI flag name and are never both in play in the same command.
  *
  * Adding a provider whose credentials don't fit this exact field set still
- * means editing this interface once — but once, here, instead of 8 times.
+ * means editing this interface (and `pickCredentialOptions` below) once —
+ * but once, here, instead of 8 times.
  */
 export interface CredentialOptions {
   provider?: ProviderType
@@ -26,6 +30,8 @@ export interface CredentialOptions {
   zoneId?: string
   accountId?: string
   workspaceId?: string
+  policyName?: string
+  serviceAccountKeyPath?: string
 }
 
 interface YargsCredentialOption {
@@ -42,11 +48,13 @@ function describeField(entries: { provider: ProviderType; field: CredentialField
     return `${field.label}${optional} (defaults to ${field.envVar} env var${configFallback})`
   }
 
-  // A CLI flag shared by more than one provider's descriptor (today: just
-  // `apiToken`, for Cloudflare and Fastly) — describe every provider's env
-  // var rather than just whichever provider happened to be listed first.
-  const perProvider = entries.map((e) => `${getProviderDisplayName(e.provider)}: ${e.field.envVar}`).join(', ')
-  return `API token — resolved against whichever provider is active (${perProvider})`
+  // A CLI flag shared by more than one provider's descriptor (`apiToken`
+  // for Cloudflare/Fastly, `projectId` for Vercel/GCP) — describe every
+  // provider's own field generically rather than assuming what's being
+  // shared. Every field's `label` already names its provider (e.g. "GCP
+  // Project ID"), so no need to also prefix `getProviderDisplayName` here.
+  const perField = entries.map((e) => `${e.field.label} (${e.field.envVar})`).join(' / ')
+  return `Resolved against whichever provider is active: ${perField}`
 }
 
 const fieldsByKey = new Map<string, { provider: ProviderType; field: CredentialField }[]>()
@@ -72,14 +80,22 @@ for (const providerType of PROVIDER_TYPES) {
  * ```
  */
 export const credentialOptions: Record<string, YargsCredentialOption> = Object.fromEntries(
-  Array.from(fieldsByKey.entries()).map(([key, entries]) => [
-    key,
-    {
-      type: 'string' as const,
-      ...(entries.length === 1 && entries[0]!.field.cliAlias ? { alias: entries[0]!.field.cliAlias } : {}),
-      description: describeField(entries),
-    },
-  ]),
+  Array.from(fieldsByKey.entries()).map(([key, entries]) => {
+    // An alias is a shortcut for the flag itself, not a claim about what it
+    // means — harmless to keep even when the key is shared, and dropping it
+    // just because a second provider's same-named field doesn't declare one
+    // would silently take away an existing shortcut (e.g. -p for
+    // --projectId) the moment a colliding provider is added.
+    const cliAlias = entries.map((e) => e.field.cliAlias).find((alias): alias is string => !!alias)
+    return [
+      key,
+      {
+        type: 'string' as const,
+        ...(cliAlias ? { alias: cliAlias } : {}),
+        description: describeField(entries),
+      },
+    ]
+  }),
 )
 
 /**
@@ -99,5 +115,7 @@ export function pickCredentialOptions(argv: CredentialOptions): Record<string, s
     zoneId: argv.zoneId,
     accountId: argv.accountId,
     workspaceId: argv.workspaceId,
+    policyName: argv.policyName,
+    serviceAccountKeyPath: argv.serviceAccountKeyPath,
   }
 }

--- a/src/lib/utils/providerHelper.ts
+++ b/src/lib/utils/providerHelper.ts
@@ -6,6 +6,7 @@ import { ProviderDetector } from '../providers/ProviderDetector'
 import { VercelProvider } from '../providers/vercel'
 import { CloudflareProvider } from '../providers/cloudflare'
 import { FastlyProvider } from '../providers/fastly'
+import { CloudArmorProvider } from '../providers/gcp'
 import { PROVIDER_TYPES, type IFirewallProvider, type ProviderType } from '../providers/IFirewallProvider'
 import { CREDENTIAL_DESCRIPTORS, missingRequiredCredentials, resolveCredentials } from '../providers/credentials'
 import type { CredentialField } from '../providers/credentials'
@@ -191,6 +192,14 @@ function buildProvider(
       return {
         provider: FastlyProvider.fromConfig({ apiToken: resolved.apiToken!, workspaceId: resolved.workspaceId! }),
       }
+    case 'gcp':
+      return {
+        provider: CloudArmorProvider.fromConfig({
+          projectId: resolved.projectId!,
+          policyName: resolved.policyName!,
+          serviceAccountKeyPath: resolved.serviceAccountKeyPath,
+        }),
+      }
     default:
       throw new Error(`Unknown provider: ${providerType as string}`)
   }
@@ -263,6 +272,8 @@ export function getProviderDisplayName(providerType: ProviderType): string {
       return 'Cloudflare WAF'
     case 'fastly':
       return 'Fastly Next-Gen WAF'
+    case 'gcp':
+      return 'Google Cloud Armor'
     default:
       return providerType
   }

--- a/src/tests/testHelpers/providerMocks.ts
+++ b/src/tests/testHelpers/providerMocks.ts
@@ -4,6 +4,8 @@ import type { CloudflareRuleset } from '../../lib/types/cloudflare'
 import type { VercelClient, VercelConfig } from '../../lib/providers/vercel/VercelClient'
 import type { FastlyClient } from '../../lib/providers/fastly/FastlyClient'
 import type { FastlyRule, FastlyRuleInput, FastlyList } from '../../lib/types/fastly'
+import type { CloudArmorClient } from '../../lib/providers/gcp/CloudArmorClient'
+import type { CloudArmorRule, CloudArmorSecurityPolicy } from '../../lib/types/gcp'
 
 /**
  * Default empty Cloudflare ruleset used by tests that don't care about its contents.
@@ -203,4 +205,70 @@ export function mockFastlyClientPrototype(
     .fn()
     .mockImplementation((id: string, entries: string[]) => Promise.resolve(emptyFastlyList({ id, entries }))) as any
   MockedFastlyClient.prototype.verifyCredentials = jest.fn().mockResolvedValue(true) as any
+}
+
+/**
+ * Default empty Cloud Armor security policy used by tests that don't care about its contents.
+ */
+export function emptyCloudArmorPolicy(overrides: Partial<CloudArmorSecurityPolicy> = {}): CloudArmorSecurityPolicy {
+  return {
+    id: 'policy-1',
+    name: 'doorman-managed-policy',
+    description: 'Managed by doorman',
+    rules: [],
+    fingerprint: 'fp-1',
+    ...overrides,
+  }
+}
+
+/**
+ * Wires up a mocked `CloudArmorClient` class (from `jest.mock('.../providers/gcp/CloudArmorClient')`)
+ * with sensible defaults so commands that resolve a GCP provider don't make
+ * real network calls. Unlike the other providers' mocks, this keeps a real
+ * in-memory `rules[]` array that `addRule`/`patchRule`/`removeRule` actually
+ * mutate and `getPolicy` reflects — `CloudArmorFirewallService.syncRules`
+ * re-fetches the policy mid-sync (to compute unoccupied priorities), so a
+ * mock that always returns the same static snapshot would silently hide
+ * priority-collision bugs a stateful one catches. Call this after
+ * `jest.mock('.../providers/gcp/CloudArmorClient')` in the test file; pass
+ * the mocked class itself.
+ */
+export function mockCloudArmorClientPrototype(
+  MockedCloudArmorClient: jest.MockedClass<typeof CloudArmorClient>,
+  options: { rules?: CloudArmorRule[] } = {},
+): void {
+  const state: { rules: CloudArmorRule[] } = { rules: [...(options.rules ?? [])] }
+
+  // See the equivalent note on `mockVercelClientPrototype`/`mockFastlyClientPrototype`
+  // — an automock doesn't run the real constructor, so `this.projectId`
+  // (read via the real, public `client.projectId`) would otherwise be undefined.
+  MockedCloudArmorClient.mockImplementation(function (this: CloudArmorClient, projectId: string, policyName: string) {
+    Object.assign(this, { projectId, policyName })
+  } as unknown as (projectId: string, policyName: string) => CloudArmorClient)
+
+  MockedCloudArmorClient.prototype.getPolicy = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(emptyCloudArmorPolicy({ rules: state.rules }))) as any
+  MockedCloudArmorClient.prototype.addRule = jest.fn().mockImplementation((rule: CloudArmorRule) => {
+    if (state.rules.some((r) => r.priority === rule.priority)) {
+      return Promise.reject(new Error(`gcp API error: 400 Bad Request - priority ${rule.priority} already in use`))
+    }
+    state.rules.push(rule)
+    return Promise.resolve(undefined)
+  }) as any
+  MockedCloudArmorClient.prototype.patchRule = jest
+    .fn()
+    .mockImplementation((priority: number, rule: CloudArmorRule) => {
+      const index = state.rules.findIndex((r) => r.priority === priority)
+      if (index === -1) {
+        return Promise.reject(new Error(`gcp API error: 404 Not Found - no rule at priority ${priority}`))
+      }
+      state.rules[index] = rule
+      return Promise.resolve(undefined)
+    }) as any
+  MockedCloudArmorClient.prototype.removeRule = jest.fn().mockImplementation((priority: number) => {
+    state.rules = state.rules.filter((r) => r.priority !== priority)
+    return Promise.resolve(undefined)
+  }) as any
+  MockedCloudArmorClient.prototype.verifyCredentials = jest.fn().mockResolvedValue(true) as any
 }


### PR DESCRIPTION
## Summary

Third and largest slice of the GCP Cloud Armor epic (#187) — the provider itself, following Fastly's 7-file precedent (#186), plus every wiring touch point required to register a fourth provider. Builds on #232 (async auth) and #234 (CEL builder/parser).

New: `src/lib/providers/gcp/{CloudArmorClient,CloudArmorFirewallService,CloudArmorProvider,credentials,translator,index}.ts`, `src/lib/types/gcp.ts`, `demos/cloudarmor-mock-server.mjs` + fixtures.

## Two structural differences from every existing provider

Both confirmed against the real Compute v1 API before writing code (see prior research comments on #187):

- **Every mutating `securityPolicies` method returns a long-running Operation**, not the updated resource. `CloudArmorClient.waitForOperation` polls it internally so every public method still presents the same "await and it's done" shape the other three providers' clients have.
- **A rule's `priority` *is* its id, its evaluation order, and its addressing key all at once** — no separate server-assigned id. `CloudArmorFirewallService` assigns priorities (spaced 1000 apart, matching common Cloud Armor/gcloud convention) to brand-new local rules right before translation, checking a freshly-fetched remote policy to avoid collisions. There's also no dedicated IP-blocking resource — an IP rule is just another entry in the same flat `rules[]` array, classified on fetch via `translator.ts`'s `looksLikeIpRule` (recognizes exactly the shape `unifiedIPToGcp` itself produces — same "parse exactly what we emit" discipline `CelParser` already applies to expressions, extended to rule shape).

Auth needs a new dependency, `google-auth-library` (official Google client).

## CompatibilityMatrix

Gained a full set of `gcp` entries for every action/field, matching what the translator actually implements today, not aspirationally: region/city/continent-level geo and scheme/protocol are `not-supported` (no CEL attribute for any of them, confirmed by research — not a translator gap); cookie is `partial` (no parsed cookie map); challenge is `not-supported` (no standalone challenge action for ordinary custom rules).

## Three real bugs caught by testing before trusting the sync logic

All the same underlying class: `isDeepEqual` compares objects by `Object.keys().length` first, so a field present with value `undefined` — or present with its *default* value — isn't the same object shape as the field being absent, which is what a real local config loaded from JSON always looks like. Found via `getChanges` reporting a false "update" for a rule byte-for-byte identical to its local config:

- `gcpToUnified` always set `action.rateLimit`/`action.redirect` (even when `undefined`) and `conditionLogic` (even when just `'AND'`, the documented default) as explicit keys. Fixed with conditional spreads.
- `CelParser`'s `leafToCondition` always set `group: 0` on every parsed condition, even the common ungrouped case where `group` carries no information. Fixed by threading `group: number | undefined` through, only including it for the genuinely multi-group OR branch. **`WirefilterParser` (Cloudflare, #178) appears to have the identical pattern** — flagged separately rather than touched here, since fixing shipped Cloudflare code isn't in scope for this PR.
- The same function also always set `key: undefined` for fields with no header/cookie key. Fixed the same way.

## Deliberately out of scope

Matching #187's own framing: preconfigured/managed WAF rules (gated behind #183 for every provider), a standalone challenge action, and a fully offline mock-server end-to-end run — `GoogleAuth`'s token flow requires a real OAuth2 exchange against Google's real infrastructure even for local testing (confirmed empirically: pointing the CLI at the mock server with no real GCP credentials fails with `invalid_grant` inside `getAuthHeaders`, before ever reaching the mock server). Real end-to-end verification needs a real GCP project — planned as a follow-up check against the user's own project, not included in this PR's verification.

## Verification

- `pnpm exec tsc --noEmit && pnpm jest && pnpm eslint .` clean — 89 suites, 1652 tests (+63 new).
- **Mutation-verify**: all three diffing bugs above confirmed by reverting each fix and watching the exact predicted test failure appear. Additionally reverted the priority-collision-avoidance logic in `syncRules` directly (occupied set built from a nonsense mapping) — the dedicated test failed with the exact predicted mismatch (new rule assigned the already-occupied priority 1000). Restored, full suite green again.
- Mock server verified directly via `curl` against its real HTTP surface (getPolicy/addRule/patchRule/removeRule/operation-polling) — confirms request/response shapes independent of the auth-layer limitation above.
- End-to-end against the real doorman-www Vercel config (several shared files touched by this PR — `providerHelper.ts`/`credentialOptions.ts`/`compatibility.ts`/`commonSchemas.ts`/`types/common.ts`): `doorman status` still works correctly. `--help` output spot-checked — `--provider` lists `gcp`, `--projectId`'s description correctly covers both Vercel and GCP.

## Test plan

- [x] Unit tests pass (`pnpm jest`)
- [x] Typecheck + lint clean
- [x] Mutation-verify on all new diffing/priority-assignment logic
- [x] Mock server verified directly via curl
- [x] E2e sanity check against a real (Vercel) config to confirm no regression in shared files
- [ ] Real end-to-end check against an actual GCP project — planned as a follow-up, not yet done