### PR TITLE
fix(gcp): auth headers silently dropped on every request; CEL parsed twice per rule

### DIFF
--- a/src/lib/providers/gcp/CloudArmorClient.ts
+++ b/src/lib/providers/gcp/CloudArmorClient.ts
@@ -59,11 +59,13 @@ export class CloudArmorClient extends BaseFirewallClient {
   protected async getAuthHeaders(): Promise<Record<string, string>> {
     const client = await this.auth.getClient()
     const headers = await client.getRequestHeaders()
-    // google-auth-library types this as a plain header record already;
-    // the cast is only to satisfy BaseFirewallClient's Record<string,
-    // string> contract against the library's own (structurally identical)
-    // Headers-like type.
-    return headers as unknown as Record<string, string>
+    // getRequestHeaders() returns a real WHATWG Headers instance, not a
+    // plain object. BaseFirewallClient.makeRequest merges auth headers by
+    // object-spreading this return value into a header literal — spreading
+    // a Headers instance produces `{}`, silently dropping every header
+    // (including Authorization) from every real request. Converting via
+    // entries() is required, not optional.
+    return Object.fromEntries(headers.entries())
   }
 
   private policyPath(...segments: string[]): string {

--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -2,6 +2,7 @@ import { logger } from '../../logger'
 import { BaseFirewallService } from '../BaseFirewallService'
 import { CloudArmorClient } from './CloudArmorClient'
 import { RuleTranslator } from '../../translators'
+import { parseCelExpression } from '../../translators/CelParser'
 import { isDeepEqual } from '../../utils/isDeepEqual'
 import { omitId } from '../../utils/omitId'
 import { unifiedConfigSchema } from '../../schemas/unifiedSchemas'
@@ -81,11 +82,15 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
     const ips: UnifiedIPRule[] = []
 
     for (const rule of policy.rules) {
-      if (RuleTranslator.gcpLooksLikeIpRule(rule)) {
-        ips.push(RuleTranslator.gcpToUnifiedIP(rule))
+      // Parsed once and threaded through both the classification check and
+      // whichever translation follows it, rather than each re-parsing the
+      // same CEL expression from scratch.
+      const parsed = parseCelExpression(rule.match.expr.expression)
+      if (RuleTranslator.gcpLooksLikeIpRule(rule, parsed)) {
+        ips.push(RuleTranslator.gcpToUnifiedIP(rule, parsed))
         continue
       }
-      const translation = RuleTranslator.gcpToUnified(rule)
+      const translation = RuleTranslator.gcpToUnified(rule, parsed)
       if (translation.warnings.length > 0) {
         translation.warnings.forEach((w) => {
           const { TranslationWarningSystem } = require('../../translators/TranslationWarningSystem')

--- a/src/lib/providers/gcp/__tests__/CloudArmorClient.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorClient.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { CloudArmorClient } from '../CloudArmorClient'
+import type { CloudArmorSecurityPolicy } from '../../../types/gcp'
+
+// Mock logger
+jest.mock('../../../logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+// getClient().getRequestHeaders() returns a real WHATWG Headers instance in
+// the real library (confirmed against google-auth-library's own source) —
+// mocking it as a plain object here would silently hide the exact bug this
+// suite exists to catch (spreading a Headers instance produces `{}`), so the
+// mock deliberately returns a real `new Headers(...)`, not `{authorization: ...}`.
+const getRequestHeaders = jest.fn<() => Promise<Headers>>()
+jest.mock('google-auth-library', () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getClient: jest.fn<() => Promise<{ getRequestHeaders: typeof getRequestHeaders }>>().mockResolvedValue({
+      getRequestHeaders,
+    }),
+  })),
+}))
+
+// Helper to build Response-like objects
+const makeResponse = (init: { ok: boolean; status: number; statusText?: string; jsonBody?: unknown }): Response => {
+  const body = init.jsonBody
+  return {
+    ok: init.ok,
+    status: init.status,
+    statusText: init.statusText || '',
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response
+}
+
+describe('CloudArmorClient', () => {
+  let client: CloudArmorClient
+  let fetchMock: jest.SpiedFunction<typeof fetch>
+
+  beforeEach(() => {
+    client = new CloudArmorClient('test-project', 'test-policy')
+    fetchMock = jest.spyOn(globalThis, 'fetch')
+    jest.spyOn(CloudArmorClient.prototype as any, 'delay').mockResolvedValue(undefined)
+    getRequestHeaders.mockResolvedValue(
+      new Headers({ authorization: 'Bearer test-access-token', 'x-goog-user-project': 'test-project' }),
+    )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('getAuthHeaders', () => {
+    it('sends the real Authorization header on every request (regression: getRequestHeaders() returns a Headers instance, and spreading one directly silently drops every header)', async () => {
+      const policy: CloudArmorSecurityPolicy = { name: 'test-policy', rules: [] }
+      fetchMock.mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: policy }))
+
+      await client.getPolicy()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+      const headers = requestInit.headers as Record<string, string>
+      expect(headers['authorization']).toBe('Bearer test-access-token')
+      expect(headers['x-goog-user-project']).toBe('test-project')
+    })
+  })
+})

--- a/src/lib/providers/gcp/__tests__/translator.test.ts
+++ b/src/lib/providers/gcp/__tests__/translator.test.ts
@@ -1,6 +1,7 @@
 import { unifiedToGcp, gcpToUnified, unifiedIPToGcp, gcpToUnifiedIP, looksLikeIpRule } from '../translator'
 import type { UnifiedRule, UnifiedIPRule } from '../../../types/unified'
 import type { CloudArmorRule } from '../../../types/gcp'
+import type { CelParseResult } from '../../../translators/CelParser'
 
 describe('unifiedToGcp', () => {
   const baseRule: UnifiedRule = {
@@ -228,5 +229,62 @@ describe('looksLikeIpRule / unifiedIPToGcp / gcpToUnifiedIP', () => {
     // grammar this parser understands (it's an AND of two leaves) — belt
     // and suspenders check that this never misclassifies.
     expect(looksLikeIpRule(rule)).toBe(false)
+  })
+})
+
+describe('preparsed parameter (avoids re-parsing a CEL expression the caller already parsed)', () => {
+  // Each rule's real expression deliberately parses to something OTHER than
+  // what the fake `preparsed` value below claims — if any of these functions
+  // ignored `preparsed` and re-parsed the real string instead, the
+  // assertions here would fail (or, for gcpToUnified, warn "could not be
+  // parsed"). That's what proves the passed-in value is actually being used.
+
+  const nonIpRule: CloudArmorRule = {
+    priority: 1000,
+    match: { expr: { expression: "request.path == '/admin'" } },
+    action: 'deny(403)',
+  }
+
+  const fakeIpParse: CelParseResult = {
+    conditions: [{ field: 'ip', operator: 'eq', value: '9.9.9.9' }],
+    conditionLogic: 'AND',
+  }
+
+  it('looksLikeIpRule trusts a given preparsed result instead of re-parsing', () => {
+    expect(looksLikeIpRule(nonIpRule)).toBe(false) // sanity: real expression is not an ip rule
+    expect(looksLikeIpRule(nonIpRule, fakeIpParse)).toBe(true)
+  })
+
+  it('gcpToUnifiedIP trusts a given preparsed result instead of re-parsing', () => {
+    expect(gcpToUnifiedIP(nonIpRule, fakeIpParse).ip).toBe('9.9.9.9')
+  })
+
+  it('gcpToUnified trusts a given preparsed result instead of re-parsing', () => {
+    const unparseableRule: CloudArmorRule = {
+      priority: 1000,
+      match: { expr: { expression: 'this is not valid cel at all {{{' } },
+      action: 'deny(403)',
+    }
+    const fakeParse: CelParseResult = {
+      conditions: [{ field: 'path', operator: 'eq', value: '/fake' }],
+      conditionLogic: 'AND',
+    }
+
+    const real = gcpToUnified(unparseableRule)
+    expect(real.warnings).toHaveLength(1) // sanity: the real expression genuinely fails to parse
+
+    const { result, warnings } = gcpToUnified(unparseableRule, fakeParse)
+    expect(result.conditions).toEqual(fakeParse.conditions)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('all three still parse for real when no preparsed value is given', () => {
+    const ipRule: CloudArmorRule = {
+      priority: 2000,
+      match: { expr: { expression: "origin.ip == '5.5.5.5'" } },
+      action: 'deny(403)',
+    }
+    expect(looksLikeIpRule(ipRule)).toBe(true)
+    expect(gcpToUnifiedIP(ipRule).ip).toBe('5.5.5.5')
   })
 })

--- a/src/lib/providers/gcp/translator.ts
+++ b/src/lib/providers/gcp/translator.ts
@@ -4,7 +4,7 @@ import type { ActionType } from '../../types/common'
 import type { TranslationResult, TranslationWarning } from '../../translators/TranslationTypes'
 import { TranslationWarningSystem } from '../../translators/TranslationWarningSystem'
 import { CelExpressionBuilder } from '../../translators/CelExpressionBuilder'
-import { parseCelExpression } from '../../translators/CelParser'
+import { parseCelExpression, type CelParseResult } from '../../translators/CelParser'
 import { ipAddressSchema } from '../../schemas/commonSchemas'
 
 /**
@@ -90,14 +90,19 @@ export function unifiedToGcp(rule: UnifiedRule): TranslationResult<CloudArmorRul
   return { result: gcpRule, warnings }
 }
 
-export function gcpToUnified(rule: CloudArmorRule): TranslationResult<UnifiedRule> {
+export function gcpToUnified(rule: CloudArmorRule, preparsed?: CelParseResult | null): TranslationResult<UnifiedRule> {
   const warnings: TranslationWarning[] = []
 
   // doorman only ever *writes* CEL itself, so CelParser understands exactly
   // the grammar subset it can produce — anything else (hand-authored, or
   // from another tool) is reported as unparseable (`null`) rather than
   // guessed at, same as WirefilterParser's own precedent (#178).
-  const parsed = parseCelExpression(rule.match.expr.expression)
+  //
+  // `preparsed` lets a caller that already parsed this same expression once
+  // (e.g. translatePolicy, to classify it via looksLikeIpRule first) pass
+  // that result through instead of re-running the tokenizer/parser on an
+  // identical string — see CloudArmorFirewallService.translatePolicy.
+  const parsed = preparsed !== undefined ? preparsed : parseCelExpression(rule.match.expr.expression)
 
   let conditions: UnifiedRule['conditions'] = []
   let conditionLogic: UnifiedRule['conditionLogic']
@@ -162,17 +167,18 @@ export function gcpToUnified(rule: CloudArmorRule): TranslationResult<UnifiedRul
  * (extra conditions, a different action, rate limiting) is a custom rule
  * that happens to reference `ip`, not an IP-blocking entry.
  */
-export function looksLikeIpRule(rule: CloudArmorRule): boolean {
+export function looksLikeIpRule(rule: CloudArmorRule, preparsed?: CelParseResult | null): boolean {
   if (rule.action !== 'allow' && rule.action !== 'deny(403)') return false
   if (rule.preview) return false
-  const parsed = parseCelExpression(rule.match.expr.expression)
+  const parsed = preparsed !== undefined ? preparsed : parseCelExpression(rule.match.expr.expression)
   if (!parsed || parsed.conditions.length !== 1) return false
   const condition = parsed.conditions[0]!
   return condition.field === 'ip' && (condition.operator === 'eq' || condition.operator === 'in') && !condition.key
 }
 
-export function gcpToUnifiedIP(rule: CloudArmorRule): UnifiedIPRule {
-  const condition = parseCelExpression(rule.match.expr.expression)!.conditions[0]!
+export function gcpToUnifiedIP(rule: CloudArmorRule, preparsed?: CelParseResult | null): UnifiedIPRule {
+  const parsed = preparsed !== undefined ? preparsed : parseCelExpression(rule.match.expr.expression)
+  const condition = parsed!.conditions[0]!
   const value = condition.value
   return {
     id: String(rule.priority),


### PR DESCRIPTION
## Summary

Two bugs found by a whole-epic review of #187 (`/code-review high` against the cumulative diff of #232+#234+#238+#240), both verified against the actual installed libraries / production code before fixing, not just reasoned about:

**1. Every real GCP API call went out with zero auth headers.** `CloudArmorClient.getAuthHeaders()` cast `google-auth-library`'s `getRequestHeaders()` return value straight to `Record<string,string>`. It's actually a real WHATWG `Headers` instance — confirmed by reading the installed `google-auth-library@11.0.2` source. `BaseFirewallClient.makeRequest` merges auth headers with `{...headers}`, and spreading a `Headers` instance produces `{}` (confirmed empirically in Node). Every `addRule`/`patchRule`/`removeRule`/`getPolicy` call was sending no `Authorization` header at all, guaranteeing an immediate 401/403. This is almost certainly why real-GCP-project e2e verification for this epic has never succeeded. Fix: `Object.fromEntries(headers.entries())`.

**2. Every fetched rule's CEL expression was parsed twice.** `translatePolicy` calls `looksLikeIpRule` (which parses the CEL to classify the rule) and then, regardless of branch, `gcpToUnified`/`gcpToUnifiedIP` (which parses the *same* string again to extract conditions) — a full tokenize+recursive-descent+AST-lowering pass, duplicated, on every rule, on every `fetchConfig`/`getChanges` call. Fixed by threading the already-parsed result through via a new optional `preparsed` parameter on all three functions (falls back to parsing when omitted, so every existing call site — including all of `translator.test.ts` — is unchanged). Also removes a non-null assertion in `gcpToUnifiedIP` that used to implicitly trust a second independent parse would succeed identically.

Both fixes are mutation-verified: reverted each, confirmed the new tests fail with a legible message, restored.

## The other 5 findings from the same review

Filed as issues rather than fixed here, since each needs a more deliberate design decision than a one-line patch:

- #248 (critical) — a plain single-IP `rules[]` entry gets misclassified as an IP-list entry, causing delete+recreate every sync
- #249 (high) — editing a rule's priority silently never relocates it server-side
- #250 (high) — a translation error mid-sync can discard already-applied rule additions, permanently desyncing local config
- #251 — Operation polling has no fast-path/backoff, compounding with fully-sequential sync loops into slow syncs
- #252 (code-quality) — the new CEL parser hand-duplicates safety-critical logic from the existing Cloudflare wirefilter parser instead of sharing it (with a confirmed precedent: a bug fix already landed in one and not the other)

## Test plan

- [x] `pnpm compile` — clean
- [x] `pnpm test` — 1681/1681 passing across 91 suites (one unrelated pre-existing flaky test, `CloudflarePerformanceBenchmarks.test.ts`'s timing assertion, confirmed passing 19/19 in isolation)
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] New regression test for the auth-header fix mocks `google-auth-library` returning a *real* `Headers` instance (not a plain object) — a plain-object mock would not have caught the original bug
- [x] New regression tests for the double-parse fix prove the `preparsed` value is actually used (not just present) by passing a deliberately-wrong parse result and asserting the output reflects it
- [x] Both fixes mutation-verified (temporarily reverted, confirmed new tests fail, restored)