### PR TITLE
fix(gcp): isolate per-rule translation failures during sync instead of aborting the whole batch

### DIFF
--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -220,9 +220,16 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
       let rulesAdded = 0
       for (const rule of rulesToAdd) {
         const priority = rule.priority ?? assignPriority()
-        const translation = RuleTranslator.unifiedToGcp({ ...rule, priority })
-        translation.warnings.forEach((w) => warnings.push(w.message))
+        // Translation happens inside the try, not before it: it can throw
+        // (CelExpressionBuilder rejects unsupported fields, parseWindowToSeconds
+        // rejects a malformed rate-limit window) just as easily as the network
+        // call can fail, and a throw here needs the exact same per-item
+        // isolation — recorded in errors[], loop moves on — rather than
+        // escaping to the outer catch and discarding every rule already
+        // added by an earlier iteration in this same loop (#250).
         try {
+          const translation = RuleTranslator.unifiedToGcp({ ...rule, priority })
+          translation.warnings.forEach((w) => warnings.push(w.message))
           logger.debug(`Adding Cloud Armor rule at priority ${priority}: ${translation.result.description}`)
           await this.client.addRule(translation.result)
           rulesAdded++
@@ -238,20 +245,23 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
         const oldPriority = priorityOf(rule.id)
         if (oldPriority === undefined) continue
 
-        const translation = RuleTranslator.unifiedToGcp(rule)
-        translation.warnings.forEach((w) => warnings.push(w.message))
-
-        // Cloud Armor has no "change priority" operation (see types/gcp.ts's
-        // CloudArmorRule doc comment) — a PATCH is always addressed by, and
-        // can only touch, the rule already at oldPriority; a body that also
-        // carries a different desired priority doesn't relocate it, the
-        // field is just ignored server-side. Route a priority change through
-        // remove-then-add-at-the-new-priority instead, the one relocation
-        // path the real API supports, with the same idRemappings bookkeeping
-        // a brand-new rule gets — this rule's addressing id is changing too
-        // (#249).
-        const relocating = rule.priority !== undefined && rule.priority !== oldPriority
+        // Translation (and the relocation check that depends on it) happens
+        // inside the try — see the identical reasoning on the rulesToAdd
+        // loop above (#250).
         try {
+          const translation = RuleTranslator.unifiedToGcp(rule)
+          translation.warnings.forEach((w) => warnings.push(w.message))
+
+          // Cloud Armor has no "change priority" operation (see types/gcp.ts's
+          // CloudArmorRule doc comment) — a PATCH is always addressed by, and
+          // can only touch, the rule already at oldPriority; a body that also
+          // carries a different desired priority doesn't relocate it, the
+          // field is just ignored server-side. Route a priority change through
+          // remove-then-add-at-the-new-priority instead, the one relocation
+          // path the real API supports, with the same idRemappings bookkeeping
+          // a brand-new rule gets — this rule's addressing id is changing too
+          // (#249).
+          const relocating = rule.priority !== undefined && rule.priority !== oldPriority
           if (relocating) {
             logger.debug(`Relocating Cloud Armor rule from priority ${oldPriority} to ${rule.priority}`)
             await this.client.removeRule(oldPriority)
@@ -271,8 +281,10 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
       let ipsAdded = 0
       for (const ip of ipsToAdd) {
         const priority = priorityOf(ip.id) ?? assignPriority()
-        const translated = RuleTranslator.unifiedIPToGcp(ip, priority)
+        // Translation inside the try — unifiedIPToGcp throws on an invalid
+        // IP/CIDR, same isolation reasoning as rulesToAdd above (#250).
         try {
+          const translated = RuleTranslator.unifiedIPToGcp(ip, priority)
           logger.debug(`Adding Cloud Armor IP rule at priority ${priority}: ${ip.ip}`)
           await this.client.addRule(translated)
           ipsAdded++

--- a/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
@@ -383,6 +383,45 @@ describe('CloudArmorFirewallService', () => {
       expect(result.errors![0]).toContain('boom')
     })
 
+    it('a translation failure on one rule does not discard another rule already added in the same sync (#250)', async () => {
+      jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([]))
+      const addRuleSpy = jest.spyOn(client, 'addRule').mockResolvedValue(undefined)
+
+      const config: UnifiedConfig = {
+        ...baseConfig,
+        rules: [
+          {
+            name: 'Rule A (translatable)',
+            enabled: true,
+            conditions: [{ field: 'path', operator: 'eq', value: '/a' }],
+            action: { type: 'deny' },
+          },
+          {
+            // `region` has no CEL mapping in CelExpressionBuilder — throws
+            // during translation, not during the network call.
+            name: 'Rule B (untranslatable)',
+            enabled: true,
+            conditions: [{ field: 'region', operator: 'eq', value: 'US' }],
+            action: { type: 'deny' },
+          },
+        ],
+      }
+
+      const result = await service.syncRules(config)
+
+      // syncRules must return a normal result, not throw — a thrown error
+      // here means the caller (src/commands/sync.ts) never reaches
+      // applySyncResultToConfig, leaving the local config permanently
+      // desynced from the rule that DID get created remotely.
+      expect(result.success).toBe(false)
+      expect(result.rulesAdded).toBe(1)
+      expect(addRuleSpy).toHaveBeenCalledTimes(1)
+      expect(result.idRemappings).toHaveLength(1)
+      expect(result.idRemappings![0]!.name).toBe('Rule A (translatable)')
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors![0]).toContain('Rule B (untranslatable)')
+    })
+
     it('does not delete+recreate a rules[]-authored single-IP rule on a second sync (#248)', async () => {
       const singleIpRule: UnifiedRule = {
         id: '1000',


### PR DESCRIPTION
## Summary

Closes #250 — another finding from the #187 epic-wide review, filed separately in #253 since it needed a design decision (translate-up-front vs. per-item isolation) rather than a one-line patch.

The `rulesToAdd`, `rulesToUpdate`, and `ipsToAdd` loops in `syncRules` called their translator (`unifiedToGcp`/`unifiedIPToGcp`) *before* entering that iteration's own try/catch. Translation can throw synchronously and non-recoverably (`CelExpressionBuilder` rejects unsupported condition fields like `region`/`city`/`port`/`scheme`; `parseWindowToSeconds` rejects a malformed rate-limit window) — just as easily as the network call can fail, but without the same per-item isolation. A throw there escaped both the per-item catch and the loop entirely, landing in `syncRules`' outer catch, which discarded it into a brand-new generic error — losing `rulesAdded`, `idRemappings`, and `errors[]` already accumulated from earlier items in the same loop that had already been created for real against Cloud Armor.

Worse: since `syncRules` threw instead of returning a `SyncResult`, callers (`src/commands/sync.ts`) never reached `applySyncResultToConfig` — the local config's write-back of `idRemappings`/version — leaving it permanently desynced from a rule that was live remotely but whose id the local file never learned.

## Fix

Moved translation inside each loop's try, alongside the network call, so a translation throw is caught and recorded in `errors[]` exactly like a mutation failure — the loop moves on to the next item instead of escaping, and `syncRules` always returns a normal `SyncResult` for this scenario. `ipsToUpdate` already translated inside its try and needed no change.

This chooses per-item isolation over Vercel/Fastly's "translate the whole batch up front" pattern — the acceptance criteria specifically wants a translatable rule's `addRule` call to still happen even when a *different* rule in the same batch fails to translate, which an up-front `.map()` (throwing before any mutation runs at all) can't provide.

## Test plan

- [x] New regression test: a `rulesToAdd` batch with one translatable rule and one whose condition uses an unsupported field, asserting the translatable rule's `addRule` call still happened and is reflected in the returned result (`idRemappings`/`rulesAdded`), rather than the whole sync throwing.
- [x] Mutation-verified: reverting the fix (moving translation back outside the try) reproduces the exact original failure mode — `syncRules` throws the generic wrapped error instead of returning a result. Restoring the fix passes again.
- [x] `pnpm compile` — clean
- [x] `pnpm test` — 1685/1685 passing across 91 suites
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)