### PR TITLE
fix: diff Fastly rules against the parsed/defaulted config, not the raw one

### DIFF
--- a/src/lib/providers/fastly/FastlyFirewallService.ts
+++ b/src/lib/providers/fastly/FastlyFirewallService.ts
@@ -327,8 +327,17 @@ export class FastlyFirewallService extends BaseFirewallService implements IFirew
       // a translated local rule against an untranslated remote one produces
       // spurious diffs from defaults `unifiedToFastly` fills in that the
       // remote rule never had.
+      //
+      // Diff against `configValidation.data`, not the raw `config` param —
+      // `fastlyToUnified` always sets `conditionLogic` explicitly (see
+      // `extractUnifiedConditions`), but a local rule relying on the
+      // schema's documented 'AND' default omits the key entirely. Reading
+      // from the unparsed `config` meant that local rule had one fewer key
+      // than the always-explicit translated remote side, so `isDeepEqual`
+      // flagged it as a phantom "update" forever — the same bug found and
+      // fixed on Vercel's getChanges, see #225.
       const remoteRules = this.translateFastlyRules(fastlyRules)
-      const { toAdd, toUpdate, toDelete } = this.diffRules(config.rules, remoteRules)
+      const { toAdd, toUpdate, toDelete } = this.diffRules(configValidation.data.rules, remoteRules)
 
       const denyEntries = denyList?.entries ?? []
       const allowEntries = allowList?.entries ?? []
@@ -336,7 +345,7 @@ export class FastlyFirewallService extends BaseFirewallService implements IFirew
         ...RuleTranslator.fastlyListEntriesToUnified(denyEntries, 'deny'),
         ...RuleTranslator.fastlyListEntriesToUnified(allowEntries, 'allow'),
       ]
-      const { ipsToAdd, ipsToDelete } = this.diffIPs(config.ips || [], remoteIPs)
+      const { ipsToAdd, ipsToDelete } = this.diffIPs(configValidation.data.ips || [], remoteIPs)
 
       return {
         rulesToAdd: toAdd,

--- a/src/lib/providers/fastly/__tests__/FastlyFirewallService.test.ts
+++ b/src/lib/providers/fastly/__tests__/FastlyFirewallService.test.ts
@@ -184,6 +184,36 @@ describe('FastlyFirewallService', () => {
       expect(changes.hasChanges).toBe(false)
     })
 
+    it('should detect no changes for a local rule that omits conditionLogic (regression test for #225)', async () => {
+      // getChanges previously diffed the raw `config` parameter rather than
+      // unifiedConfigSchema.safeParse(config).data — so a local rule relying
+      // on the documented conditionLogic default ('AND') never actually got
+      // it applied before comparison, while fastlyToUnified always sets it
+      // explicitly on the translated remote side. One fewer key on the
+      // local side made isDeepEqual flag every such rule as a phantom
+      // "update". Same bug, same fix, as Vercel's getChanges.
+      jest.spyOn(client, 'fetchRules').mockResolvedValue([mockRequestRule])
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            id: 'rule_1',
+            name: 'Block bad bots',
+            enabled: true,
+            // No `conditionLogic` key at all — relies entirely on the
+            // schema's documented default.
+            conditions: [{ field: 'user_agent', operator: 'contains', value: 'BadBot', group: 0 }],
+            action: { type: 'block' },
+          },
+        ],
+      }
+
+      const changes = await service.getChanges(config)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
     it('should detect an update when a rule with the same id has different content', async () => {
       jest.spyOn(client, 'fetchRules').mockResolvedValue([mockRequestRule])
 


### PR DESCRIPTION
## Summary
Closes #243 — the exact same bug as #225 (Vercel), found by checking whether the same pattern existed in the other providers after fixing it there. `FastlyFirewallService.getChanges` called `unifiedConfigSchema.safeParse(config)` only to validate, then diffed the original unparsed `config.rules`/`config.ips` instead of `configValidation.data`. `fastlyToUnified` always sets `conditionLogic` explicitly on the translated remote side, so a local rule relying on the schema's documented `'AND'` default had one fewer key than the remote side — `isDeepEqual` flagged it as a phantom "update" forever.

`diffRules` already expects pre-normalized `UnifiedRule[]` input; the call site just wasn't honoring that contract — same fix shape as #235.

Also checked GCP's `CloudArmorFirewallService.getChanges` for the same pattern: it also reads raw `config.rules`, but `gcpToUnified` conditionally omits `conditionLogic` (only includes it for the non-default `'OR'` case) rather than always setting it explicitly — so the asymmetry this bug depends on doesn't exist there. No fix needed for GCP.

## Test plan
- [x] Empirically confirmed the bug before fixing, via the existing `FastlyFirewallService` test harness (mocked `fetchRules` + a local config omitting `conditionLogic`) — showed `rulesToUpdate: [...]`, `hasChanges: true` for an otherwise-identical rule
- [x] Added a regression test mirroring the existing Vercel one
- [x] `pnpm test:ci` — 89/89 suites (one `CloudflarePerformanceBenchmarks` flake observed under host CPU load on a separate run, unrelated to this change — passes in isolation)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean