### PR TITLE
fix: parse negated starts_with/ends_with/matches/gt/ge/lt/le CEL back correctly

### DIFF
--- a/src/lib/translators/CelParser.ts
+++ b/src/lib/translators/CelParser.ts
@@ -562,20 +562,56 @@ function comparisonToCondition(
   const mapped = mapFieldToUnified(refField, refKey)
   if (!mapped) return null
 
+  // Known, accepted lossiness (same category as this file's keyed-cookie
+  // note above): for eq/ne, contains/not_contains, and in/not_in, a local
+  // condition using the *flag* convention (`{ operator: 'eq', negated:
+  // true }`, Vercel's/Fastly's own convention) round-trips through Cloud
+  // Armor as the *distinct-operator* convention (`{ operator: 'ne' }`,
+  // no flag) instead — same CEL either way, but a cosmetically different
+  // shape, so a local config written with the flag form for one of these
+  // three pairs will show a one-time no-op "update" on its first sync.
+  // Not fixed here: doing so would mean threading the *original* condition's
+  // negation style through the diff, not just re-deriving correct CEL from
+  // it, and the operators that actually had a correctness bug (produced
+  // wrong CEL, not just a cosmetic mismatch — see #239) are the ones with
+  // no distinct operator pair, handled by `resultNegated` below.
   let operator: UnifiedCondition['operator']
   let value: string | number | string[] | number[]
+  // Set only for an operator with no distinct negative form in the unified
+  // Operator union (starts_with/ends_with/matches/gt/ge/lt/le) — mirrors
+  // CelExpressionBuilder's own fallback (flip to the paired operator where
+  // one exists, else keep the base operator and carry `negated: true`
+  // instead of fabricating an operator value like `not_starts_with` that
+  // doesn't exist in the type). Before this, a `!(...)`-wrapped comparison
+  // on one of these operators — which the builder now legitimately
+  // produces for a `negated: true` condition (see #239) — parsed back to
+  // `null` (unsupported), turning every such rule into a permanent phantom
+  // diff the moment it round-tripped through a fetch.
+  let resultNegated = false
 
   if (node.type === 'comparison') {
-    operator = negated ? negateSimpleOperator(node.operator) : node.operator
+    if (!negated) {
+      operator = node.operator
+    } else if (node.operator === 'eq') {
+      operator = 'ne'
+    } else if (node.operator === 'ne') {
+      operator = 'eq'
+    } else {
+      operator = node.operator
+      resultNegated = true
+    }
     value = node.value
   } else if (node.type === 'methodCall') {
     const base = METHOD_TO_OPERATOR[node.method]
     if (!base) return null
-    operator = negated ? (`not_${base}` as UnifiedCondition['operator']) : base
-    // Only 'contains'/'not_contains' have a dedicated negative form in the
-    // unified operator set — the builder never negates startsWith/endsWith/
-    // matches, so this is unreachable for those methods in practice.
-    if (negated && operator !== 'not_contains') return null
+    if (!negated) {
+      operator = base
+    } else if (base === 'contains') {
+      operator = 'not_contains'
+    } else {
+      operator = base
+      resultNegated = true
+    }
     value = node.value
   } else {
     operator = negated ? 'not_in' : 'in'
@@ -586,20 +622,10 @@ function comparisonToCondition(
     field: mapped.unifiedField,
     operator,
     value,
+    ...(resultNegated ? { negated: true } : {}),
     ...(mapped.unifiedKey !== undefined ? { key: mapped.unifiedKey } : {}),
     ...(group !== undefined ? { group } : {}),
   }
-}
-
-function negateSimpleOperator(op: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le'): UnifiedCondition['operator'] {
-  // CelExpressionBuilder never emits a `not`-wrapped bare comparison (`eq`
-  // negates to the native `!=` operator, not `!(field == x)`) — reachable
-  // only for a hand-authored expression using this codebase's grammar
-  // subset in a way the builder itself wouldn't. `ne` is the sole case with
-  // an obvious inverse; anything else has no single-operator negation.
-  if (op === 'eq') return 'ne'
-  if (op === 'ne') return 'eq'
-  throw new ParseError(`No negated form for comparison operator '${op}'`)
 }
 
 /**

--- a/src/lib/translators/__tests__/CelParser.test.ts
+++ b/src/lib/translators/__tests__/CelParser.test.ts
@@ -229,6 +229,45 @@ describe('parseCelExpression', () => {
       expect(parsed!.conditions[0]).toMatchObject({ field: 'ip', operator: 'ne', value: '203.0.113.9' })
     })
 
+    // Regression coverage for #239: before the fix, CelExpressionBuilder
+    // silently ignored `negated`, so these cases never reached the parser
+    // wrapped in `!(...)` at all — that shape simply didn't exist yet.
+    // Fixing the builder made it reachable, which exposed a second gap: the
+    // parser tried to represent "negated starts_with" etc. as a fabricated
+    // `not_starts_with` operator (not a real value in the Operator union),
+    // rejected its own fabrication, and returned null — turning the
+    // now-correct CEL into an "unparseable expression" warning with empty
+    // conditions on every fetch. Fixed by carrying `negated: true` on the
+    // output condition instead, for every operator with no distinct
+    // negative-operator form.
+    it.each([
+      { field: 'path', operator: 'starts_with', value: '/admin' },
+      { field: 'path', operator: 'ends_with', value: '.php' },
+      { field: 'path', operator: 'matches', value: '/x/' },
+      { field: 'asn', operator: 'gt', value: 1000 },
+      { field: 'asn', operator: 'ge', value: 1000 },
+      { field: 'asn', operator: 'lt', value: 1000 },
+      { field: 'asn', operator: 'le', value: 1000 },
+    ] as const)('round-trips a negated $operator condition via the negated flag, not a fabricated operator', (base) => {
+      const condition: UnifiedCondition = { ...base, negated: true }
+      const { parsed } = roundTrip([condition])
+      expect(parsed).not.toBeNull()
+      expect(parsed!.conditions[0]).toMatchObject({ ...base, negated: true })
+    })
+
+    // Known, accepted lossiness (documented on comparisonToCondition) — not
+    // a #239 regression, since the pre-fix parser already normalized these
+    // three pairs to the distinct-operator form with no flag. What matters,
+    // same as the keyed-cookie case above, is idempotence: re-feeding the
+    // reshaped condition produces the exact same CEL, not a different one.
+    it('round-trips a negated eq condition to the equivalent (reshaped, idempotent) ne condition', () => {
+      const original: UnifiedCondition = { field: 'method', operator: 'eq', value: 'POST', negated: true }
+      const firstPass = roundTrip([original])
+      expect(firstPass.parsed!.conditions[0]).toMatchObject({ field: 'method', operator: 'ne', value: 'POST' })
+      const secondPass = roundTrip(firstPass.parsed!.conditions)
+      expect(secondPass.expression).toBe(firstPass.expression)
+    })
+
     // A keyed cookie condition is CEL's one inherently lossy case (see
     // CelParser.ts's file-level doc comment) — there is no CEL shape that
     // distinguishes "this specific cookie" from "this substring appears in


### PR DESCRIPTION
## Summary
Direct follow-up to #240/#239, caught during my own post-merge verification before any release depended on it — no separate issue filed since it never had independent existence outside completing that fix.

#240 correctly taught `CelExpressionBuilder` to build `!(...)`-wrapped CEL for a negated condition when the `Operator` union has no distinct paired form (e.g. `{ operator: 'starts_with', negated: true }` → `!(field.startsWith(x))`). That made a CEL shape reachable that never existed before — but `CelParser` (which only needs to understand exactly what the builder produces) still tried to represent it back as a fabricated `not_starts_with` operator, rejected its own fabrication via an `operator !== 'not_contains'` guard, and returned `null`. Net effect: a rule using one of these operators negated would fetch back as "expression could not be parsed" with empty conditions — turning #240's now-correct CEL into a permanent phantom diff on every sync.

**Verified the gap empirically before fixing:**
```
{"field":"path","operator":"starts_with","value":"/admin","negated":true} => CEL: !(request.path.startsWith('/admin')) => PARSED: null
```

Fixed the same way as the builder: carry `negated: true` on the output condition instead of fabricating an operator, for every operator with no distinct negative form (`starts_with`/`ends_with`/`matches`/`gt`/`ge`/`lt`/`le`).

Also **documented but did not fix** a separate, much lower-severity, pre-existing asymmetry unrelated to #240: `eq`/`ne`, `contains`/`not_contains`, and `in`/`not_in` normalize to the distinct-operator form on read-back regardless of which convention the original condition used, so a local config authored with the flag convention for one of those three pairs shows a one-time cosmetic no-op "update" on first sync. Same category as this file's own already-documented keyed-cookie lossiness (reshaped but behaviorally identical CEL) — not a correctness bug, and pre-dates #240 entirely.

## Test plan
- [x] Empirically confirmed the regression before fixing (see above)
- [x] 7 new `it.each` round-trip tests covering every operator with no distinct negative form
- [x] 1 new test documenting the accepted eq/ne lossy-but-idempotent case (asserts re-feeding the reshaped condition produces identical CEL)
- [x] `pnpm test:ci` — 89/89 suites, 1672/1672 tests
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean