### PR TITLE
fix(gcp): a single-IP rules[] entry no longer gets misclassified as an ips[] entry

### DIFF
--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -77,7 +77,18 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
     }
   }
 
-  private translatePolicy(policy: { rules: CloudArmorRule[] }): { rules: UnifiedRule[]; ips: UnifiedIPRule[] } {
+  /**
+   * `localRuleIds` (ids present in the local config's `rules[]`, i.e.
+   * `getChanges`'s caller) breaks the classification tie described below in
+   * the local config's favor — see #248. `fetchConfig` has no local config
+   * to check against and passes nothing, preserving its prior CEL-shape-only
+   * behavior (there's no existing classification to conflict with when
+   * building a config from scratch).
+   */
+  private translatePolicy(
+    policy: { rules: CloudArmorRule[] },
+    localRuleIds?: ReadonlySet<string>,
+  ): { rules: UnifiedRule[]; ips: UnifiedIPRule[] } {
     const rules: UnifiedRule[] = []
     const ips: UnifiedIPRule[] = []
 
@@ -86,7 +97,18 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
       // whichever translation follows it, rather than each re-parsing the
       // same CEL expression from scratch.
       const parsed = parseCelExpression(rule.match.expr.expression)
-      if (RuleTranslator.gcpLooksLikeIpRule(rule, parsed)) {
+
+      // Cloud Armor has no field distinguishing "IP-blocking entry" from
+      // "ordinary rule that happens to match on ip" — a single ip==X
+      // condition under `rules[]` produces CEL byte-identical to a real
+      // `ips[]` entry (#248). looksLikeIpRule can't resolve that ambiguity
+      // from CEL shape alone, so when the caller knows this rule's priority
+      // already exists in local `rules[]`, that wins the tie regardless of
+      // shape — otherwise a hand-authored single-IP rule gets silently
+      // reclassified into `ips[]` on every fetch, which getChanges then
+      // reads as "delete the rule, create an orphaned IP entry," forever.
+      const isKnownLocalRule = localRuleIds?.has(String(rule.priority)) ?? false
+      if (!isKnownLocalRule && RuleTranslator.gcpLooksLikeIpRule(rule, parsed)) {
         ips.push(RuleTranslator.gcpToUnifiedIP(rule, parsed))
         continue
       }
@@ -291,7 +313,8 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
     try {
       logger.debug('Fetching existing Cloud Armor configuration')
       const policy = await this.client.getPolicy()
-      const { rules: remoteRules, ips: remoteIPs } = this.translatePolicy(policy)
+      const localRuleIds = new Set(config.rules.map((r) => r.id).filter((id): id is string => id !== undefined))
+      const { rules: remoteRules, ips: remoteIPs } = this.translatePolicy(policy, localRuleIds)
 
       // Diff in unified space, normalizing both sides through gcpToUnified —
       // same reasoning as every other provider's getChanges: comparing a

--- a/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
@@ -1,7 +1,8 @@
 import { CloudArmorFirewallService } from '../CloudArmorFirewallService'
 import { CloudArmorClient } from '../CloudArmorClient'
+import { unifiedToGcp } from '../translator'
 import type { CloudArmorRule, CloudArmorSecurityPolicy } from '../../../types/gcp'
-import type { UnifiedConfig } from '../../../types/unified'
+import type { UnifiedConfig, UnifiedRule } from '../../../types/unified'
 
 jest.mock('../../../logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
@@ -148,6 +149,38 @@ describe('CloudArmorFirewallService', () => {
       expect(changes.rulesToAdd).toHaveLength(0)
       expect(changes.rulesToUpdate).toHaveLength(1)
       expect(changes.rulesToDelete).toHaveLength(0)
+    })
+
+    it('does not misclassify a rules[]-authored single-IP rule as an ips[] entry (#248)', async () => {
+      // A plain custom rule whose one condition happens to be on `ip` — CEL-
+      // identical to what unifiedIPToGcp would produce for an ips[] entry,
+      // since Cloud Armor has no server-side field distinguishing the two.
+      const singleIpRule: UnifiedRule = {
+        id: '1000',
+        name: 'Block known bad actor',
+        description: 'Block known bad actor',
+        enabled: true,
+        conditions: [{ field: 'ip', operator: 'eq', value: '198.51.100.7' }],
+        action: { type: 'deny' },
+        priority: 1000,
+      }
+      // Built via the real translator (not hand-typed CEL) so the remote
+      // fixture is exactly what a prior sync of `singleIpRule` would have
+      // produced — the same round-trip the bug report reproduced.
+      const remoteRule: CloudArmorRule = unifiedToGcp(singleIpRule).result
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([remoteRule]))
+
+      const config: UnifiedConfig = { ...baseConfig, rules: [singleIpRule] }
+      const changes = await service.getChanges(config)
+
+      expect(changes.hasChanges).toBe(false)
+      expect(changes.rulesToAdd).toHaveLength(0)
+      expect(changes.rulesToUpdate).toHaveLength(0)
+      expect(changes.rulesToDelete).toHaveLength(0)
+      // The bug's signature: the remote rule reclassified as an orphaned IP
+      // entry with no local ips[] match, queued for deletion.
+      expect(changes.ipsToAdd).toHaveLength(0)
+      expect(changes.ipsToDelete).toHaveLength(0)
     })
   })
 
@@ -312,6 +345,36 @@ describe('CloudArmorFirewallService', () => {
       expect(result.rulesAdded).toBe(1)
       expect(result.errors).toHaveLength(1)
       expect(result.errors![0]).toContain('boom')
+    })
+
+    it('does not delete+recreate a rules[]-authored single-IP rule on a second sync (#248)', async () => {
+      const singleIpRule: UnifiedRule = {
+        id: '1000',
+        name: 'Block known bad actor',
+        description: 'Block known bad actor',
+        enabled: true,
+        conditions: [{ field: 'ip', operator: 'eq', value: '198.51.100.7' }],
+        action: { type: 'deny' },
+        priority: 1000,
+      }
+      // The remote state a first sync of this exact rule would have left
+      // behind — built via the real translator, not hand-typed CEL.
+      const remoteRule: CloudArmorRule = unifiedToGcp(singleIpRule).result
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([remoteRule]))
+      const addRuleSpy = jest.spyOn(client, 'addRule')
+      const removeRuleSpy = jest.spyOn(client, 'removeRule')
+      const patchRuleSpy = jest.spyOn(client, 'patchRule')
+
+      const result = await service.syncRules({ ...baseConfig, rules: [singleIpRule] })
+
+      expect(result.success).toBe(true)
+      expect(result.rulesAdded).toBe(0)
+      expect(result.rulesDeleted).toBe(0)
+      expect(result.ipsAdded).toBe(0)
+      expect(result.ipsDeleted).toBe(0)
+      expect(addRuleSpy).not.toHaveBeenCalled()
+      expect(removeRuleSpy).not.toHaveBeenCalled()
+      expect(patchRuleSpy).not.toHaveBeenCalled()
     })
 
     it('does not call addRule/patchRule/removeRule when the user cancels the confirmation', async () => {


### PR DESCRIPTION
## Summary

Closes #248 — the critical finding from the #187 epic-wide review that #253 filed rather than fixed inline, since it needed an actual design decision.

Cloud Armor has no field distinguishing "IP-blocking entry" from "ordinary rule that happens to match on ip" — a `rules[]` entry with a single `field: 'ip'` condition produces CEL byte-identical to what `unifiedIPToGcp` produces for a real `ips[]` entry (`CelExpressionBuilder` routes a single condition through with no wrapping either way). `looksLikeIpRule` can only inspect the serialized CEL shape, which is provably non-injective given doorman's own translation code — it can't tell these two authoring paths apart.

Previously this meant `translatePolicy` silently reclassified such a rule into the `ips[]` bucket on every fetch. `getChanges` then read that as "the local rule is missing remotely → add it" **and** "there's an orphaned remote IP entry → delete it." `syncRules` deletes before adds, so every sync destroyed the rule and rebuilt it at a new priority — forever, with a real (if brief) enforcement gap each time, and self-perpetuating since the recreated rule has the identical shape.

## Fix

`getChanges` now passes the local config's `rules[]` ids into `translatePolicy`. A remote rule whose priority matches an existing local `rules[]` id wins the classification tie regardless of CEL shape — the local config is the tie-breaker whenever one exists. `fetchConfig` (no local config to reconcile against — `doorman pull`/`init`, building a config from scratch) is intentionally unaffected: the bug is specifically about a remote rule's classification *conflicting* with an existing local one, not about how a from-scratch fetch represents an inherently ambiguous rule.

## Test plan

- [x] Two new regression tests (`getChanges`, `syncRules`) reproduce the exact collision from #248: a single-IP `UnifiedRule` authored under `rules[]`, translated once via the real translator (not hand-typed CEL) to build the remote fixture — exactly what a prior sync would have left behind.
- [x] Both mutation-verified: reverting the fix makes the `getChanges` test fail on a clear assertion mismatch, and makes the `syncRules` test hang/timeout (the delete+recreate cycle genuinely fires and tries a real network call) — restoring the fix fixes both.
- [x] `pnpm compile` — clean
- [x] `pnpm test` — 1683/1683 passing across 91 suites (one unrelated one-off timing flake on re-run, confirmed by a clean re-run of the full suite immediately after)
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)