### PR TITLE
fix: apply UnifiedCondition.negated in Cloud Armor CEL generation

### DIFF
--- a/src/lib/translators/CelExpressionBuilder.ts
+++ b/src/lib/translators/CelExpressionBuilder.ts
@@ -1,4 +1,5 @@
 import type { UnifiedCondition } from '../types/unified'
+import type { Operator } from '../types/common'
 import { escapeCelString } from './celEscape'
 import { ipAddressSchema } from '../schemas/commonSchemas'
 
@@ -143,7 +144,7 @@ export class CelExpressionBuilder {
         : `origin.ip == '${escapeCelString(value)}'`
     })
 
-    const negated = condition.operator === 'not_in' || condition.operator === 'ne'
+    const negated = this.isNegated(condition, condition.operator === 'not_in' || condition.operator === 'ne')
 
     if (checks.length > 1) {
       const combined = `(${checks.join(' || ')})`
@@ -178,8 +179,9 @@ export class CelExpressionBuilder {
     const field = `request.headers['${escapeCelString(headerKey)}']`
     const guard = `has(${field})`
 
-    if (condition.operator === 'exists') return guard
-    if (condition.operator === 'not_exists') return `!${guard}`
+    if (condition.operator === 'exists' || condition.operator === 'not_exists') {
+      return this.isNegated(condition, condition.operator === 'not_exists') ? `!${guard}` : guard
+    }
 
     return `(${guard} && ${this.buildComparison(field, condition, false)})`
   }
@@ -202,8 +204,9 @@ export class CelExpressionBuilder {
     const field = `request.headers['cookie']`
     const guard = `has(${field})`
 
-    if (condition.operator === 'exists') return guard
-    if (condition.operator === 'not_exists') return `!${guard}`
+    if (condition.operator === 'exists' || condition.operator === 'not_exists') {
+      return this.isNegated(condition, condition.operator === 'not_exists') ? `!${guard}` : guard
+    }
 
     if (!condition.key) {
       return `(${guard} && ${this.buildComparison(field, condition, false)})`
@@ -217,7 +220,7 @@ export class CelExpressionBuilder {
 
     const pair = `${condition.key}=${String(condition.value)}`
     const check = `${field}.contains('${escapeCelString(pair)}')`
-    const negated = condition.operator === 'ne' || condition.operator === 'not_contains'
+    const negated = this.isNegated(condition, condition.operator === 'ne' || condition.operator === 'not_contains')
     return `(${guard} && ${negated ? `!${check}` : check})`
   }
 
@@ -228,14 +231,35 @@ export class CelExpressionBuilder {
    * numeric field (`asn`, via `==`/`>`/`>=`/`<`/`<=`).
    */
   private static buildComparison(field: string, condition: UnifiedCondition, numeric: boolean): string {
-    const { operator, value } = condition
+    const { value } = condition
 
-    if (operator === 'exists' || operator === 'not_exists') {
+    if (condition.operator === 'exists' || condition.operator === 'not_exists') {
       // Every field routed here is always present on the request (unlike
       // the header-backed fields, which never reach this branch for these
       // two operators — see buildHeaderCondition) — so existence is
       // trivially always true/false rather than a meaningful check.
-      throw new Error(`"${operator}" is not meaningful for Cloud Armor's "${field}" — it is always present`)
+      throw new Error(`"${condition.operator}" is not meaningful for Cloud Armor's "${field}" — it is always present`)
+    }
+
+    // `negated: true` (Vercel's/Fastly's "base operator + separate flag"
+    // convention, as opposed to a distinct operator like `ne`) was
+    // previously ignored entirely here — a condition arriving as e.g.
+    // `{ operator: 'contains', negated: true }` (meaning "does not
+    // contain") built the exact same CEL as its non-negated counterpart,
+    // silently deploying the opposite of the configured rule. Flip to the
+    // paired operator where the Operator union has one (eq/ne, contains/
+    // not_contains, in/not_in); every other operator (starts_with/
+    // ends_with/matches/gt/ge/lt/le have no negative form) wraps the
+    // finished comparison in `!(...)` instead, after the switch below.
+    let operator: Operator = condition.operator
+    let wrapInNot = false
+    if (condition.negated) {
+      const flipped = NEGATED_OPERATOR[operator]
+      if (flipped) {
+        operator = flipped
+      } else {
+        wrapInNot = true
+      }
     }
 
     if (operator === 'in' || operator === 'not_in') {
@@ -247,32 +271,60 @@ export class CelExpressionBuilder {
 
     const literal = this.formatLiteral(value, numeric)
 
+    let result: string
     switch (operator) {
       case 'eq':
-        return `${field} == ${literal}`
+        result = `${field} == ${literal}`
+        break
       case 'ne':
-        return `${field} != ${literal}`
+        result = `${field} != ${literal}`
+        break
       case 'contains':
-        return `${field}.contains(${literal})`
+        result = `${field}.contains(${literal})`
+        break
       case 'not_contains':
-        return `!${field}.contains(${literal})`
+        result = `!${field}.contains(${literal})`
+        break
       case 'starts_with':
-        return `${field}.startsWith(${literal})`
+        result = `${field}.startsWith(${literal})`
+        break
       case 'ends_with':
-        return `${field}.endsWith(${literal})`
+        result = `${field}.endsWith(${literal})`
+        break
       case 'matches':
-        return `${field}.matches(${literal})`
+        result = `${field}.matches(${literal})`
+        break
       case 'gt':
-        return `${field} > ${literal}`
+        result = `${field} > ${literal}`
+        break
       case 'ge':
-        return `${field} >= ${literal}`
+        result = `${field} >= ${literal}`
+        break
       case 'lt':
-        return `${field} < ${literal}`
+        result = `${field} < ${literal}`
+        break
       case 'le':
-        return `${field} <= ${literal}`
+        result = `${field} <= ${literal}`
+        break
       default:
         throw new Error(`Cloud Armor CEL builder has no mapping for operator "${operator}"`)
     }
+    return wrapInNot ? `!(${result})` : result
+  }
+
+  /**
+   * Whether a condition's *effective* polarity is negative, folding
+   * together the two ways a unified condition can express "not" — a
+   * distinct operator (`ne`, `not_contains`, `not_exists`, `not_in`,
+   * `operatorImpliesNegation`) and the separate `negated` boolean flag
+   * (Vercel's/Fastly's convention: a base operator plus a flag). XOR'd
+   * rather than OR'd so a (currently unrealistic, but not type-forbidden)
+   * condition combining both — e.g. `{ operator: 'ne', negated: true }` —
+   * resolves to "negate the already-negative operator" (back to positive)
+   * rather than silently collapsing to just "negative".
+   */
+  private static isNegated(condition: UnifiedCondition, operatorImpliesNegation: boolean): boolean {
+    return operatorImpliesNegation !== !!condition.negated
   }
 
   private static formatLiteral(value: unknown, numeric: boolean): string {
@@ -305,6 +357,22 @@ export class CelExpressionBuilder {
     }
     return expressions.length === 1 ? expressions[0]! : `(${expressions.join(' || ')})`
   }
+}
+
+/**
+ * Operators with a distinct paired form for the opposite polarity, used by
+ * `buildComparison` to fold a `negated: true` flag into the base operator
+ * rather than wrapping the result in `!(...)`. `starts_with`/`ends_with`/
+ * `matches`/`gt`/`ge`/`lt`/`le` have no such pair in the `Operator` union
+ * (CEL has no "not greater than" keyword, etc.) and fall back to wrapping.
+ */
+const NEGATED_OPERATOR: Partial<Record<Operator, Operator>> = {
+  eq: 'ne',
+  ne: 'eq',
+  contains: 'not_contains',
+  not_contains: 'contains',
+  in: 'not_in',
+  not_in: 'in',
 }
 
 const SIMPLE_FIELD_MAP: Record<string, { path: string; numeric: boolean }> = {

--- a/src/lib/translators/__tests__/CelExpressionBuilder.test.ts
+++ b/src/lib/translators/__tests__/CelExpressionBuilder.test.ts
@@ -223,6 +223,61 @@ describe('CelExpressionBuilder', () => {
     })
   })
 
+  describe('fromUnifiedCondition — negated flag (Vercel/Fastly base-operator-plus-flag convention)', () => {
+    // Distinct from the `ne`/`not_in`/`not_exists`/`not_contains` cases
+    // above, which express negation via a different operator value. Vercel
+    // and Fastly both translate to Unified using a base operator plus a
+    // separate `negated: true` flag instead — this was previously ignored
+    // completely here, so e.g. a Vercel rule with `neg: true` silently lost
+    // its negation on the way to Cloud Armor, deploying the exact opposite
+    // of the configured rule.
+    it('flips eq to != for a simple field', () => {
+      const c: UnifiedCondition = { field: 'method', operator: 'eq', value: 'POST', negated: true }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.method != 'POST'")
+    })
+
+    it('wraps a guarded header comparison, preserving "false when header absent"', () => {
+      const c: UnifiedCondition = { field: 'user_agent', operator: 'contains', value: 'GoodBot', negated: true }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        "(has(request.headers['user-agent']) && !request.headers['user-agent'].contains('GoodBot'))",
+      )
+    })
+
+    it('wraps in !(...) for an operator with no distinct negative form', () => {
+      const c: UnifiedCondition = { field: 'path', operator: 'starts_with', value: '/admin', negated: true }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("!(request.path.startsWith('/admin'))")
+    })
+
+    it('produces identical CEL to the distinct-operator convention for ip', () => {
+      const viaFlag: UnifiedCondition = { field: 'ip', operator: 'eq', value: '203.0.113.9', negated: true }
+      const viaOperator: UnifiedCondition = { field: 'ip', operator: 'ne', value: '203.0.113.9' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(viaFlag)).toBe(
+        CelExpressionBuilder.fromUnifiedCondition(viaOperator),
+      )
+    })
+
+    it('cancels out when combined with an already-negative operator (double negative)', () => {
+      const c: UnifiedCondition = { field: 'ip', operator: 'ne', value: '203.0.113.9', negated: true }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("origin.ip == '203.0.113.9'")
+    })
+
+    it('flips exists to not_exists on a header-backed field', () => {
+      const c: UnifiedCondition = { field: 'header', key: 'X-Foo', operator: 'exists', negated: true }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe(
+        CelExpressionBuilder.fromUnifiedCondition({
+          field: 'header',
+          key: 'X-Foo',
+          operator: 'not_exists',
+        }),
+      )
+    })
+
+    it('does not affect an ordinary condition with no negated flag (regression baseline)', () => {
+      const c: UnifiedCondition = { field: 'method', operator: 'eq', value: 'POST' }
+      expect(CelExpressionBuilder.fromUnifiedCondition(c)).toBe("request.method == 'POST'")
+    })
+  })
+
   describe('fromUnifiedCondition — unsupported fields', () => {
     it.each(['region', 'city', 'port', 'scheme'])(
       'throws a clear error for "%s" (no Cloud Armor CEL equivalent)',


### PR DESCRIPTION
## Summary
Closes #239 — `CelExpressionBuilder` never read `condition.negated` anywhere. Vercel passes it through as the native `neg` field; Fastly uses it to pick the paired native operator (`does_not_equal`, etc.). Cloud Armor's CEL builder did neither, so a condition using the base-operator-plus-flag convention (`{ operator: 'contains', negated: true }`) built identical CEL whether or not it was negated — deploying the exact opposite of the configured rule, silently, with no error or warning.

This is reachable through the tool's core use case: any rule migrated from Vercel or Fastly (both of which always translate negation this way) and then synced to a newly-added Cloud Armor provider hits this on every negated condition.

**Empirical proof before writing the fix:**
```ts
CelExpressionBuilder.fromUnifiedCondition({
  field: 'user_agent', operator: 'contains', value: 'GoodBot', negated: true,
})
// => "(has(request.headers['user-agent']) && request.headers['user-agent'].contains('GoodBot'))"
// Matches when user-agent DOES contain GoodBot — the opposite of "does NOT contain".
```

Fixed across all four condition builders:
- `buildComparison` — flips to the paired operator where `Operator` has one (`eq`/`ne`, `contains`/`not_contains`, `in`/`not_in`); wraps in `!(...)` for operators with no CEL-level negative form (`starts_with`/`ends_with`/`matches`/`gt`/`ge`/`lt`/`le`).
- `buildIpCondition`, and the `exists`/`not_exists` branches in `buildHeaderCondition`/`buildCookieCondition` — fold the flag in via XOR against whatever the operator already implies, so combining both conventions (unrealistic today, not type-forbidden) resolves correctly instead of silently double-negating.
- The existing "false when header is absent" convention for negated header/cookie checks is preserved for the flag-based path too, not just the distinct-operator path — verified by test.

## Test plan
- [x] 7 new test cases covering: simple-field flip, guarded-header wrap (preserving absent-header semantics), no-paired-operator wrap, flag-vs-distinct-operator equivalence, double-negative cancellation, exists→not_exists flip, and a regression baseline confirming zero change to the ordinary non-negated case
- [x] `pnpm test:ci` — 89/89 suites, 1664/1664 tests
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean
- Not tested against a live Cloud Armor project (no GCP credentials in this environment) — verified via the existing translator unit-test harness, same approach used for the Fastly fix in #237