### PR TITLE
feat(cloudflare): add managed rule group support

### DIFF
--- a/src/lib/providers/BaseFirewallService.ts
+++ b/src/lib/providers/BaseFirewallService.ts
@@ -231,6 +231,29 @@ export abstract class BaseFirewallService implements IFirewallProvider {
   }
 
   /**
+   * Guards the "fails clearly rather than silently no-op'ing" half of #183:
+   * a provider that doesn't implement managed rule groups (every provider
+   * except Cloudflare, currently) throws a clear, specific error the moment
+   * a config declares any, instead of `getChanges`/`syncRules` just
+   * ignoring `config.managedRules` and reporting a clean diff/sync.
+   *
+   * Called explicitly from each non-Cloudflare provider's `getChanges`
+   * rather than wired through `IFirewallProvider.validateConfig()` —
+   * nothing in the CLI command layer actually calls `validateConfig()`
+   * today (a separate, pre-existing gap, out of scope for #183), so gating
+   * here is what actually protects a real `sync`/`diff`/`status` run.
+   */
+  protected assertManagedRulesSupported(config: UnifiedConfig): void {
+    if (!config.managedRules || config.managedRules.length === 0) return
+    if (this.getSupportedFeatures().supportsManagedRules) return
+
+    throw new Error(
+      `${this.name} does not support managed rule groups, but this config declares ${config.managedRules.length}. ` +
+        'Remove `managedRules` from the config, or switch to a provider that supports them (currently Cloudflare only).',
+    )
+  }
+
+  /**
    * Validate rule count against provider limits
    */
   protected validateRuleCount(count: number, limit: number | undefined): void {
@@ -302,6 +325,12 @@ export abstract class BaseFirewallService implements IFirewallProvider {
       logger.info(`  IPs added: ${result.ipsAdded}`)
       logger.info(`  IPs updated: ${result.ipsUpdated}`)
       logger.info(`  IPs deleted: ${result.ipsDeleted}`)
+    }
+
+    if (result.managedRulesAdded !== undefined) {
+      logger.info(`  Managed rule groups added: ${result.managedRulesAdded}`)
+      logger.info(`  Managed rule groups updated: ${result.managedRulesUpdated}`)
+      logger.info(`  Managed rule groups deleted: ${result.managedRulesDeleted}`)
     }
 
     if (result.version) {

--- a/src/lib/providers/IFirewallProvider.ts
+++ b/src/lib/providers/IFirewallProvider.ts
@@ -52,6 +52,9 @@ export interface SyncResult {
   ipsAdded?: number
   ipsUpdated?: number
   ipsDeleted?: number
+  managedRulesAdded?: number
+  managedRulesUpdated?: number
+  managedRulesDeleted?: number
   version?: number
   /** Provider's post-sync timestamp, paired with `version` for local
    * config metadata write-back. Optional — not every provider tracks one. */
@@ -100,6 +103,9 @@ export interface ChangeSet {
   ipsToAdd?: import('../types/unified').UnifiedIPRule[]
   ipsToUpdate?: import('../types/unified').UnifiedIPRule[]
   ipsToDelete?: import('../types/unified').UnifiedIPRule[]
+  managedRulesToAdd?: import('../types/unified').UnifiedManagedRuleGroup[]
+  managedRulesToUpdate?: import('../types/unified').UnifiedManagedRuleGroup[]
+  managedRulesToDelete?: import('../types/unified').UnifiedManagedRuleGroup[]
   /** The provider's current remote version, if it tracks one. Lets a caller
    * detect version-only drift (e.g. another tool synced since the local
    * config was last saved) even when there are no rule/IP changes to make
@@ -117,14 +123,13 @@ export interface FeatureSet {
   supportsRateLimiting: boolean
   /**
    * Whether the provider offers vendor-managed rule groups (Cloudflare
-   * Managed Rulesets, AWS Managed Rules, GCP preconfigured WAF, …).
+   * Managed Rulesets, AWS Managed Rules, GCP preconfigured WAF, …) and can
+   * act on `UnifiedConfig.managedRules[]` (#183).
    *
-   * **Reserved — declared but not yet actionable.** Nothing consumes this
-   * today because `UnifiedConfig` has no surface for declaring *which*
-   * managed rulesets to enable or how to override individual rules within
-   * them. Kept as the capability signal the config surface will gate on
-   * once that lands; see the managed-rule-groups issue. Do not treat a
-   * `true` here as meaning doorman can currently manage those rules.
+   * Gated by `BaseFirewallService.assertManagedRulesSupported`: a provider
+   * that declares `false` here throws a clear error from `getChanges`/
+   * `syncRules` if a config declares any `managedRules`, rather than
+   * silently no-op'ing. Only Cloudflare implements this today.
    */
   supportsManagedRules: boolean
   supportsGeoBlocking: boolean

--- a/src/lib/providers/cloudflare/CloudflareClient.ts
+++ b/src/lib/providers/cloudflare/CloudflareClient.ts
@@ -428,6 +428,47 @@ export class CloudflareClient extends BaseFirewallClient {
   }
 
   /**
+   * Get or create the managed-rules (execute) ruleset (#183).
+   *
+   * Deployed rulesets (Cloudflare Managed Ruleset, OWASP CRS, etc.) live in
+   * their own phase entrypoint, `http_request_firewall_managed`, entirely
+   * separate from the custom-rules ruleset above — Cloudflare evaluates the
+   * two phases in a fixed order (custom rules always run first, zone-wide,
+   * not configurable), so the two rulesets never interact or need
+   * cross-referencing.
+   *
+   * Looked up by `phase` alone, not `phase` + `kind` like the custom-rules
+   * lookup above: a zone can only have one entrypoint ruleset bound to a
+   * given phase, so `phase` alone is already a unique match — this avoids
+   * depending on the exact `kind` value Cloudflare assigns to a zone-owned
+   * phase entrypoint ruleset, which wasn't confirmed against a live API
+   * response while building this (see #183's implementation notes). The
+   * `kind: 'zone'` used on create is the standard Rulesets API convention
+   * for a customer-owned phase entrypoint; verify this against a real zone
+   * or the mock server before trusting it in production.
+   */
+  public async getOrCreateManagedRulesRuleset(): Promise<CloudflareRuleset> {
+    logger.debug('Looking for existing managed-rules ruleset')
+
+    const rulesets = await this.listRulesets()
+    const existingRuleset = rulesets.find((rs) => rs.phase === 'http_request_firewall_managed')
+
+    if (existingRuleset) {
+      logger.debug(`Found existing managed-rules ruleset: ${existingRuleset.id}`)
+      return existingRuleset
+    }
+
+    logger.info('No existing managed-rules ruleset found, creating new one')
+    return this.createRuleset({
+      name: 'Doorman Managed Rules',
+      kind: 'zone',
+      phase: 'http_request_firewall_managed',
+      description: 'Managed rule groups deployed by Doorman',
+      rules: [],
+    })
+  }
+
+  /**
    * Verify API credentials and connectivity
    */
   public async verifyCredentials(): Promise<boolean> {

--- a/src/lib/providers/cloudflare/CloudflareFirewallService.ts
+++ b/src/lib/providers/cloudflare/CloudflareFirewallService.ts
@@ -8,7 +8,7 @@ import { CloudflareErrorHandler } from './CloudflareErrorHandler'
 import { cloudflareErrors } from '../../errors'
 import { sortRulesByPriority } from '../../utils/sortRulesByPriority'
 import type { ProviderType, SyncOptions, SyncResult, ChangeSet, FeatureSet, HealthScore } from '../IFirewallProvider'
-import type { UnifiedConfig, UnifiedRule, UnifiedIPRule } from '../../types/unified'
+import type { UnifiedConfig, UnifiedRule, UnifiedIPRule, UnifiedManagedRuleGroup } from '../../types/unified'
 import type { CloudflareRule } from '../../types/cloudflare'
 // CloudflareRuleset imported for future caching use
 // import type { CloudflareRuleset } from '../../types/cloudflare'
@@ -167,6 +167,26 @@ export class CloudflareFirewallService extends BaseFirewallService {
         }
       }
 
+      // Managed rule groups (#183) live in the separate managed-rules phase
+      // entrypoint ruleset, not the custom-rules one processed above.
+      const managedRules: UnifiedManagedRuleGroup[] = []
+      try {
+        const managedRuleset = await this.client.getOrCreateManagedRulesRuleset()
+        for (const rule of managedRuleset.rules) {
+          if (!rule || rule.action !== 'execute') continue
+          const translation = RuleTranslator.cloudflareToUnifiedManagedRuleGroup(rule)
+          managedRules.push(translation.result)
+          if (translation.warnings.length > 0) {
+            translation.warnings.forEach((w) => {
+              const { TranslationWarningSystem } = require('../../translators/TranslationWarningSystem')
+              translationWarnings.push(TranslationWarningSystem.formatWarning(w))
+            })
+          }
+        }
+      } catch (error) {
+        logger.warn(`Failed to fetch managed rule groups: ${error instanceof Error ? error.message : String(error)}`)
+      }
+
       if (translationWarnings.length > 0) {
         logger.warn('Translation warnings detected:')
         translationWarnings.forEach((warning) => logger.warn(warning))
@@ -190,6 +210,7 @@ export class CloudflareFirewallService extends BaseFirewallService {
         },
         rules,
         ips,
+        managedRules,
         metadata: {
           version: parseInt(ruleset.version, 10),
           updatedAt: ruleset.last_updated,
@@ -232,6 +253,9 @@ export class CloudflareFirewallService extends BaseFirewallService {
         ipsAdded: dryRunResult.changes.ipsToAdd?.length || 0,
         ipsUpdated: dryRunResult.changes.ipsToUpdate?.length || 0,
         ipsDeleted: dryRunResult.changes.ipsToDelete?.length || 0,
+        managedRulesAdded: dryRunResult.changes.managedRulesToAdd?.length || 0,
+        managedRulesUpdated: dryRunResult.changes.managedRulesToUpdate?.length || 0,
+        managedRulesDeleted: dryRunResult.changes.managedRulesToDelete?.length || 0,
         warnings: dryRunResult.warnings,
       }
     }
@@ -399,6 +423,40 @@ export class CloudflareFirewallService extends BaseFirewallService {
       rules: cloudflareRules,
     })
 
+    // Managed rule groups (#183) live in a separate ruleset/phase, written
+    // independently of the custom-rules ruleset above. Only touched when the
+    // config actually declares `managedRules` — mirrors the `if
+    // (config.managedRules)` gate in getChanges, so a config that never
+    // opts in never has this ruleset created or modified, and an explicit
+    // `managedRules: []` clears it (full-array replace, same semantics as
+    // custom rules).
+    let managedRulesAdded = 0
+    let managedRulesUpdated = 0
+    let managedRulesDeleted = 0
+    if (config.managedRules) {
+      const managedCloudflareRules: CloudflareRule[] = []
+      for (const group of config.managedRules) {
+        const translation = RuleTranslator.unifiedManagedRuleGroupToCloudflare(group)
+        managedCloudflareRules.push(translation.result)
+
+        if (translation.warnings.length > 0) {
+          translation.warnings.forEach((w) => {
+            const { TranslationWarningSystem } = require('../../translators/TranslationWarningSystem')
+            logger.warn(TranslationWarningSystem.formatWarning(w))
+          })
+        }
+      }
+
+      const managedRuleset = await this.client.getOrCreateManagedRulesRuleset()
+      await this.client.updateRuleset(managedRuleset.id, {
+        rules: managedCloudflareRules,
+      })
+
+      managedRulesAdded = dryRunResult.changes.managedRulesToAdd?.length || 0
+      managedRulesUpdated = dryRunResult.changes.managedRulesToUpdate?.length || 0
+      managedRulesDeleted = dryRunResult.changes.managedRulesToDelete?.length || 0
+    }
+
     const result: SyncResult = {
       success: true,
       // The actual write below is a full-ruleset replace, not incremental
@@ -415,6 +473,9 @@ export class CloudflareFirewallService extends BaseFirewallService {
       ipsAdded,
       ipsUpdated,
       ipsDeleted,
+      managedRulesAdded,
+      managedRulesUpdated,
+      managedRulesDeleted,
       version: parseInt(updatedRuleset.version, 10),
       warnings: dryRunResult.warnings?.length ? dryRunResult.warnings : undefined,
     }
@@ -472,6 +533,56 @@ export class CloudflareFirewallService extends BaseFirewallService {
       ipDiff = this.optimizer.diffIPRules(config.ips, remoteIPs)
     }
 
+    // Managed rule groups (#183) live in a separate ruleset/phase entirely
+    // (see CloudflareClient.getOrCreateManagedRulesRuleset), so they're
+    // fetched and diffed independently of custom rules above — but diffed
+    // the *same way* custom rules are: in Cloudflare's native space, not
+    // Unified space. `cloudflareToUnifiedManagedRuleGroup` synthesizes a
+    // `name` from Cloudflare's (always-present) `description` field, so a
+    // local group declared with no explicit `name` would never deep-equal
+    // its own remote round-trip in Unified space — a phantom `toUpdate` on
+    // every sync, forever. Comparing native CloudflareRule objects directly
+    // (translating only the local side, never the remote side) sidesteps
+    // that entirely — see diffCloudflareRules' doc comment for the identical
+    // reasoning applied to custom rules. This also means the diff is
+    // inherently on the *declaration* — the vendor ruleset's actual current
+    // rule contents are never fetched at all — never on content that could
+    // drift out from under it as the vendor updates the ruleset, exactly the
+    // risk the issue calls out.
+    let managedRulesDiff: {
+      toAdd: UnifiedManagedRuleGroup[]
+      toUpdate: UnifiedManagedRuleGroup[]
+      toDelete: UnifiedManagedRuleGroup[]
+    } = { toAdd: [], toUpdate: [], toDelete: [] }
+    if (config.managedRules) {
+      const managedRuleset = await this.client.getOrCreateManagedRulesRuleset()
+      const remoteManagedRules = managedRuleset.rules.filter((r) => r && r.id && r.action === 'execute')
+
+      const localManagedTranslations = config.managedRules.map((group) => ({
+        group,
+        translated: RuleTranslator.unifiedManagedRuleGroupToCloudflare(group).result,
+      }))
+      const groupByTranslatedId = new Map(localManagedTranslations.map((t) => [t.translated.id, t.group]))
+
+      const nativeDiff = this.diffItems<CloudflareRule>(
+        localManagedTranslations.map((t) => t.translated),
+        remoteManagedRules,
+        (a, b) => this.optimizer.cloudflareRulesEqual(a, b),
+      )
+
+      managedRulesDiff = {
+        // Every entry in nativeDiff.toAdd/toUpdate originated from
+        // groupByTranslatedId above (built from the same localManagedTranslations
+        // this diff was fed), so the lookup can't miss.
+        toAdd: nativeDiff.toAdd.map((r) => groupByTranslatedId.get(r.id)!),
+        toUpdate: nativeDiff.toUpdate.map((r) => groupByTranslatedId.get(r.id)!),
+        // No local counterpart for a remote-only group — best-effort
+        // translation back to Unified is fine for a delete preview, same
+        // reasoning as rulesToDelete above.
+        toDelete: nativeDiff.toDelete.map((r) => RuleTranslator.cloudflareToUnifiedManagedRuleGroup(r).result),
+      }
+    }
+
     return {
       rulesToAdd: ruleDiff.toAdd,
       rulesToUpdate: ruleDiff.toUpdate,
@@ -479,6 +590,9 @@ export class CloudflareFirewallService extends BaseFirewallService {
       ipsToAdd: ipDiff.toAdd,
       ipsToUpdate: ipDiff.toUpdate,
       ipsToDelete: ipDiff.toDelete,
+      managedRulesToAdd: managedRulesDiff.toAdd,
+      managedRulesToUpdate: managedRulesDiff.toUpdate,
+      managedRulesToDelete: managedRulesDiff.toDelete,
       version: parseInt(ruleset.version, 10),
       hasChanges:
         ruleDiff.toAdd.length > 0 ||
@@ -486,7 +600,10 @@ export class CloudflareFirewallService extends BaseFirewallService {
         rulesToDelete.length > 0 ||
         ipDiff.toAdd.length > 0 ||
         ipDiff.toUpdate.length > 0 ||
-        ipDiff.toDelete.length > 0,
+        ipDiff.toDelete.length > 0 ||
+        managedRulesDiff.toAdd.length > 0 ||
+        managedRulesDiff.toUpdate.length > 0 ||
+        managedRulesDiff.toDelete.length > 0,
     }
   }
 

--- a/src/lib/providers/cloudflare/CloudflareOptimizer.ts
+++ b/src/lib/providers/cloudflare/CloudflareOptimizer.ts
@@ -292,8 +292,13 @@ export class CloudflareOptimizer {
    * determine wire behavior. `id`/`last_updated`/`version`/`ref`/`categories`
    * are deliberately excluded — they're either identity (already used for
    * matching, not equality) or metadata Cloudflare manages itself.
+   *
+   * Public so CloudflareFirewallService.getChanges can reuse it directly for
+   * managed rule groups (#183) — those diff in native space too, for the
+   * same reason custom rules do (see diffCloudflareRules' doc comment), so
+   * duplicating this comparison would just be two copies to keep in sync.
    */
-  private cloudflareRulesEqual(a: CloudflareRule, b: CloudflareRule): boolean {
+  public cloudflareRulesEqual(a: CloudflareRule, b: CloudflareRule): boolean {
     return (
       a.action === b.action &&
       a.expression === b.expression &&

--- a/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareClient.test.ts
@@ -408,6 +408,118 @@ describe('CloudflareClient', () => {
     })
   })
 
+  describe('getOrCreateManagedRulesRuleset', () => {
+    it('should return existing managed-rules ruleset, matched by phase alone', async () => {
+      // Deliberately a `kind` other than 'zone' — the lookup matches on
+      // `phase` alone (see CloudflareClient.getOrCreateManagedRulesRuleset's
+      // doc comment on why `kind` isn't part of the match), so this proves
+      // the lookup doesn't silently depend on an unverified `kind` value.
+      const existingRuleset: CloudflareRuleset = {
+        id: 'existing-managed-ruleset',
+        name: 'Existing Managed Rules',
+        description: 'Existing Description',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [],
+      }
+
+      const mockResponse: CloudflareAPIResponse<CloudflareRuleset[]> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: [existingRuleset],
+      }
+
+      fetchMock.mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: mockResponse }))
+
+      const result = await client.getOrCreateManagedRulesRuleset()
+
+      expect(result).toEqual(existingRuleset)
+      expect(fetchMock).toHaveBeenCalledTimes(1) // Only list, no create
+    })
+
+    it('should create a new managed-rules ruleset if none exists', async () => {
+      const listResponse: CloudflareAPIResponse<CloudflareRuleset[]> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: [], // No existing rulesets
+      }
+
+      const newRuleset: CloudflareRuleset = {
+        id: 'new-managed-ruleset',
+        name: 'Doorman Managed Rules',
+        description: 'Managed rule groups deployed by Doorman',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [],
+      }
+
+      const createResponse: CloudflareAPIResponse<CloudflareRuleset> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: newRuleset,
+      }
+
+      fetchMock
+        .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: listResponse }))
+        .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: createResponse }))
+
+      const result = await client.getOrCreateManagedRulesRuleset()
+
+      expect(result.name).toBe('Doorman Managed Rules')
+      expect(result.phase).toBe('http_request_firewall_managed')
+      expect(fetchMock).toHaveBeenCalledTimes(2) // List + create
+    })
+
+    it('does not match a custom firewall ruleset (different phase)', async () => {
+      const customRuleset: CloudflareRuleset = {
+        id: 'custom-ruleset',
+        name: 'Doorman Custom Firewall Rules',
+        description: 'Custom firewall rules managed by Doorman',
+        kind: 'custom',
+        phase: 'http_request_firewall_custom',
+        version: '1',
+        rules: [],
+      }
+      const listResponse: CloudflareAPIResponse<CloudflareRuleset[]> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: [customRuleset],
+      }
+      const newRuleset: CloudflareRuleset = {
+        id: 'new-managed-ruleset',
+        name: 'Doorman Managed Rules',
+        description: 'Managed rule groups deployed by Doorman',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [],
+      }
+      const createResponse: CloudflareAPIResponse<CloudflareRuleset> = {
+        success: true,
+        errors: [],
+        messages: [],
+        result: newRuleset,
+      }
+
+      fetchMock
+        .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: listResponse }))
+        .mockResolvedValueOnce(makeResponse({ ok: true, status: 200, jsonBody: createResponse }))
+
+      const result = await client.getOrCreateManagedRulesRuleset()
+
+      // The custom-rules ruleset must not be mistaken for the managed-rules
+      // one — a new one gets created instead.
+      expect(result.id).toBe('new-managed-ruleset')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('verifyCredentials', () => {
     it('should return true for valid credentials', async () => {
       const mockResponse: CloudflareAPIResponse<CloudflareRuleset[]> = {

--- a/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflareFirewallService.test.ts
@@ -67,6 +67,20 @@ describe('CloudflareFirewallService', () => {
       modified_on: '2024-01-01T00:00:00Z',
     })
     jest.spyOn(mockClient, 'getListItems').mockResolvedValue([])
+
+    // Default managed-rules ruleset (#183): empty, so fetchConfig/getChanges/
+    // syncRules tests that don't care about managed rule groups get a fast,
+    // deterministic response instead of falling through to a real network
+    // call. Tests that do care override this with their own mock.
+    jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+      id: 'managed-ruleset-1',
+      name: 'Doorman Managed Rules',
+      description: 'Managed rule groups deployed by Doorman',
+      kind: 'zone',
+      phase: 'http_request_firewall_managed',
+      version: '1',
+      rules: [],
+    })
   })
 
   afterEach(() => {
@@ -1417,6 +1431,247 @@ describe('CloudflareFirewallService', () => {
       expect(changes.rulesToUpdate).toHaveLength(1)
       expect(changes.rulesToDelete).toHaveLength(0)
       expect(changes.hasChanges).toBe(true)
+    })
+  })
+
+  // #183 — managed rule group support. `managedRules` is optional and
+  // independent of `rules`/`ips`: a config that never declares it should
+  // never touch the managed-rules ruleset at all (opt-in, not "empty means
+  // clear"). Every scenario below sets up its own custom-rules mocks rather
+  // than relying on shared fixtures, matching the surrounding describe
+  // blocks' convention.
+  describe('managed rule groups (#183)', () => {
+    const emptyCustomRuleset: CloudflareRuleset = {
+      id: 'ruleset-1',
+      name: 'Test Ruleset',
+      description: 'Test',
+      kind: 'custom',
+      phase: 'http_request_firewall_custom',
+      version: '1',
+      rules: [],
+    }
+
+    it('fetchConfig includes managed rule groups translated from the managed-rules ruleset', async () => {
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Test',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [
+          {
+            id: 'execute-1',
+            action: 'execute',
+            expression: 'true',
+            description: 'OWASP Core Ruleset',
+            enabled: true,
+            action_parameters: { id: 'efb7b8c949ac4650a09736fc376e9aee' } as any,
+          },
+        ],
+      })
+
+      const config = await service.fetchConfig()
+
+      expect(config.managedRules).toHaveLength(1)
+      expect(config.managedRules?.[0]).toEqual({
+        id: 'execute-1',
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+        name: 'OWASP Core Ruleset',
+      })
+    })
+
+    it('getChanges does not touch the managed-rules ruleset when the config does not declare managedRules', async () => {
+      const localConfig: UnifiedConfig = { version: '2.0', provider: 'cloudflare', rules: [], ips: [] }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      const managedRulesSpy = jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset')
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(managedRulesSpy).not.toHaveBeenCalled()
+      expect(changes.managedRulesToAdd).toEqual([])
+      expect(changes.managedRulesToUpdate).toEqual([])
+      expect(changes.managedRulesToDelete).toEqual([])
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('getChanges detects a managed rule group to add when none exists remotely', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [],
+        managedRules: [{ id: 'execute-1', ruleset: 'efb7b8c949ac4650a09736fc376e9aee', enabled: true }],
+      }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Test',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [], // nothing deployed remotely yet
+      })
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(changes.managedRulesToAdd).toHaveLength(1)
+      expect(changes.managedRulesToAdd?.[0]?.ruleset).toBe('efb7b8c949ac4650a09736fc376e9aee')
+      expect(changes.managedRulesToUpdate).toHaveLength(0)
+      expect(changes.managedRulesToDelete).toHaveLength(0)
+      expect(changes.hasChanges).toBe(true)
+    })
+
+    // Regression coverage for a real bug caught while building this test:
+    // diffing managed rule groups by round-tripping the remote rule through
+    // cloudflareToUnifiedManagedRuleGroup (Unified space) synthesizes a
+    // `name` from Cloudflare's `description` field — so a group declared
+    // with no explicit `name` would never deep-equal its own remote
+    // round-trip, showing `toUpdate` on every sync forever, even a genuine
+    // no-op. getChanges diffs in Cloudflare's native space instead (see its
+    // doc comment), which this proves: the group below has no `name`.
+    it('detects no changes for a declared managed rule group matching its remote counterpart (diff-on-declaration)', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [],
+        managedRules: [{ id: 'execute-1', ruleset: 'efb7b8c949ac4650a09736fc376e9aee', enabled: true, action: 'log' }],
+      }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Test',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [
+          {
+            id: 'execute-1',
+            action: 'execute',
+            expression: 'true',
+            // No explicit name was declared locally, so this is exactly what
+            // unifiedManagedRuleGroupToCloudflare's fallback produces.
+            description: 'Managed ruleset efb7b8c949ac4650a09736fc376e9aee',
+            enabled: true,
+            action_parameters: {
+              id: 'efb7b8c949ac4650a09736fc376e9aee',
+              overrides: { action: 'log' },
+            } as any,
+          },
+        ],
+      })
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(changes.managedRulesToAdd).toHaveLength(0)
+      expect(changes.managedRulesToUpdate).toHaveLength(0)
+      expect(changes.managedRulesToDelete).toHaveLength(0)
+      expect(changes.hasChanges).toBe(false)
+    })
+
+    it('getChanges detects an update and a delete together', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [],
+        managedRules: [{ id: 'execute-b', ruleset: 'ruleset-b', enabled: true, action: 'log' }],
+      }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Test',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [
+          {
+            // Same id as the local group, but no override — content differs,
+            // so this should show as an update, not add+delete.
+            id: 'execute-b',
+            action: 'execute',
+            expression: 'true',
+            description: 'Managed ruleset ruleset-b',
+            enabled: true,
+            action_parameters: { id: 'ruleset-b' } as any,
+          },
+          {
+            // Not declared locally at all — should show as a delete.
+            id: 'execute-c',
+            action: 'execute',
+            expression: 'true',
+            description: 'Managed ruleset ruleset-c',
+            enabled: true,
+            action_parameters: { id: 'ruleset-c' } as any,
+          },
+        ],
+      })
+
+      const changes = await service.getChanges(localConfig)
+
+      expect(changes.managedRulesToAdd).toHaveLength(0)
+      expect(changes.managedRulesToUpdate).toHaveLength(1)
+      expect(changes.managedRulesToUpdate?.[0]?.id).toBe('execute-b')
+      expect(changes.managedRulesToDelete).toHaveLength(1)
+      expect(changes.managedRulesToDelete?.[0]?.ruleset).toBe('ruleset-c')
+      expect(changes.hasChanges).toBe(true)
+    })
+
+    it('syncRules writes the managed-rules ruleset and reports counts when the config declares managedRules', async () => {
+      const localConfig: UnifiedConfig = {
+        version: '2.0',
+        provider: 'cloudflare',
+        rules: [],
+        ips: [],
+        managedRules: [{ id: 'execute-1', ruleset: 'efb7b8c949ac4650a09736fc376e9aee', enabled: true }],
+      }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'updateRuleset').mockImplementation(async (id) => ({
+        ...emptyCustomRuleset,
+        id,
+        version: '2',
+      }))
+      jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset').mockResolvedValue({
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Test',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [], // nothing remote yet, so this is an add
+      })
+
+      const result = await service.syncRules(localConfig)
+
+      expect(result.success).toBe(true)
+      expect(result.managedRulesAdded).toBe(1)
+      expect(mockClient.updateRuleset).toHaveBeenCalledWith(
+        'managed-ruleset-1',
+        expect.objectContaining({
+          rules: [expect.objectContaining({ id: 'execute-1', action: 'execute' })],
+        }),
+      )
+    })
+
+    it('syncRules does not touch the managed-rules ruleset when the config does not declare managedRules', async () => {
+      const localConfig: UnifiedConfig = { version: '2.0', provider: 'cloudflare', rules: [], ips: [] }
+      jest.spyOn(mockClient, 'getOrCreateFirewallRuleset').mockResolvedValue(emptyCustomRuleset)
+      jest.spyOn(mockClient, 'updateRuleset').mockResolvedValue({ ...emptyCustomRuleset, version: '2' })
+      const managedRulesetSpy = jest.spyOn(mockClient, 'getOrCreateManagedRulesRuleset')
+
+      const result = await service.syncRules(localConfig)
+
+      expect(result.success).toBe(true)
+      expect(managedRulesetSpy).not.toHaveBeenCalled()
+      expect(result.managedRulesAdded).toBe(0)
+      expect(result.managedRulesUpdated).toBe(0)
+      expect(result.managedRulesDeleted).toBe(0)
     })
   })
 

--- a/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
@@ -604,6 +604,21 @@ describe('Cloudflare Performance Benchmarks', () => {
      */
     it('should maintain consistent performance across multiple operations', async () => {
       const mockRuleset = TestDataGenerator.generateCloudflareRuleset(20)
+      // #183: fetchConfig now also looks up the managed-rules ruleset
+      // (separate phase). Included here alongside the custom one so a single
+      // cached `listRulesets()` response satisfies both lookups — matching a
+      // real zone that already has both provisioned — rather than each of
+      // the 10 fetchConfig() calls falling through to an uncached
+      // createRuleset() call and exhausting this fixed-size mock queue.
+      const mockManagedRuleset: CloudflareRuleset = {
+        id: 'managed-ruleset-1',
+        name: 'Doorman Managed Rules',
+        description: 'Managed rule groups deployed by Doorman',
+        kind: 'zone',
+        phase: 'http_request_firewall_managed',
+        version: '1',
+        rules: [],
+      }
 
       // Mock responses for multiple operations
       for (let i = 0; i < 10; i++) {
@@ -611,7 +626,7 @@ describe('Cloudflare Performance Benchmarks', () => {
           new Response(
             JSON.stringify({
               success: true,
-              result: [mockRuleset],
+              result: [mockRuleset, mockManagedRuleset],
             }),
           ),
         )

--- a/src/lib/providers/cloudflare/__tests__/translator.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/translator.test.ts
@@ -2,9 +2,15 @@ jest.mock('../../../logger', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
-import { cloudflareToUnified, unifiedToCloudflare, unifiedIPToCloudflare } from '../translator'
-import type { CloudflareRule } from '../../../types/cloudflare'
-import type { UnifiedRule, UnifiedIPRule } from '../../../types/unified'
+import {
+  cloudflareToUnified,
+  unifiedToCloudflare,
+  unifiedIPToCloudflare,
+  unifiedManagedRuleGroupToCloudflare,
+  cloudflareToUnifiedManagedRuleGroup,
+} from '../translator'
+import type { CloudflareRule, CloudflareExecuteActionParameters } from '../../../types/cloudflare'
+import type { UnifiedRule, UnifiedIPRule, UnifiedManagedRuleGroup } from '../../../types/unified'
 
 // Split out of the former RuleTranslator.test.ts as part of #196 — this
 // covers exactly the Cloudflare <-> Unified directions now living in
@@ -451,4 +457,168 @@ describe('cloudflare/translator', () => {
       expect(() => unifiedIPToCloudflare(ip)).toThrow('Invalid IP address or CIDR range')
     })
   })
+
+  // #183 — managed rule group support. These `execute` rules deploy a vendor
+  // ruleset (e.g. Cloudflare Managed Ruleset) rather than encoding custom
+  // logic, so the translation is structural (ruleset id, enabled, overrides)
+  // rather than the wirefilter-expression parsing the other tests exercise.
+  describe('unifiedManagedRuleGroupToCloudflare', () => {
+    function makeGroup(overrides: Partial<UnifiedManagedRuleGroup> = {}): UnifiedManagedRuleGroup {
+      return {
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+        ...overrides,
+      }
+    }
+
+    it('translates a minimal group to an execute rule with no overrides', () => {
+      const { result, warnings } = unifiedManagedRuleGroupToCloudflare(makeGroup())
+
+      expect(result.action).toBe('execute')
+      expect(result.expression).toBe('true')
+      expect(result.enabled).toBe(true)
+      expect(result.description).toBe('Managed ruleset efb7b8c949ac4650a09736fc376e9aee')
+      const params = result.action_parameters as CloudflareExecuteActionParameters
+      expect(params.id).toBe('efb7b8c949ac4650a09736fc376e9aee')
+      expect(params.overrides).toBeUndefined()
+      expect(warnings).toEqual([])
+    })
+
+    it('uses the provided id, or generates one when absent', () => {
+      const withId = unifiedManagedRuleGroupToCloudflare(makeGroup({ id: 'rule-abc' }))
+      expect(withId.result.id).toBe('rule-abc')
+
+      const withoutId = unifiedManagedRuleGroupToCloudflare(makeGroup())
+      expect(typeof withoutId.result.id).toBe('string')
+      expect(withoutId.result.id.length).toBeGreaterThan(0)
+    })
+
+    it('uses the group name as the description when present', () => {
+      const { result } = unifiedManagedRuleGroupToCloudflare(makeGroup({ name: 'OWASP Core Ruleset' }))
+      expect(result.description).toBe('OWASP Core Ruleset')
+    })
+
+    it('maps a ruleset-wide action override', () => {
+      const { result, warnings } = unifiedManagedRuleGroupToCloudflare(makeGroup({ action: 'log' }))
+      const params = result.action_parameters as CloudflareExecuteActionParameters
+      expect(params.overrides?.action).toBe('log')
+      expect(warnings).toEqual([])
+    })
+
+    it('warns and omits the override when the ruleset-wide action has no managed-rule equivalent', () => {
+      const { result, warnings } = unifiedManagedRuleGroupToCloudflare(makeGroup({ id: 'grp-1', action: 'redirect' }))
+      const params = result.action_parameters as CloudflareExecuteActionParameters
+      expect(params.overrides?.action).toBeUndefined()
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]!.field).toBe('action')
+      expect(warnings[0]!.rule).toBe('grp-1')
+    })
+
+    it('maps per-rule overrides, including a bare enabled toggle with no action', () => {
+      const { result, warnings } = unifiedManagedRuleGroupToCloudflare(
+        makeGroup({
+          overrides: [
+            { ruleId: 'cf-rule-1', action: 'deny', enabled: true },
+            { ruleId: 'cf-rule-2', enabled: false },
+          ],
+        }),
+      )
+      const params = result.action_parameters as CloudflareExecuteActionParameters
+      expect(params.overrides?.rules).toEqual([
+        { id: 'cf-rule-1', action: 'block', enabled: true },
+        { id: 'cf-rule-2', enabled: false },
+      ])
+      expect(warnings).toEqual([])
+    })
+
+    it('warns per-rule when an override action has no managed-rule equivalent, identifying the specific ruleId', () => {
+      const { warnings } = unifiedManagedRuleGroupToCloudflare(
+        makeGroup({ id: 'grp-2', overrides: [{ ruleId: 'cf-rule-9', action: 'bypass' }] }),
+      )
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]!.field).toBe('overrides[cf-rule-9].action')
+      expect(warnings[0]!.rule).toBe('grp-2')
+    })
+  })
+
+  describe('cloudflareToUnifiedManagedRuleGroup', () => {
+    it('translates a minimal execute rule back to a managed rule group', () => {
+      const rule: CloudflareRule = {
+        id: 'cf-execute-1',
+        action: 'execute',
+        expression: 'true',
+        description: 'Managed ruleset efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+        action_parameters: { id: 'efb7b8c949ac4650a09736fc376e9aee' } as CloudflareExecuteActionParameters,
+      }
+      const { result, warnings } = cloudflareToUnifiedManagedRuleGroup(rule)
+
+      expect(result).toEqual({
+        id: 'cf-execute-1',
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+        name: 'Managed ruleset efb7b8c949ac4650a09736fc376e9aee',
+      })
+      expect(warnings).toEqual([])
+    })
+
+    it('falls back to an empty ruleset id when action_parameters is missing', () => {
+      const rule: CloudflareRule = {
+        id: 'cf-execute-2',
+        action: 'execute',
+        expression: 'true',
+        enabled: true,
+      }
+      const { result } = cloudflareToUnifiedManagedRuleGroup(rule)
+      expect(result.ruleset).toBe('')
+    })
+
+    it('maps overrides.action and overrides.rules back to unified shape', () => {
+      const rule: CloudflareRule = {
+        id: 'cf-execute-3',
+        action: 'execute',
+        expression: 'true',
+        enabled: true,
+        action_parameters: {
+          id: 'efb7b8c949ac4650a09736fc376e9aee',
+          overrides: {
+            action: 'log',
+            rules: [
+              { id: 'cf-rule-1', action: 'block', enabled: true },
+              { id: 'cf-rule-2', enabled: false },
+            ],
+          },
+        } as CloudflareExecuteActionParameters,
+      }
+      const { result } = cloudflareToUnifiedManagedRuleGroup(rule)
+
+      expect(result.action).toBe('log')
+      expect(result.overrides).toEqual([
+        { ruleId: 'cf-rule-1', action: 'deny', enabled: true },
+        { ruleId: 'cf-rule-2', enabled: false },
+      ])
+    })
+
+    it('round-trips through unifiedManagedRuleGroupToCloudflare and back', () => {
+      const original = makeManagedGroup()
+      const { result: cfRule } = unifiedManagedRuleGroupToCloudflare(original)
+      const { result: roundTripped } = cloudflareToUnifiedManagedRuleGroup(cfRule)
+
+      expect(roundTripped).toEqual(original)
+    })
+  })
 })
+
+function makeManagedGroup(): UnifiedManagedRuleGroup {
+  return {
+    id: 'grp-roundtrip',
+    ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+    name: 'OWASP Core Ruleset',
+    enabled: true,
+    action: 'log',
+    overrides: [
+      { ruleId: 'cf-rule-1', action: 'deny', enabled: true },
+      { ruleId: 'cf-rule-2', enabled: false },
+    ],
+  }
+}

--- a/src/lib/providers/cloudflare/translator.ts
+++ b/src/lib/providers/cloudflare/translator.ts
@@ -1,5 +1,5 @@
-import type { CloudflareRule } from '../../types/cloudflare'
-import type { UnifiedRule, UnifiedIPRule, UnifiedAction } from '../../types/unified'
+import type { CloudflareRule, CloudflareAction, CloudflareExecuteActionParameters } from '../../types/cloudflare'
+import type { UnifiedRule, UnifiedIPRule, UnifiedAction, UnifiedManagedRuleGroup } from '../../types/unified'
 import type { ActionType } from '../../types/common'
 import type { TranslationResult, TranslationWarning } from '../../translators/TranslationTypes'
 import { TranslationWarningSystem } from '../../translators/TranslationWarningSystem'
@@ -215,6 +215,136 @@ export function unifiedIPToCloudflare(ip: UnifiedIPRule): CloudflareRule {
   }
 }
 
+/**
+ * Translate a Unified managed rule group to a Cloudflare `execute` rule.
+ * Deploys via a phase-entrypoint ruleset the same way custom rules do, just
+ * targeting `http_request_firewall_managed` instead of
+ * `http_request_firewall_custom` — see CloudflareClient.getOrCreateManagedRulesRuleset.
+ * `expression: 'true'` means the ruleset applies to every request; doorman
+ * doesn't currently expose a way to scope *when* a managed ruleset applies,
+ * only whether it's enabled and how its own rules are overridden (#183).
+ */
+export function unifiedManagedRuleGroupToCloudflare(group: UnifiedManagedRuleGroup): TranslationResult<CloudflareRule> {
+  const warnings: TranslationWarning[] = []
+  const overrides: NonNullable<CloudflareExecuteActionParameters['overrides']> = {}
+
+  if (group.action) {
+    const { action, warning } = mapUnifiedActionToManagedRuleOverride(group.action, group.id, 'action')
+    if (warning) warnings.push(warning)
+    if (action) overrides.action = action
+  }
+
+  if (group.overrides && group.overrides.length > 0) {
+    overrides.rules = group.overrides.map((override) => {
+      const ruleOverride: { id: string; action?: CloudflareAction; enabled?: boolean } = { id: override.ruleId }
+      if (override.enabled !== undefined) ruleOverride.enabled = override.enabled
+      if (override.action) {
+        const { action, warning } = mapUnifiedActionToManagedRuleOverride(
+          override.action,
+          group.id,
+          `overrides[${override.ruleId}].action`,
+        )
+        if (warning) warnings.push(warning)
+        if (action) ruleOverride.action = action
+      }
+      return ruleOverride
+    })
+  }
+
+  const actionParameters: CloudflareExecuteActionParameters = {
+    id: group.ruleset,
+    ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
+  }
+
+  const cloudflareRule: CloudflareRule = {
+    id: group.id || crypto.randomUUID(),
+    action: 'execute',
+    expression: 'true',
+    description: group.name || `Managed ruleset ${group.ruleset}`,
+    enabled: group.enabled,
+    action_parameters: actionParameters,
+  }
+
+  return { result: cloudflareRule, warnings }
+}
+
+/**
+ * Translate a Cloudflare `execute` rule back to a Unified managed rule group.
+ */
+export function cloudflareToUnifiedManagedRuleGroup(rule: CloudflareRule): TranslationResult<UnifiedManagedRuleGroup> {
+  const warnings: TranslationWarning[] = []
+  const params = rule.action_parameters as CloudflareExecuteActionParameters | undefined
+
+  const group: UnifiedManagedRuleGroup = {
+    id: rule.id,
+    ruleset: params?.id ?? '',
+    enabled: rule.enabled ?? true,
+    ...(rule.description ? { name: rule.description } : {}),
+  }
+
+  if (params?.overrides?.action) {
+    group.action = mapManagedRuleOverrideActionToUnified(params.overrides.action)
+  }
+
+  if (params?.overrides?.rules && params.overrides.rules.length > 0) {
+    group.overrides = params.overrides.rules.map((override) => ({
+      ruleId: override.id,
+      ...(override.action !== undefined ? { action: mapManagedRuleOverrideActionToUnified(override.action) } : {}),
+      ...(override.enabled !== undefined ? { enabled: override.enabled } : {}),
+    }))
+  }
+
+  return { result: group, warnings }
+}
+
+/**
+ * Managed-ruleset overrides accept a narrower action set than an ordinary
+ * custom rule — they're overriding a single WAF signature rule's response,
+ * not building general rule logic, so `bypass`(skip)/`rate_limit`/`redirect`
+ * don't apply. Deliberately separate from mapUnifiedActionToCloudflare
+ * rather than reusing it, so an unsupported value is caught and warned about
+ * here instead of silently producing an override Cloudflare's API rejects.
+ */
+function mapUnifiedActionToManagedRuleOverride(
+  action: ActionType,
+  ruleId: string | undefined,
+  field: string,
+): { action?: CloudflareAction; warning?: TranslationWarning } {
+  const mapping: Partial<Record<ActionType, CloudflareAction>> = {
+    log: 'log',
+    deny: 'block',
+    block: 'block',
+    challenge: 'managed_challenge',
+    allow: 'allow',
+  }
+
+  const mapped = mapping[action]
+  if (mapped) return { action: mapped }
+
+  return {
+    warning: TranslationWarningSystem.createUnsupportedFeatureWarning(
+      `'${action}' as a managed-ruleset override action`,
+      'unified config',
+      'Cloudflare',
+      ruleId,
+      field,
+    ),
+  }
+}
+
+function mapManagedRuleOverrideActionToUnified(action: CloudflareAction): ActionType {
+  const mapping: Partial<Record<CloudflareAction, ActionType>> = {
+    log: 'log',
+    block: 'deny',
+    challenge: 'challenge',
+    managed_challenge: 'challenge',
+    js_challenge: 'challenge',
+    allow: 'allow',
+  }
+
+  return mapping[action] || 'deny'
+}
+
 function mapCloudflareActionToUnified(action: CloudflareRule['action']): ActionType {
   const mapping: Record<CloudflareRule['action'], ActionType> = {
     block: 'deny',
@@ -226,6 +356,13 @@ function mapCloudflareActionToUnified(action: CloudflareRule['action']): ActionT
     allow: 'allow',
     rewrite: 'bypass',
     redirect: 'redirect',
+    // Unreachable in practice: `execute` rules deploy managed rulesets and
+    // live only in the http_request_firewall_managed phase ruleset, which
+    // this function never sees — CloudflareFirewallService.fetchConfig only
+    // passes custom-rules-phase rules through cloudflareToUnified.
+    // cloudflareToUnifiedManagedRuleGroup (#183) handles execute rules.
+    // Present only to satisfy Record's exhaustiveness over CloudflareAction.
+    execute: 'log',
   }
 
   return mapping[action] || 'deny'

--- a/src/lib/providers/fastly/FastlyFirewallService.ts
+++ b/src/lib/providers/fastly/FastlyFirewallService.ts
@@ -313,6 +313,7 @@ export class FastlyFirewallService extends BaseFirewallService implements IFirew
     if (!configValidation.success) {
       throw new Error(`Invalid firewall configuration: ${configValidation.error.message}`)
     }
+    this.assertManagedRulesSupported(config)
 
     try {
       logger.debug('Fetching existing Fastly configuration')

--- a/src/lib/providers/fastly/__tests__/FastlyFirewallService.test.ts
+++ b/src/lib/providers/fastly/__tests__/FastlyFirewallService.test.ts
@@ -125,6 +125,19 @@ describe('FastlyFirewallService', () => {
       ips: [],
     }
 
+    // #183 — Fastly doesn't implement managed rule groups. A config that
+    // declares them must fail loudly (BaseFirewallService.assertManagedRulesSupported),
+    // not silently report a clean diff/sync while quietly ignoring what the
+    // user asked for.
+    it('throws a clear error when the config declares managedRules', async () => {
+      const configWithManagedRules: UnifiedConfig = {
+        ...baseConfig,
+        managedRules: [{ ruleset: 'some-vendor-ruleset', enabled: true }],
+      }
+
+      await expect(service.getChanges(configWithManagedRules)).rejects.toThrow(/does not support managed rule groups/)
+    })
+
     it('should detect additions', async () => {
       jest.spyOn(client, 'fetchRules').mockResolvedValue([])
 

--- a/src/lib/providers/gcp/CloudArmorFirewallService.ts
+++ b/src/lib/providers/gcp/CloudArmorFirewallService.ts
@@ -354,6 +354,7 @@ export class CloudArmorFirewallService extends BaseFirewallService implements IF
     if (!configValidation.success) {
       throw new Error(`Invalid firewall configuration: ${configValidation.error.message}`)
     }
+    this.assertManagedRulesSupported(config)
 
     try {
       logger.debug('Fetching existing Cloud Armor configuration')

--- a/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
+++ b/src/lib/providers/gcp/__tests__/CloudArmorFirewallService.test.ts
@@ -78,6 +78,19 @@ describe('CloudArmorFirewallService', () => {
   describe('getChanges', () => {
     const baseConfig: UnifiedConfig = { version: '2.0', provider: 'gcp', rules: [], ips: [] }
 
+    // #183 — GCP Cloud Armor doesn't implement managed rule groups. A config
+    // that declares them must fail loudly
+    // (BaseFirewallService.assertManagedRulesSupported), not silently report
+    // a clean diff/sync while quietly ignoring what the user asked for.
+    it('throws a clear error when the config declares managedRules', async () => {
+      const configWithManagedRules: UnifiedConfig = {
+        ...baseConfig,
+        managedRules: [{ ruleset: 'some-vendor-ruleset', enabled: true }],
+      }
+
+      await expect(service.getChanges(configWithManagedRules)).rejects.toThrow(/does not support managed rule groups/)
+    })
+
     it('reports no changes when local and remote match exactly', async () => {
       jest.spyOn(client, 'getPolicy').mockResolvedValue(policy([blockAdminRule]))
 

--- a/src/lib/providers/vercel/VercelFirewallService.ts
+++ b/src/lib/providers/vercel/VercelFirewallService.ts
@@ -418,6 +418,7 @@ export class VercelFirewallService extends BaseFirewallService implements IFirew
     if (!configValidation.success) {
       throw new Error(`Invalid firewall configuration: ${configValidation.error.message}`)
     }
+    this.assertManagedRulesSupported(config)
 
     try {
       logger.debug('Fetching existing firewall configuration')

--- a/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
+++ b/src/lib/providers/vercel/__tests__/VercelFirewallService.test.ts
@@ -818,6 +818,20 @@ describe('VercelFirewallService', () => {
       ips: [],
     }
 
+    // #183 — Vercel doesn't implement managed rule groups. A config that
+    // declares them must fail loudly (BaseFirewallService.assertManagedRulesSupported),
+    // not silently report a clean diff/sync while quietly ignoring what the
+    // user asked for.
+    it('throws a clear error when the config declares managedRules', async () => {
+      const configWithManagedRules: UnifiedConfig = {
+        ...unifiedConfig,
+        rules: [],
+        managedRules: [{ ruleset: 'some-vendor-ruleset', enabled: true }],
+      }
+
+      await expect(service.getChanges(configWithManagedRules)).rejects.toThrow(/does not support managed rule groups/)
+    })
+
     it('should detect additions', async () => {
       jest.spyOn(client, 'fetchFirewallConfig').mockResolvedValue({
         ...mockVercelConfig,

--- a/src/lib/schemas/__tests__/unifiedSchemas.test.ts
+++ b/src/lib/schemas/__tests__/unifiedSchemas.test.ts
@@ -4,6 +4,7 @@ import {
   unifiedRuleSchema,
   unifiedIPRuleSchema,
   unifiedConfigSchema,
+  unifiedManagedRuleGroupSchema,
   validateUnifiedConfig,
 } from '../unifiedSchemas'
 
@@ -215,6 +216,51 @@ describe('unifiedSchemas', () => {
     })
   })
 
+  // #183 — managed rule group support.
+  describe('unifiedManagedRuleGroupSchema', () => {
+    it('accepts a minimal managed rule group', () => {
+      const result = unifiedManagedRuleGroupSchema.safeParse({
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a managed rule group with all optional fields', () => {
+      const result = unifiedManagedRuleGroupSchema.safeParse({
+        id: 'execute-1',
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        name: 'OWASP Core Ruleset',
+        enabled: true,
+        action: 'log',
+        overrides: [
+          { ruleId: 'cf-rule-1', action: 'deny', enabled: true },
+          { ruleId: 'cf-rule-2', enabled: false },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a missing ruleset', () => {
+      const result = unifiedManagedRuleGroupSchema.safeParse({ enabled: true })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a missing enabled', () => {
+      const result = unifiedManagedRuleGroupSchema.safeParse({ ruleset: 'efb7b8c949ac4650a09736fc376e9aee' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an override missing ruleId', () => {
+      const result = unifiedManagedRuleGroupSchema.safeParse({
+        ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+        enabled: true,
+        overrides: [{ action: 'deny' }],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
   describe('unifiedConfigSchema', () => {
     const validConfig = {
       rules: [
@@ -249,6 +295,30 @@ describe('unifiedSchemas', () => {
     it('rejects config without rules', () => {
       const result = unifiedConfigSchema.safeParse({})
       expect(result.success).toBe(false)
+    })
+
+    // #183 — Zod has no `.strict()` anywhere in this schema, so it silently
+    // *strips* unknown keys rather than rejecting them. A `managedRules`
+    // field added only to the `UnifiedConfig` TS type (and not wired into
+    // this schema) would vanish here on every safeParse — `success: true`
+    // alone wouldn't catch that, since a silently-stripped field still
+    // "successfully" parses. Asserting on `result.data.managedRules` itself
+    // is the part that actually proves the field survives.
+    it('round-trips managedRules through safeParse without stripping it', () => {
+      const managedRules = [
+        {
+          id: 'execute-1',
+          ruleset: 'efb7b8c949ac4650a09736fc376e9aee',
+          name: 'OWASP Core Ruleset',
+          enabled: true,
+          action: 'log' as const,
+          overrides: [{ ruleId: 'cf-rule-1', action: 'deny' as const, enabled: true }],
+        },
+      ]
+      const result = unifiedConfigSchema.safeParse({ ...validConfig, managedRules })
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.managedRules).toEqual(managedRules)
     })
   })
 

--- a/src/lib/schemas/unifiedSchemas.ts
+++ b/src/lib/schemas/unifiedSchemas.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod'
-import type { UnifiedCondition, UnifiedAction, UnifiedRule, UnifiedIPRule, UnifiedConfig } from '../types/unified'
+import type {
+  UnifiedCondition,
+  UnifiedAction,
+  UnifiedRule,
+  UnifiedIPRule,
+  UnifiedManagedRuleGroupOverride,
+  UnifiedManagedRuleGroup,
+  UnifiedConfig,
+} from '../types/unified'
 import {
   actionTypeSchema,
   operatorSchema,
@@ -92,11 +100,29 @@ export const unifiedIPRuleSchema = z.object({
   action: z.enum(['deny', 'allow']),
 }) satisfies z.ZodType<UnifiedIPRule>
 
+// Managed rule group per-rule override schema
+export const unifiedManagedRuleGroupOverrideSchema = z.object({
+  ruleId: z.string().min(1, 'ruleId is required'),
+  action: actionTypeSchema.optional(),
+  enabled: z.boolean().optional(),
+}) satisfies z.ZodType<UnifiedManagedRuleGroupOverride>
+
+// Managed rule group schema (#183)
+export const unifiedManagedRuleGroupSchema = z.object({
+  id: idSchema,
+  ruleset: z.string().min(1, 'ruleset is required'),
+  name: z.string().optional(),
+  enabled: z.boolean(),
+  action: actionTypeSchema.optional(),
+  overrides: z.array(unifiedManagedRuleGroupOverrideSchema).optional(),
+}) satisfies z.ZodType<UnifiedManagedRuleGroup>
+
 // Unified config schema
 export const unifiedConfigSchema = baseConfigSchema.extend({
   providers: providersConfigSchema.optional(),
   rules: z.array(unifiedRuleSchema),
   ips: z.array(unifiedIPRuleSchema).optional(),
+  managedRules: z.array(unifiedManagedRuleGroupSchema).optional(),
   metadata: configMetadataSchema.optional(),
 }) satisfies z.ZodType<UnifiedConfig>
 

--- a/src/lib/translators/RuleTranslator.ts
+++ b/src/lib/translators/RuleTranslator.ts
@@ -1,5 +1,11 @@
 import { vercelToUnified, unifiedToVercel, vercelIPToUnified } from '../providers/vercel/translator'
-import { cloudflareToUnified, unifiedToCloudflare, unifiedIPToCloudflare } from '../providers/cloudflare/translator'
+import {
+  cloudflareToUnified,
+  unifiedToCloudflare,
+  unifiedIPToCloudflare,
+  unifiedManagedRuleGroupToCloudflare,
+  cloudflareToUnifiedManagedRuleGroup,
+} from '../providers/cloudflare/translator'
 import {
   fastlyToUnified,
   unifiedToFastly,
@@ -46,6 +52,8 @@ export class RuleTranslator {
   static cloudflareToUnified = cloudflareToUnified
   static unifiedToCloudflare = unifiedToCloudflare
   static unifiedIPToCloudflare = unifiedIPToCloudflare
+  static unifiedManagedRuleGroupToCloudflare = unifiedManagedRuleGroupToCloudflare
+  static cloudflareToUnifiedManagedRuleGroup = cloudflareToUnifiedManagedRuleGroup
 
   static fastlyToUnified = fastlyToUnified
   static unifiedToFastly = unifiedToFastly

--- a/src/lib/types/cloudflare.ts
+++ b/src/lib/types/cloudflare.ts
@@ -31,6 +31,7 @@ export type CloudflareAction =
   | 'allow'
   | 'rewrite'
   | 'redirect'
+  | 'execute' // Deploys a managed/vendor ruleset (#183) — see CloudflareExecuteActionParameters.
 
 /**
  * Cloudflare action parameters for block actions
@@ -78,12 +79,53 @@ export interface CloudflareSkipActionParameters {
 }
 
 /**
+ * A single rule's override within an executed managed ruleset, referenced
+ * by that rule's id within the vendor ruleset (not doorman's own id space).
+ */
+export interface CloudflareManagedRuleOverride {
+  id: string
+  action?: CloudflareAction
+  enabled?: boolean
+}
+
+/**
+ * A tag/category-level override within an executed managed ruleset — applies
+ * to every rule in the ruleset carrying that tag (e.g. Cloudflare's
+ * "wordpress" tag on its Managed Ruleset).
+ */
+export interface CloudflareManagedRuleCategoryOverride {
+  category: string
+  action?: CloudflareAction
+  enabled?: boolean
+}
+
+/**
+ * Cloudflare action parameters for the `execute` action — deploys a
+ * vendor-managed ruleset, identified by `id`, with optional overrides at
+ * the ruleset, category/tag, and individual-rule level. Confirmed against
+ * https://developers.cloudflare.com/ruleset-engine/managed-rulesets/override-managed-ruleset/
+ * (#183) — doorman only models ruleset-level and rule-level overrides today
+ * (see UnifiedManagedRuleGroup); `categories` exists here because it's part
+ * of the real API shape, but nothing currently populates it.
+ */
+export interface CloudflareExecuteActionParameters {
+  id: string
+  overrides?: {
+    action?: CloudflareAction
+    enabled?: boolean
+    categories?: CloudflareManagedRuleCategoryOverride[]
+    rules?: CloudflareManagedRuleOverride[]
+  }
+}
+
+/**
  * Cloudflare action parameters union
  */
 export type CloudflareActionParameters =
   | CloudflareBlockActionParameters
   | CloudflareRedirectActionParameters
   | CloudflareSkipActionParameters
+  | CloudflareExecuteActionParameters
 
 /**
  * Cloudflare rule

--- a/src/lib/types/unified.ts
+++ b/src/lib/types/unified.ts
@@ -117,6 +117,44 @@ export interface UnifiedIPRule {
 }
 
 /**
+ * A per-rule override within a managed/vendor rule group — e.g. "enable the
+ * vendor ruleset but downgrade this one noisy rule to log-only."
+ */
+export interface UnifiedManagedRuleGroupOverride {
+  ruleId: string
+  action?: ActionType
+  enabled?: boolean
+}
+
+/**
+ * Unified managed rule group
+ * Provider-agnostic representation of a vendor-managed/preconfigured
+ * ruleset (Cloudflare Managed Ruleset, AWS Managed Rules, GCP preconfigured
+ * WAF, OWASP CRS, …) deployed as a whole, with optional per-rule overrides.
+ *
+ * A genuinely different kind of thing from `UnifiedRule` — no conditions,
+ * and its identity is a vendor ruleset id rather than a user-authored
+ * expression, so it isn't forced into `UnifiedRule[]`. See #183.
+ */
+export interface UnifiedManagedRuleGroup {
+  /**
+   * Provider-assigned identity for diff/sync matching — mirrors
+   * `UnifiedRule.id`. Omitted for a new declaration not yet synced.
+   */
+  id?: string
+  /** The vendor's managed-ruleset identifier being deployed (e.g. Cloudflare Managed Ruleset's well-known id). Opaque to doorman. */
+  ruleset: string
+  /** Optional human label. */
+  name?: string
+  /** Whether this managed-ruleset deployment is active. */
+  enabled: boolean
+  /** Ruleset-wide action override — e.g. downgrade every rule in the group to `log`. */
+  action?: ActionType
+  /** Per-rule overrides within the ruleset. */
+  overrides?: UnifiedManagedRuleGroupOverride[]
+}
+
+/**
  * Unified firewall configuration
  * Provider-agnostic configuration format supporting all providers
  */
@@ -127,6 +165,7 @@ export interface UnifiedConfig {
   providers?: ProvidersConfig // Provider-specific settings
   rules: UnifiedRule[]
   ips?: UnifiedIPRule[]
+  managedRules?: UnifiedManagedRuleGroup[]
   metadata?: ConfigMetadata
 }
 

--- a/src/lib/utils/__tests__/operationSafety.test.ts
+++ b/src/lib/utils/__tests__/operationSafety.test.ts
@@ -1,5 +1,5 @@
 import { OperationSafety } from '../operationSafety'
-import type { UnifiedConfig } from '../../types/unified'
+import type { UnifiedConfig, UnifiedManagedRuleGroup } from '../../types/unified'
 import type { ChangeSet } from '../../providers/IFirewallProvider'
 
 // Mock the logger
@@ -224,6 +224,27 @@ describe('OperationSafety', () => {
       const changes = changesWith({ rulesToUpdate: [{}] as UnifiedConfig['rules'] })
       expect(OperationSafety.assessOperationRisk(changes, configWithRules(5))).toBe('medium')
     })
+
+    // #183 — managed rule groups must feed the same risk signals rules/ips
+    // already do; a config that only touches managedRules shouldn't be
+    // silently classified as 'low' risk just because assessOperationRisk
+    // never looked at those fields.
+    it('is medium risk for managed rule group updates', () => {
+      const changes = changesWith({ managedRulesToUpdate: [{}] as UnifiedManagedRuleGroup[] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(0))).toBe('medium')
+    })
+
+    it('is high risk when the total change count exceeds 50, counting managed rule group additions', () => {
+      const changes = changesWith({
+        managedRulesToAdd: Array.from({ length: 51 }, () => ({})) as UnifiedManagedRuleGroup[],
+      })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(0))).toBe('high')
+    })
+
+    it('is medium risk for a managed rule group deletion alone (deletion gate is not rules/ips-only)', () => {
+      const changes = changesWith({ managedRulesToDelete: [{}] as UnifiedManagedRuleGroup[] })
+      expect(OperationSafety.assessOperationRisk(changes, configWithRules(10))).toBe('medium')
+    })
   })
 
   describe('confirmDestructiveOperation', () => {
@@ -297,6 +318,32 @@ describe('OperationSafety', () => {
       })
 
       expect(confirmed).toBe(true)
+    })
+
+    // #183 — the deletion gate must count managed rule group deletions too,
+    // not just rules/ips, or a config that only removes a managed ruleset
+    // could slip through a non-interactive --force/--ci run unconfirmed.
+    it('refuses a non-interactive operation that would delete managed rule groups without allowDeletions', async () => {
+      const changesWithManagedRuleDeletions: ChangeSet = {
+        rulesToAdd: [],
+        rulesToUpdate: [],
+        rulesToDelete: [],
+        ipsToAdd: [],
+        ipsToUpdate: [],
+        ipsToDelete: [],
+        managedRulesToDelete: [{}] as UnifiedManagedRuleGroup[],
+        hasChanges: true,
+      }
+
+      const confirmed = await OperationSafety.confirmDestructiveOperation({
+        operation: 'sync rules',
+        target: 'Cloudflare zone test',
+        changes: changesWithManagedRuleDeletions,
+        riskLevel: 'high',
+        skipConfirmation: true,
+      })
+
+      expect(confirmed).toBe(false)
     })
   })
 

--- a/src/lib/utils/operationSafety.ts
+++ b/src/lib/utils/operationSafety.ts
@@ -63,7 +63,10 @@ export class OperationSafety {
       return true
     }
 
-    const deletionCount = (changes?.rulesToDelete?.length || 0) + (changes?.ipsToDelete?.length || 0)
+    const deletionCount =
+      (changes?.rulesToDelete?.length || 0) +
+      (changes?.ipsToDelete?.length || 0) +
+      (changes?.managedRulesToDelete?.length || 0)
 
     if (skipConfirmation) {
       // `skipConfirmation` (--force/--ci) authorizes running non-interactively,
@@ -161,6 +164,9 @@ export class OperationSafety {
       ipsToAdd: [],
       ipsToUpdate: [],
       ipsToDelete: [],
+      managedRulesToAdd: [],
+      managedRulesToUpdate: [],
+      managedRulesToDelete: [],
       hasChanges: false,
     }
 
@@ -207,12 +213,17 @@ export class OperationSafety {
   public static assessOperationRisk(changes: ChangeSet, config: UnifiedConfig): 'low' | 'medium' | 'high' {
     const totalRules = config.rules.length
     const totalIPs = config.ips?.length || 0
-    const totalDeletions = (changes.rulesToDelete?.length || 0) + (changes.ipsToDelete?.length || 0)
+    const totalDeletions =
+      (changes.rulesToDelete?.length || 0) +
+      (changes.ipsToDelete?.length || 0) +
+      (changes.managedRulesToDelete?.length || 0)
     const totalChanges =
       (changes.rulesToAdd?.length || 0) +
       (changes.rulesToUpdate?.length || 0) +
       (changes.ipsToAdd?.length || 0) +
       (changes.ipsToUpdate?.length || 0) +
+      (changes.managedRulesToAdd?.length || 0) +
+      (changes.managedRulesToUpdate?.length || 0) +
       totalDeletions
 
     // High risk conditions
@@ -252,6 +263,10 @@ export class OperationSafety {
 
     if (changes.rulesToUpdate && changes.rulesToUpdate.length > 0) {
       return 'medium' // Rule updates can be risky
+    }
+
+    if (changes.managedRulesToUpdate && changes.managedRulesToUpdate.length > 0) {
+      return 'medium' // Overriding a managed ruleset's actions/enablement can be risky
     }
 
     // Low risk - only additions or small changes
@@ -405,6 +420,15 @@ export class OperationSafety {
     if (changes.ipsToDelete?.length) {
       logger.info(`   • IPs to delete: ${changes.ipsToDelete.length}`)
     }
+    if (changes.managedRulesToAdd?.length) {
+      logger.info(`   • Managed rule groups to add: ${changes.managedRulesToAdd.length}`)
+    }
+    if (changes.managedRulesToUpdate?.length) {
+      logger.info(`   • Managed rule groups to update: ${changes.managedRulesToUpdate.length}`)
+    }
+    if (changes.managedRulesToDelete?.length) {
+      logger.info(`   • Managed rule groups to delete: ${changes.managedRulesToDelete.length}`)
+    }
 
     if (!changes.hasChanges) {
       logger.info('   • No changes detected')
@@ -494,12 +518,17 @@ export class OperationSafety {
    */
   private static validateChanges(changes: ChangeSet, warnings: string[]): void {
     // Check for excessive deletions
-    const totalDeletions = (changes.rulesToDelete?.length || 0) + (changes.ipsToDelete?.length || 0)
+    const totalDeletions =
+      (changes.rulesToDelete?.length || 0) +
+      (changes.ipsToDelete?.length || 0) +
+      (changes.managedRulesToDelete?.length || 0)
     const totalChanges =
       (changes.rulesToAdd?.length || 0) +
       (changes.rulesToUpdate?.length || 0) +
       (changes.ipsToAdd?.length || 0) +
       (changes.ipsToUpdate?.length || 0) +
+      (changes.managedRulesToAdd?.length || 0) +
+      (changes.managedRulesToUpdate?.length || 0) +
       totalDeletions
 
     if (totalDeletions > 0 && totalChanges > 0) {


### PR DESCRIPTION
## Summary

Closes #183. Adds `UnifiedConfig.managedRules[]` — a provider-agnostic way to declare vendor-managed rulesets (Cloudflare Managed Ruleset, OWASP CRS, etc.), with optional ruleset-wide and per-rule action/enabled overrides. Implemented for Cloudflare via the `execute` action deployed in the separate `http_request_firewall_managed` phase entrypoint ruleset (real API mechanics confirmed against Cloudflare's Ruleset Engine docs — see plan notes in commit history).

- **Schema**: `unifiedManagedRuleGroupSchema` wired into `unifiedConfigSchema`. This repo's Zod schemas have no `.strict()` anywhere, so they silently *strip* unknown keys — a field added only to the `UnifiedConfig` TS type would vanish on every `safeParse` without this wiring. Verified with a regression test that asserts the round-tripped field, not just `success: true` (which wouldn't catch silent stripping).
- **Cloudflare**: new translator functions (`unifiedManagedRuleGroupToCloudflare` / `cloudflareToUnifiedManagedRuleGroup`), `CloudflareClient.getOrCreateManagedRulesRuleset()` (looked up by `phase` alone, not `phase`+`kind` — the exact `kind` Cloudflare assigns to this phase entrypoint wasn't confirmed against a live API response, documented in code), and `fetchConfig`/`getChanges`/`syncRules` wiring.
- **Diffing**: `getChanges` diffs managed rule groups in Cloudflare's *native* space (translating only the local side, comparing against the real remote `CloudflareRule` objects), not Unified space. Diffing through `cloudflareToUnifiedManagedRuleGroup` synthesizes a `name` from Cloudflare's (always-present) `description` field, so a group declared with no explicit `name` would never deep-equal its own remote round-trip — a phantom "update" on every sync, forever. This is the same translation-round-trip trap the existing custom-rules diffing code comment already warns about (`diffCloudflareRules`); made `CloudflareOptimizer.cloudflareRulesEqual` public to reuse it directly rather than duplicating the comparison. Caught via a mutation-tested regression test before this even shipped.
- **Cross-provider guard**: `BaseFirewallService.assertManagedRulesSupported` — a config declaring `managedRules` against Vercel/Fastly/GCP throws a clear, specific error from `getChanges` instead of silently no-op'ing (the acceptance criterion from #183).
- **Safety**: `OperationSafety`'s risk assessment, non-interactive `--force`/`--ci` deletion gate, and confirmation-prompt change summary now account for `managedRules` changes. These previously only looked at `rules`/`ips`, so a sync that only touched managed rule groups would under-assess risk and never appear in the "Proposed Changes" preview shown before a destructive operation — a real gap given this class's whole purpose is safety confirmation.

## Test plan

- [x] Translator unit tests: round-trip, ruleset/rule-level override mapping, unsupported-action warnings (mutation-verified)
- [x] `CloudflareClient.getOrCreateManagedRulesRuleset`: find-vs-create, phase-only matching doesn't false-match a custom ruleset (mutation-verified)
- [x] `CloudflareFirewallService`: fetchConfig includes managedRules; getChanges add/update/delete + the no-op "diff-on-declaration" case that caught the native-vs-Unified-space bug above (mutation-verified); syncRules writes the managed-rules ruleset and reports counts, and leaves it untouched when the config doesn't declare `managedRules`
- [x] Cross-provider guard tests for Vercel/Fastly/GCP
- [x] Schema round-trip test proving the field survives `safeParse`
- [x] `OperationSafety` risk/deletion-gate/summary coverage for managed rule changes (mutation-verified)
- [x] `pnpm compile && pnpm test && pnpm lint` all green