### PR TITLE
fix(gcp): relocate a rule via remove+add, not patch, when its priority changes

### DIFF
--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -235,17 +235,36 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
 
       let rulesUpdated = 0
       for (const rule of rulesToUpdate) {
-        const priority = priorityOf(rule.id)
-        if (priority === undefined) continue
+        const oldPriority = priorityOf(rule.id)
+        if (oldPriority === undefined) continue
+
         const translation = RuleTranslator.unifiedToGcp(rule)
         translation.warnings.forEach((w) => warnings.push(w.message))
+
+        // Cloud Armor has no "change priority" operation (see types/gcp.ts's
+        // CloudArmorRule doc comment) — a PATCH is always addressed by, and
+        // can only touch, the rule already at oldPriority; a body that also
+        // carries a different desired priority doesn't relocate it, the
+        // field is just ignored server-side. Route a priority change through
+        // remove-then-add-at-the-new-priority instead, the one relocation
+        // path the real API supports, with the same idRemappings bookkeeping
+        // a brand-new rule gets — this rule's addressing id is changing too
+        // (#249).
+        const relocating = rule.priority !== undefined && rule.priority !== oldPriority
         try {
-          logger.debug(`Updating Cloud Armor rule at priority ${priority}`)
-          await this.client.patchRule(priority, translation.result)
+          if (relocating) {
+            logger.debug(`Relocating Cloud Armor rule from priority ${oldPriority} to ${rule.priority}`)
+            await this.client.removeRule(oldPriority)
+            await this.client.addRule(translation.result)
+            idRemappings.push({ oldId: rule.id, newId: String(rule.priority), name: rule.name })
+          } else {
+            logger.debug(`Updating Cloud Armor rule at priority ${oldPriority}`)
+            await this.client.patchRule(oldPriority, translation.result)
+          }
           rulesUpdated++
         } catch (error) {
-          logger.error(`Failed to update Cloud Armor rule at priority ${priority}:`, error)
-          errors.push(describeError(`Failed to update rule at priority ${priority}`, error))
+          logger.error(`Failed to update Cloud Armor rule at priority ${oldPriority}:`, error)
+          errors.push(describeError(`Failed to update rule at priority ${oldPriority}`, error))
         }
       }
 

--- a/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
@@ -300,6 +300,42 @@ describe('CloudArmorFirewallService', () => {
       expect(patchRuleSpy).toHaveBeenCalledWith(1000, expect.objectContaining({ priority: 1000 }))
     })
 
+    it('relocates a rule via remove+add, not patch, when its priority changes (#249)', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule])) // remote: priority 1000
+      const patchRuleSpy = jest.spyOn(client, 'patchRule').mockResolvedValue(undefined)
+      const removeRuleSpy = jest.spyOn(client, 'removeRule').mockResolvedValue(undefined)
+      const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)
+
+      // Same rule, id unchanged, but the user moved it to priority 2000 —
+      // Cloud Armor has no PATCH-based relocation (see types/gcp.ts), so
+      // this can only be honored as remove(1000) + add(...priority: 2000).
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            id: '1000',
+            name: 'Block admin',
+            description: 'Block admin',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/admin' }],
+            action: { type: 'deny' },
+            priority: 2000,
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      expect(result.success).toBe(true)
+      expect(result.rulesUpdated).toBe(1)
+      expect(patchRuleSpy).not.toHaveBeenCalled()
+      expect(removeRuleSpy).toHaveBeenCalledWith(1000)
+      expect(addRuleSpy).toHaveBeenCalledTimes(1)
+      const addedRule = addRuleSpy.mock.calls[0]![0] as CloudArmorRule
+      expect(addedRule.priority).toBe(2000)
+      expect(result.idRemappings).toContainEqual({ oldId: '1000', newId: '2000', name: 'Block admin' })
+    })
+
     it('adds a new IP rule with an assigned priority', async () => {
       jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
       const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)


### PR DESCRIPTION
## Summary

Closes #249 — another finding from the #187 epic-wide review, filed separately in #253 since it needed a real design decision rather than a one-line patch.

Cloud Armor has no "change priority" operation (see the `CloudArmorRule` doc comment in `types/gcp.ts`) — a PATCH request is always addressed by, and can only touch, the rule already at its *current* priority. When a user edited only a rule's `priority` in local config (leaving `id` unchanged, the natural edit), the update path addressed the PATCH at the *old* priority (looked up via the unchanged `id`) while the request *body* carried the *new* desired priority — a shape the real API doesn't support relocating via, so the priority field in the body was silently ignored server-side. The rule never actually moved, but doorman's local state and `rulesUpdated` bookkeeping believed it had, so `getChanges` re-detected the identical "needs update" diff on every subsequent sync, forever.

## Fix

The `rulesToUpdate` loop now detects when a matched rule's desired priority differs from where it currently lives (the old priority, derived from its `id`) and routes that case through `removeRule(oldPriority)` + `addRule(...)` at the new priority instead of `patchRule` — the one relocation path the real API supports — with the same `idRemappings` bookkeeping a brand-new rule gets, since this rule's addressing id is changing too. Ordinary content-only updates (priority unchanged) still go through `patchRule` exactly as before — no behavior change there.

## Test plan

- [x] New regression test reproduces the exact bug: a rule matched by `id` but with local `priority` (2000) differing from remote (1000). Asserts `patchRule` is never called, `removeRule`/`addRule` fire with the correct old/new priorities, and `idRemappings` correctly maps the old id to the new one.
- [x] Mutation-verified: forcing the relocation branch off reproduces the original bug exactly — the mock capture shows `patchRule` called at the old address (1000) with the new priority (2000) silently baked into a body the real API would ignore. Restoring the fix makes the test pass again.
- [x] `pnpm compile` — clean
- [x] `pnpm test` — 1684/1684 passing across 91 suites (one unrelated pre-existing flaky test, confirmed passing in isolation)
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)