### PR TITLE
docs(skills): fix legacy rule shape shown as universal in Cloudflare docs

### DIFF
--- a/skills/doorman/SKILL.md
+++ b/skills/doorman/SKILL.md
@@ -76,7 +76,7 @@ FASTLY_WORKSPACE_ID=workspace_xxx
 }
 ```
 
-For Cloudflare or Fastly, add `provider` and `providers` fields instead of `projectId`/`teamId`.
+For Cloudflare or Fastly, add `provider` and `providers` fields instead of `projectId`/`teamId` — and note this switches the *rule* shape too, not just the top-level fields. See [Rule Shape](#rule-shape-minimal) below.
 
 ## Core Workflow
 
@@ -93,6 +93,10 @@ doorman backup && doorman validate && doorman diff && doorman sync && doorman st
 
 ## Rule Shape (Minimal)
 
+Two different rule shapes, picked by whether the config has `provider`/`providers` set (see [Config Structure](#config-structure) above) — **they are not interchangeable, and mixing them fails validation.**
+
+**Legacy shape** (no `provider`/`providers` — Vercel-only):
+
 ```json
 {
   "name": "Block Admin",
@@ -108,7 +112,26 @@ doorman backup && doorman validate && doorman diff && doorman sync && doorman st
 
 **Operators**: `eq`, `pre` (prefix), `suf` (suffix), `sub` (contains), `inc` (in array), `re` (regex), `ex` (exists), `nex` (not exists)
 
-**Actions**: `deny`, `challenge`, `rate_limit`, `redirect`, `log`, `bypass`
+**Actions**: `deny`, `challenge`, `rate_limit`, `redirect`, `log`, `bypass` (no `allow`/`block`)
+
+**Unified shape** (`provider`/`providers` set — required for Cloudflare/Fastly):
+
+```json
+{
+  "name": "Block Admin",
+  "enabled": true,
+  "conditions": [{ "field": "path", "operator": "starts_with", "value": "/admin" }],
+  "action": { "type": "deny" }
+}
+```
+
+**Logic**: conditions default to AND across all of them. Tag conditions with a `group` number for OR-of-AND-groups (same conditions sharing a `group` are AND'd, distinct `group`s are OR'd) — see [references/rules.md](references/rules.md) for the full explanation and an example.
+
+**Condition fields**: `ip`, `country`, `region`, `city`, `asn`, `path`, `host`, `method`, `header`, `query`, `cookie`, `user_agent`, `referer`, `scheme`, `port` — support varies by provider, see [references/cloudflare.md](references/cloudflare.md)/[references/fastly.md](references/fastly.md)
+
+**Operators**: `eq`, `ne`, `contains`, `not_contains`, `starts_with`, `ends_with`, `matches`, `in`, `not_in`, `gt`, `ge`, `lt`, `le`, `exists`, `not_exists` — **on Vercel specifically, `ne`/`not_contains`/`not_in`/`gt`/`ge`/`lt`/`le` currently degrade silently to `eq` (known bug, [doorman#261](https://github.com/gfargo/doorman/issues/261)) — avoid them in a Vercel-targeted config until that's fixed.**
+
+**Actions**: `log`, `deny`, `challenge`, `bypass`, `rate_limit`, `redirect`, `allow`, `block` — **`allow`/`block` are invalid on Vercel specifically ([doorman#262](https://github.com/gfargo/doorman/issues/262)); use `bypass`/`deny` there instead.**
 
 ## When to Read Each Reference
 
@@ -117,7 +140,7 @@ Load the relevant reference file for detailed documentation:
 | Task                                                                                        | Reference                                            |
 | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | Writing rules — full field docs, operators, actions, IP blocking, patterns                  | [references/rules.md](references/rules.md)           |
-| Cloudflare-specific setup, Lists API, expression translation, limitations                   | [references/cloudflare.md](references/cloudflare.md) |
+| Cloudflare-specific setup, Lists API, managed rule groups, expression translation, limitations | [references/cloudflare.md](references/cloudflare.md) |
 | Fastly-specific setup, condition/action mapping, rate-limit signal requirement, limitations | [references/fastly.md](references/fastly.md)         |
 | Available templates and what they protect against                                           | [references/templates.md](references/templates.md)   |
 | CI/CD integration, automation, export formats, validation in pipelines                      | [references/cicd.md](references/cicd.md)             |

--- a/skills/doorman/references/cloudflare.md
+++ b/skills/doorman/references/cloudflare.md
@@ -54,37 +54,50 @@ doorman list --provider cloudflare          # Show deployed rules
 
 ## Rule Translation
 
-Doorman translates its unified rule format into Cloudflare Wirefilter expressions automatically. The translation is bidirectional — `doorman download` pulls Cloudflare expressions back into the unified format.
+Doorman translates its unified rule format (`conditions`/`enabled`/`action: {type}` — different from the legacy shape [rules.md](rules.md) documents) into Cloudflare Wirefilter expressions automatically. The translation is bidirectional — `doorman download` pulls Cloudflare expressions back into the unified format. Cloudflare requires the unified format — a config with `provider: "cloudflare"` cannot use the legacy `conditionGroup`/`mitigate` shape.
 
 ### Field Mapping
 
-| Doorman Type         | Cloudflare Field              |
-| -------------------- | ----------------------------- |
-| `path`               | `http.request.uri.path`       |
-| `method`             | `http.request.method`         |
-| `host`               | `http.host`                   |
-| `user_agent`         | `http.user_agent`             |
-| `ip_address`         | `ip.src`                      |
-| `header`             | `http.request.headers["key"]` |
-| `query`              | `http.request.uri.query`      |
-| `cookie`             | `http.cookie`                 |
-| `geo_country`        | `ip.geoip.country`            |
-| `geo_city`           | `ip.geoip.city`               |
-| `geo_continent`      | `ip.geoip.continent`          |
-| `geo_country_region` | `ip.geoip.subdivision_1`      |
-| `geo_as_number`      | `ip.geoip.asnum`              |
-| `scheme`             | `ssl` (boolean)               |
+Cloudflare supports all 15 unified condition fields:
+
+| Doorman Field | Cloudflare Field              | Notes                                                                                    |
+| -------------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `ip`          | `ip.src`                      |                                                                                          |
+| `country`     | `ip.geoip.country`            |                                                                                          |
+| `region`      | `ip.geoip.subdivision_1`      |                                                                                          |
+| `city`        | `ip.geoip.city`                |                                                                                          |
+| `asn`         | `ip.geoip.asnum`               |                                                                                          |
+| `path`        | `http.request.uri.path`       |                                                                                          |
+| `host`        | `http.host`                   |                                                                                          |
+| `method`      | `http.request.method`         |                                                                                          |
+| `header`      | `http.request.headers["key"]` | Requires `key` (the header name)                                                        |
+| `query`       | `http.request.uri.query`      | ⚠️ `key` is currently ignored — matches the whole query string, not one parameter ([doorman#263](https://github.com/gfargo/doorman/issues/263)) |
+| `cookie`      | `http.cookie["key"]`          | Requires `key` (the cookie name)                                                         |
+| `user_agent`  | `http.user_agent`             |                                                                                          |
+| `referer`     | `http.referer`                |                                                                                          |
+| `scheme`      | `ssl` (boolean)                |                                                                                          |
+| `port`        | `cf.edge.server_port`         |                                                                                          |
+
+### Operator Mapping
+
+Cloudflare supports all 15 unified operators exactly, no approximation — `not_contains`/`not_in`/`not_exists` compile to a wrapped `not (...)` expression rather than a single wirefilter token, but the semantics are exact:
+
+`eq`, `ne`, `contains`, `not_contains`, `starts_with`, `ends_with`, `matches`, `in`, `not_in`, `gt`, `ge`, `lt`, `le`, `exists`, `not_exists`
+
+`matches` (regex) may be plan-restricted on Cloudflare's side — regex matching in the Ruleset Engine is an Enterprise-plan feature on some plans. Doorman always emits the correct `matches` expression regardless of plan; Cloudflare's API may reject it if your zone's plan doesn't support regex. Use `contains`/`starts_with`/`ends_with` as fallbacks if you hit this.
 
 ### Action Mapping
 
-| Doorman Action | Cloudflare Action                |
-| -------------- | -------------------------------- |
-| `deny`         | `block`                          |
-| `challenge`    | `managed_challenge`              |
-| `rate_limit`   | `block` + `ratelimit` config     |
-| `redirect`     | `redirect` + `from_value` params |
-| `log`          | `log`                            |
-| `bypass`       | `skip`                           |
+| Doorman Action | Cloudflare Action                | Notes                                                                                                                  |
+| --------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `log`          | `log`                              |                                                                                                                        |
+| `deny`         | `block`                            |                                                                                                                        |
+| `challenge`    | `managed_challenge`                | Cloudflare's `challenge`/`managed_challenge`/`js_challenge` all fold back to unified `challenge` on `download` — a one-way narrowing, not a failure |
+| `bypass`       | `skip`                             |                                                                                                                        |
+| `allow`        | `allow`                            |                                                                                                                        |
+| `block`        | `block`                            | Same target as `deny`                                                                                                  |
+| `rate_limit`   | `block` + `ratelimit` config       | ⚠️ If `action.rateLimit` is omitted, this silently becomes a plain unconditional `block` rule with no rate-limit effect — no error raised locally |
+| `redirect`     | `redirect` + `from_value` params   | ⚠️ If `action.redirect` is omitted, this silently becomes a rule with no redirect target — no error raised locally |
 
 ## Lists API (Bulk IP Management)
 
@@ -99,27 +112,27 @@ Without `CLOUDFLARE_ACCOUNT_ID`, IP blocking falls back to individual WAF rules 
 
 ## Limitations & Differences
 
-| Feature                   | Vercel              | Cloudflare                    | Notes                                             |
-| ------------------------- | ------------------- | ----------------------------- | ------------------------------------------------- |
-| `re` operator             | All plans           | Enterprise only               | Use `sub`/`pre`/`suf` as alternatives             |
-| `environment` type        | Yes                 | No                            | Vercel-specific concept                           |
-| `ja3_digest`/`ja4_digest` | Yes                 | No                            | Vercel TLS fingerprints                           |
-| `region` type             | Yes                 | No                            | Vercel edge region                                |
-| IP Lists (bulk)           | Individual rules    | Lists API                     | Cloudflare needs `accountId`                      |
-| Max custom rules          | ~100                | 5-125 (plan dependent)        | Free: 5, Pro: 20, Business: 100, Enterprise: 125+ |
-| Rate limit                | Via rule action     | Separate phase                | Different underlying mechanism                    |
-| Rule order                | Parallel evaluation | Sequential (first match wins) | Ordering matters on Cloudflare                    |
+`environment`, `ja3_digest`, `ja4_digest` are **legacy-format-only concepts** — they exist on Vercel's native rule type but have no unified-format equivalent at all, so they're not reachable through a `provider`/`providers`-tagged config for *any* provider, not just Cloudflare. Every other unified field maps to something on Cloudflare — see Field Mapping above.
+
+| Feature                   | Cloudflare                    | Notes                                             |
+| -------------------------- | ------------------------------ | ------------------------------------------------- |
+| `matches` (regex)         | Enterprise-plan-restricted on some plans | Doorman emits it regardless; Cloudflare's API may reject it — see Operator Mapping above |
+| IP Lists (bulk)           | Lists API                      | Needs `accountId`; without it, falls back to individual `ip.src` rules |
+| Max custom rules          | 5-125 (plan dependent)         | Free: 5, Pro: 20, Business: 100, Enterprise: 125+ |
+| Rate limit                | Separate phase                 | `ratelimit` config attached to a `block` action, not a distinct rule type |
+| Rule order                | Sequential (first match wins)  | `priority` is fully honoured — unlike Vercel, which can't reposition rules that already exist remotely |
+| Managed rule groups       | Supported via `managedRules`   | See [Managed Rule Groups](#managed-rule-groups) below — Cloudflare-only among doorman's providers today |
 
 ## Translation Warnings
 
 The `RuleTranslator` surfaces warnings when a translation is lossy:
 
-- **Regex on non-Enterprise** — `re` operator only works on Cloudflare Enterprise; downgraded to `contains` with a warning
-- **Unsupported types** — Vercel-only fields (`environment`, `ja3_digest`, `ja4_digest`, `region`) are dropped with a warning
-- **Duration differences** — `actionDuration` maps differently between providers
+- **Unmapped managed-ruleset override action** — an `action`/`overrides[].action` in `managedRules` with no Cloudflare equivalent (only `log`/`deny`/`challenge`/`allow` map cleanly) is dropped with a warning
 - **Negation edge cases** — complex negated conditions may produce subtly different behavior in Wirefilter
 
-Run `doorman validate` to surface warnings before deploying — it auto-detects Cloudflare from the config's `provider` field.
+Doorman does **not** currently warn on the `rate_limit`/`redirect` omitted-config-object cases noted in Action Mapping above, or the `query`-condition `key`-ignored case noted in Field Mapping above ([doorman#263](https://github.com/gfargo/doorman/issues/263)) — both are known gaps, not something `doorman validate` catches today. Double-check those specifically rather than relying on validation output.
+
+Run `doorman validate` to surface the warnings that do exist before deploying — it auto-detects Cloudflare from the config's `provider` field.
 
 ## Cloudflare-Specific Validation
 
@@ -139,6 +152,39 @@ The `CloudflareOptimizer` consolidates rules for efficient deployment:
 - Deduplicates IP entries across rules and Lists
 - Computes minimal changesets to avoid unnecessary API calls (diff-based sync)
 
+## Managed Rule Groups
+
+Cloudflare is the only provider doorman can deploy vendor-managed rulesets (Cloudflare Managed Ruleset, OWASP CRS, etc.) for today. Add a `managedRules` array alongside `rules`/`ips`:
+
+```json
+{
+  "managedRules": [
+    {
+      "id": "execute-owasp-crs",
+      "ruleset": "efb7b8c949ac4650a09736fc376e9aee",
+      "name": "OWASP Core Ruleset",
+      "enabled": true,
+      "action": "log",
+      "overrides": [
+        { "ruleId": "981176", "action": "deny" },
+        { "ruleId": "981245", "enabled": false }
+      ]
+    }
+  ]
+}
+```
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | No | Doorman's diff/sync identifier for this deployment. Omit for a new declaration — doorman assigns one on first sync. |
+| `ruleset` | string | Yes | The vendor ruleset id to deploy (e.g. Cloudflare Managed Ruleset's well-known id shown above) |
+| `name` | string | No | Human label |
+| `enabled` | boolean | Yes | Whether this deployment is active |
+| `action` | string | No | Ruleset-wide override — downgrade every rule in the group to this action. One of `log`, `deny`, `challenge`, `allow` |
+| `overrides` | array | No | Per-rule overrides within the ruleset — `{ "ruleId": string, "action"?: string, "enabled"?: boolean }`, referenced by the *vendor's* rule id within that ruleset, not a doorman id |
+
+Managed rule groups deploy in Cloudflare's separate managed-rules phase, evaluated independently of custom `rules` — no ordering interaction to think about between the two. `getChanges`/`syncRules` diff `managedRules` the same way as `rules`/`ips` — `doorman diff`/`doorman sync` cover it with no extra flags.
+
 ## Example: Full Cloudflare Config
 
 ```json
@@ -156,29 +202,35 @@ The `CloudflareOptimizer` consolidates rules for efficient deployment:
       "id": "rule_block_bots",
       "name": "Block Bad Bots",
       "description": "Block known malicious crawlers",
-      "active": true,
-      "conditionGroup": [
-        { "conditions": [{ "type": "user_agent", "op": "sub", "value": "AhrefsBot" }] },
-        { "conditions": [{ "type": "user_agent", "op": "sub", "value": "SemrushBot" }] }
+      "enabled": true,
+      "conditions": [
+        { "field": "user_agent", "operator": "contains", "value": "AhrefsBot", "group": 0 },
+        { "field": "user_agent", "operator": "contains", "value": "SemrushBot", "group": 1 }
       ],
-      "action": { "mitigate": { "action": "deny" } }
+      "action": { "type": "deny" }
     },
     {
       "id": "rule_rate_limit_api",
       "name": "Rate Limit API",
       "description": "Limit API requests to 100/min per IP",
-      "active": true,
-      "conditionGroup": [{ "conditions": [{ "type": "path", "op": "pre", "value": "/api/" }] }],
+      "enabled": true,
+      "conditions": [{ "field": "path", "operator": "starts_with", "value": "/api/" }],
       "action": {
-        "mitigate": {
-          "action": "rate_limit",
-          "rateLimit": {
-            "requests": 100,
-            "window": "1m",
-            "characteristics": ["ip.src"]
-          }
+        "type": "rate_limit",
+        "rateLimit": {
+          "requests": 100,
+          "window": "1m",
+          "characteristics": ["ip.src"]
         }
       }
+    }
+  ],
+  "managedRules": [
+    {
+      "ruleset": "efb7b8c949ac4650a09736fc376e9aee",
+      "name": "OWASP Core Ruleset",
+      "enabled": true,
+      "action": "log"
     }
   ],
   "ips": [{ "ip": "203.0.113.0/24", "action": "deny", "notes": "Known attack subnet" }]

--- a/skills/doorman/references/fastly.md
+++ b/skills/doorman/references/fastly.md
@@ -119,7 +119,7 @@ Unlike classic Fastly VCL services, Next-Gen WAF rule and list writes take effec
 | -------------------------- | ----------------------------- | ---------------------- | ------------------------------------------------------------------------- |
 | Geo targeting              | Country/city/continent/region | Country only           | No sub-country condition field                                            |
 | Rule ordering              | Best-effort (insertion order) | None                   | Next-Gen WAF rules are evaluated independently — `priority` has no effect |
-| Managed/vendor rule groups | CRS (enterprise)              | Templated signal rules | Not yet configurable through Doorman for either provider (#183)           |
+| Managed/vendor rule groups | CRS (enterprise)              | Templated signal rules | Doorman-managed on Cloudflare only ([cloudflare.md](cloudflare.md)); not yet configurable through Doorman for Vercel or Fastly |
 | Signal/exclusion rules     | —                             | `type: signal`         | Not managed by Doorman — see below                                        |
 
 Fastly rules of type `signal` or `templated_signal` (which tag or exclude WAF signals rather than allow/block/redirect a request) are skipped entirely by `doorman download`/`fetchConfig` rather than forced into a lossy `UnifiedRule` — they simply don't appear in the local config.

--- a/skills/doorman/references/rules.md
+++ b/skills/doorman/references/rules.md
@@ -2,6 +2,8 @@
 
 Complete reference for creating and configuring Doorman firewall rules.
 
+> **Format note:** this reference covers the **legacy (Vercel-only) rule format** — no `provider`/`providers` field in the config. If your config has `provider`/`providers` set (required for Cloudflare/Fastly), rules use a different shape entirely (`conditions`/`enabled`/flat `action: {type}` instead of `conditionGroup`/`active`/`action: {mitigate}`) — see [cloudflare.md](cloudflare.md)/[fastly.md](fastly.md) for the correct format and field/operator/action support per provider, and `SKILL.md`'s "Rule Shape" section for a side-by-side comparison.
+
 ## Rule Structure
 
 Every rule in the `rules` array has this shape:


### PR DESCRIPTION
## Summary

Found while documenting #183's `managedRules` feature in `skills/doorman/references/cloudflare.md`: the file has a real, pre-existing bug, not a stale-copy issue. Its Field Mapping table used native/legacy vocabulary (`ip_address`, `geo_country`, ...) instead of unified (`ip`, `country`, ...), it had no Operator Mapping table at all, and its "Example: Full Cloudflare Config" used the legacy `conditionGroup`/`active`/`mitigate.action` rule shape *inside* a `provider: "cloudflare"`-tagged config — which fails `unifiedConfigSchema` validation outright. Verified empirically: fed that exact example into the real schema and it rejects it (missing `enabled`, `conditions`, `action.type`).

Worse, `SKILL.md` — the entry-point file any AI agent using this skill loads first — explicitly instructed: *"For Cloudflare or Fastly, add `provider` and `providers` fields"* directly above a rule example in the legacy shape, implying that's all that changes. It isn't; the rule shape itself is different and incompatible.

`references/fastly.md` already had this right (unified vocabulary throughout, including a working `matches`/`starts_with`/`gt` operator table) — used as the reference for fixing `cloudflare.md` to match.

## Changes

- **`SKILL.md`**: "Rule Shape (Minimal)" now shows both shapes side by side, clearly labeled, with a correct unified field/operator/action list. Flagged the two Vercel translator bugs found during this work (#261 silent operator degradation, #262 invalid `allow`/`block`) inline so anyone copying a Vercel example doesn't hit them blind.
- **`references/cloudflare.md`**: rewrote Field Mapping (all 15 unified fields, correct wirefilter targets), added the missing Operator Mapping table, corrected Action Mapping (added `allow`/`block`, noted the `rate_limit`/`redirect` silent-omission gaps), rewrote the Limitations table (the old one incorrectly listed `region` as Vercel-only — it works on Cloudflare too), replaced the invalid full-config example with one that actually validates, and documented the new `managedRules` config surface.
- **`references/fastly.md`**: fixed a stale line claiming managed rule groups aren't configurable "for either provider" — Cloudflare supports them as of #260.
- **`references/rules.md`**: added a note that it documents the legacy (Vercel-only) format specifically, since nothing in the file said so and it's the file `SKILL.md` points to first for "writing rules."

Every corrected JSON example (10 total across both files) was run through the real `unifiedConfigSchema`/`firewallConfigSchema` via `safeParse` before committing — none of this is guessed.

## Why this matters

This isn't cosmetic — `skills/doorman/` is the canonical source that syncs daily to `gfargo/skills`, which `doorman-www` vendors via `npx skills add`. Any AI agent helping a real user set up Cloudflare through this skill would have generated a config guaranteed to fail validation. Also filed 3 related-but-separate issues on real (non-doc) translator/schema bugs surfaced during this audit: #261, #262, #263.

## Test plan

- [x] All 10 corrected JSON examples verified against real `unifiedConfigSchema`/`firewallConfigSchema` via `safeParse`
- [x] `pnpm lint` clean (markdown-only change, no code touched)