### PR TITLE
test(cloudflare): close remaining retry-loop mock gaps, audit the rest

### DIFF
--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -840,10 +840,11 @@ describe('CloudflareClient', () => {
   describe('Error Handling', () => {
     it('should handle network errors with proper error mapping', async () => {
       const networkError = new Error('Network connection failed')
-      // Intentionally `Once`: unlike verifyCredentials above, this doesn't
-      // assert on the error message, so it still passes if retries fall
-      // through to a real fetch() and surface a different error instead.
-      fetchMock.mockRejectedValueOnce(networkError)
+      // mockRejectedValue (not Once): see the identical comment on
+      // verifyCredentials above — a one-shot rejection only covers the
+      // first of makeRequest's retry attempts, letting the rest fall through
+      // to a real fetch() call against the live Cloudflare API.
+      fetchMock.mockRejectedValue(networkError)
 
       await expect(client.listRulesets()).rejects.toThrow()
     })

--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -840,6 +840,9 @@ describe('CloudflareClient', () => {
   describe('Error Handling', () => {
     it('should handle network errors with proper error mapping', async () => {
       const networkError = new Error('Network connection failed')
+      // Intentionally `Once`: unlike verifyCredentials above, this doesn't
+      // assert on the error message, so it still passes if retries fall
+      // through to a real fetch() and surface a different error instead.
       fetchMock.mockRejectedValueOnce(networkError)
 
       await expect(client.listRulesets()).rejects.toThrow()

--- a/src/lib/providers/cloudflare/__tests__/CloudflareCredentialValidation.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareCredentialValidation.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import { CloudflareValidator } from '../CloudflareValidator'
 import type { CloudflareCredentials } from '../CloudflareValidator'
 
-// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used in other
-// Cloudflare test files, this replaces fetch outright, so mockRejectedValueOnce()
-// below is safe even though it's single-shot: CloudflareValidator's own fetch()
-// calls (verifyTokenWithAPI, getZoneInfo, ...) make one request with no retry
-// loop, and CloudflareClient — which does retry via BaseFirewallClient — is
-// mocked separately above and never touches fetch in this file.
+// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used elsewhere,
+// this replaces fetch outright, so mockRejectedValueOnce() below is safe even
+// though it's single-shot: CloudflareValidator's own fetch() calls don't
+// retry, and the separately-mocked CloudflareClient (which does) never
+// touches fetch in this file.
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>
 global.fetch = mockFetch
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareCredentialValidation.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareCredentialValidation.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import { CloudflareValidator } from '../CloudflareValidator'
 import type { CloudflareCredentials } from '../CloudflareValidator'
 
-// Mock fetch globally
+// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used in other
+// Cloudflare test files, this replaces fetch outright, so mockRejectedValueOnce()
+// below is safe even though it's single-shot: CloudflareValidator's own fetch()
+// calls (verifyTokenWithAPI, getZoneInfo, ...) make one request with no retry
+// loop, and CloudflareClient — which does retry via BaseFirewallClient — is
+// mocked separately above and never touches fetch in this file.
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>
 global.fetch = mockFetch
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
@@ -181,6 +181,12 @@ describe('Cloudflare Error Handling Integration', () => {
   })
 
   describe('Network Error Scenarios', () => {
+    // These all use mockRejectedValueOnce, which only covers makeRequest's
+    // first attempt — later retries fall through to a real fetch() since
+    // fetchMock spies on globalThis.fetch rather than replacing it outright.
+    // Safe only because .rejects.toThrow() takes no message argument: the
+    // mocked error, a real network failure, or a real 4xx from Cloudflare
+    // (given these fake credentials) all satisfy the assertion equally.
     it('should handle DNS resolution failures', async () => {
       const dnsError = new Error('getaddrinfo ENOTFOUND api.cloudflare.com')
       fetchMock.mockRejectedValueOnce(dnsError)
@@ -261,6 +267,9 @@ describe('Cloudflare Error Handling Integration', () => {
   })
 
   describe('Service-Level Error Handling', () => {
+    // Same reasoning as the Network Error Scenarios block above: single-shot
+    // rejections here can fall through to a real fetch() on retry, but
+    // .rejects.toThrow() has no message argument so it's safe either way.
     it('should handle fetchConfig errors gracefully', async () => {
       const networkError = new Error('Network unavailable')
       fetchMock.mockRejectedValueOnce(networkError)

--- a/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareErrorHandling.test.ts
@@ -181,36 +181,34 @@ describe('Cloudflare Error Handling Integration', () => {
   })
 
   describe('Network Error Scenarios', () => {
-    // These all use mockRejectedValueOnce, which only covers makeRequest's
-    // first attempt — later retries fall through to a real fetch() since
-    // fetchMock spies on globalThis.fetch rather than replacing it outright.
-    // Safe only because .rejects.toThrow() takes no message argument: the
-    // mocked error, a real network failure, or a real 4xx from Cloudflare
-    // (given these fake credentials) all satisfy the assertion equally.
+    // mockRejectedValue (not Once): a one-shot rejection only covers
+    // makeRequest's first retry attempt, letting the rest fall through to a
+    // real fetch() call against the live Cloudflare API — see the identical
+    // comment on verifyCredentials in CloudflareClient.test.ts.
     it('should handle DNS resolution failures', async () => {
       const dnsError = new Error('getaddrinfo ENOTFOUND api.cloudflare.com')
-      fetchMock.mockRejectedValueOnce(dnsError)
+      fetchMock.mockRejectedValue(dnsError)
 
       await expect(client.listRulesets()).rejects.toThrow()
     })
 
     it('should handle connection timeouts', async () => {
       const timeoutError = new Error('Request timeout after 30000ms')
-      fetchMock.mockRejectedValueOnce(timeoutError)
+      fetchMock.mockRejectedValue(timeoutError)
 
       await expect(client.listRulesets()).rejects.toThrow()
     })
 
     it('should handle connection refused errors', async () => {
       const connError = new Error('connect ECONNREFUSED 127.0.0.1:443')
-      fetchMock.mockRejectedValueOnce(connError)
+      fetchMock.mockRejectedValue(connError)
 
       await expect(client.listRulesets()).rejects.toThrow()
     })
 
     it('should handle SSL/TLS errors', async () => {
       const sslError = new Error('certificate verify failed')
-      fetchMock.mockRejectedValueOnce(sslError)
+      fetchMock.mockRejectedValue(sslError)
 
       await expect(client.listRulesets()).rejects.toThrow()
     })
@@ -267,12 +265,10 @@ describe('Cloudflare Error Handling Integration', () => {
   })
 
   describe('Service-Level Error Handling', () => {
-    // Same reasoning as the Network Error Scenarios block above: single-shot
-    // rejections here can fall through to a real fetch() on retry, but
-    // .rejects.toThrow() has no message argument so it's safe either way.
+    // mockRejectedValue (not Once): same reasoning as Network Error Scenarios above.
     it('should handle fetchConfig errors gracefully', async () => {
       const networkError = new Error('Network unavailable')
-      fetchMock.mockRejectedValueOnce(networkError)
+      fetchMock.mockRejectedValue(networkError)
 
       await expect(service.fetchConfig()).rejects.toThrow()
     })
@@ -286,7 +282,7 @@ describe('Cloudflare Error Handling Integration', () => {
       }
 
       const serverError = new Error('Internal server error')
-      fetchMock.mockRejectedValueOnce(serverError)
+      fetchMock.mockRejectedValue(serverError)
 
       await expect(service.syncRules(mockConfig)).rejects.toThrow()
     })

--- a/src/lib/providers/cloudflare/__tests__/CloudflareValidator.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareValidator.test.ts
@@ -19,7 +19,12 @@ jest.mock('../CloudflareClient', () => ({
   })),
 }))
 
-// Mock fetch globally
+// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used in other
+// Cloudflare test files, this replaces fetch outright, so mockRejectedValueOnce()
+// below is safe even though it's single-shot: CloudflareValidator's own fetch()
+// calls (verifyTokenWithAPI, getZoneInfo, ...) make one request with no retry
+// loop, and CloudflareClient — which does retry via BaseFirewallClient — is
+// mocked separately above and never touches fetch in this file.
 const mockFetch = jest.fn() as jest.Mock
 global.fetch = mockFetch as any
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflareValidator.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareValidator.test.ts
@@ -19,12 +19,11 @@ jest.mock('../CloudflareClient', () => ({
   })),
 }))
 
-// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used in other
-// Cloudflare test files, this replaces fetch outright, so mockRejectedValueOnce()
-// below is safe even though it's single-shot: CloudflareValidator's own fetch()
-// calls (verifyTokenWithAPI, getZoneInfo, ...) make one request with no retry
-// loop, and CloudflareClient — which does retry via BaseFirewallClient — is
-// mocked separately above and never touches fetch in this file.
+// Mock fetch globally. Unlike jest.spyOn(globalThis, 'fetch') used elsewhere,
+// this replaces fetch outright, so mockRejectedValueOnce() below is safe even
+// though it's single-shot: CloudflareValidator's own fetch() calls don't
+// retry, and the separately-mocked CloudflareClient (which does) never
+// touches fetch in this file.
 const mockFetch = jest.fn() as jest.Mock
 global.fetch = mockFetch as any
 


### PR DESCRIPTION
## Summary

Follow-up to #242, which fixed 3 Cloudflare provider tests where a single `mockRejectedValueOnce(...)` only covered the first of `BaseFirewallClient.makeRequest`'s retry attempts (3 retries by default = up to 4 total `fetch()` calls). Once the mocked rejection is consumed, later attempts silently fall through to `jest.spyOn`'s default behavior of calling the *real* `fetch()` — invisible locally (sandboxed, no outbound network) but broke 3 tests in CI (real internet access).

That PR flagged ~11 more `mockRejectedValueOnce` call sites with the same shape that weren't proven broken, and said each needed individual judgment rather than a blanket find-replace. This PR is that audit, in two commits:

**Commit 1** — traced all 11 sites to their actual implementation and mock setup and found all currently pass, for two different reasons, and added comments explaining each:
- 7 sites (`CloudflareClient.test.ts`, `CloudflareErrorHandling.test.ts`) *do* exercise the same retry loop, but their assertions are bare `.rejects.toThrow()` with no message argument, so whichever error surfaces first still satisfies them.
- 4 sites (`CloudflareCredentialValidation.test.ts`, `CloudflareValidator.test.ts`) test `CloudflareValidator`, which doesn't extend `BaseFirewallClient` — its own `fetch()` calls are single-shot with no retry loop, and both files replace `global.fetch` with a plain `jest.fn()` rather than spying on the real one, so there's no live-network fallthrough possible.

**Commit 2** — ran `/code-review` against `main` on commit 1. The altitude angle made a good catch: documenting *why* the 7 retry-loop sites happen to be safe isn't as good as removing the live-network dependency entirely, since none of those tests chain a second mock response after the rejection — so `mockRejectedValueOnce` → persistent `mockRejectedValue` there is a strictly safer fix with no behavior change, consistent with the fix `#242` already applied elsewhere. Also fixed: the first commit's own comment on `CloudflareClient.test.ts:843` mischaracterized *why* a sibling test needed its fix (see commit message for detail), and trimmed a verbatim-duplicated comment across two files. Full findings in the review below.

Net effect: the only sites still using `mockRejectedValueOnce` are the 4 that genuinely make just one fetch call — every site that goes through the retry loop is now hermetic (no real network calls, in CI or locally). Confirmed by a 2x speedup in the local test run (13.2s → 6.0s) once the real-fetch fallthrough was removed.

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm test` — 1676/1676 passing across 90 suites (both before and after commit 2)
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] CI green (Lint, Test, Build)