### PR TITLE
fix: stop retrying non-idempotent rule/list creation on Fastly

### DIFF
--- a/src/lib/providers/fastly/FastlyClient.ts
+++ b/src/lib/providers/fastly/FastlyClient.ts
@@ -60,8 +60,13 @@ export class FastlyClient extends BaseFirewallClient {
     return response.data
   }
 
+  // Creating a rule is not idempotent — a retry after a response is lost
+  // (the request reached Fastly and created the rule, but the client never
+  // saw the success) creates a second, duplicate rule with a new
+  // server-assigned id. updateRule/deleteRule are keyed by id and safe to
+  // retry. Same bug, same fix, as Vercel's rules.insert — see #195.
   async createRule(rule: FastlyRuleInput): Promise<FastlyRule> {
-    return this.post<FastlyRule>(this.workspacePath('rules'), rule)
+    return this.post<FastlyRule>(this.workspacePath('rules'), rule, { retries: 0 })
   }
 
   async updateRule(ruleId: string, rule: FastlyRuleInput): Promise<FastlyRule> {
@@ -77,13 +82,21 @@ export class FastlyClient extends BaseFirewallClient {
     return response.data
   }
 
+  // Same non-idempotency as createRule above — a lost-response retry would
+  // create a second list also named DOORMAN_DENY_LIST_NAME/
+  // DOORMAN_ALLOW_LIST_NAME, and findList's `lists.find(...)` would then
+  // silently pick whichever one happens to sort first.
   async createList(name: string, entries: string[]): Promise<FastlyList> {
-    return this.post<FastlyList>(this.workspacePath('lists'), {
-      name,
-      type: 'ip',
-      description: 'Managed by doorman — do not edit entries directly, they will be overwritten on the next sync.',
-      entries,
-    })
+    return this.post<FastlyList>(
+      this.workspacePath('lists'),
+      {
+        name,
+        type: 'ip',
+        description: 'Managed by doorman — do not edit entries directly, they will be overwritten on the next sync.',
+        entries,
+      },
+      { retries: 0 },
+    )
   }
 
   async updateListEntries(listId: string, entries: string[]): Promise<FastlyList> {

--- a/src/lib/providers/fastly/__tests__/FastlyClient.test.ts
+++ b/src/lib/providers/fastly/__tests__/FastlyClient.test.ts
@@ -1,0 +1,84 @@
+import { FastlyClient } from '../FastlyClient'
+import type { FastlyRuleInput } from '../../../types/fastly'
+
+jest.mock('../../../logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+// Regression coverage for the same bug class as #195 (Vercel's rules.insert):
+// creating a rule/list has no client-supplied id, so a retry after a lost
+// response duplicates it rather than safely re-applying. Update/delete are
+// keyed by id and stay safe to retry.
+describe('FastlyClient', () => {
+  const workspaceId = 'workspace_1'
+  const apiToken = 'test-token'
+  let client: FastlyClient
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    client = new FastlyClient(workspaceId, apiToken)
+    jest.spyOn(client as any, 'delay').mockResolvedValue(undefined)
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+    jest.clearAllMocks()
+    jest.spyOn(client as any, 'delay').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  const ruleInput: FastlyRuleInput = {
+    type: 'request',
+    enabled: true,
+    description: 'Block bad bots',
+    group_operator: 'all',
+    conditions: [{ type: 'single', field: 'user_agent', operator: 'contains', value: 'BadBot' }],
+    actions: [{ type: 'block' }],
+  }
+
+  describe('createRule', () => {
+    it('does not retry after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.createRule(ruleInput)).rejects.toThrow()
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('updateRule', () => {
+    it('still retries after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateRule('rule_1', ruleInput)).rejects.toThrow()
+
+      // Default `retries: 3` -> up to 4 attempts total.
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(1)
+    })
+  })
+
+  describe('createList', () => {
+    it('does not retry after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.createList('doorman-managed-deny', ['1.2.3.4/32'])).rejects.toThrow()
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('updateListEntries', () => {
+    it('still retries after a network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('fetch failed'))
+
+      await expect(client.updateListEntries('list_1', ['1.2.3.4/32'])).rejects.toThrow()
+
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Closes #245 — same bug class as #195 (Vercel's `rules.insert`), found by systematically checking whether that fix's reasoning applied to the other providers. `createRule`/`createList` have no client-supplied id or other uniqueness key, so a retry after a lost response (the request reached Fastly and created the resource, but the client never saw success) creates a second, duplicate resource with a new server-assigned id.

`createList` is worse than a generic duplicate: `findList` resolves doorman's managed list by name via a plain `.find()`, so two lists sharing the same name would leave IP entries silently split across them with no way to tell which is authoritative going forward.

`updateRule`/`deleteRule`/`updateListEntries` are all keyed by an existing id and stay safe to retry — only the two create paths needed `{ retries: 0 }`.

Also added `src/lib/providers/fastly/__tests__/FastlyClient.test.ts`, which didn't exist before — Fastly's HTTP-client layer had zero direct unit test coverage. Kept scope tight to just what verifies this fix (create doesn't retry, update does), mirroring `VercelClient.test.ts`'s existing pattern for the same #195 fix, rather than writing comprehensive client coverage as a side effect.

## Test plan
- [x] New tests confirm `createRule`/`createList` make exactly one attempt on network failure, while `updateRule`/`updateListEntries` still retry (default 3 retries → >1 call)
- [x] `pnpm test:ci` — 90/90 suites, 1676/1676 tests
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean