### PR TITLE
test(cloudflare): stop comparing call-order timing halves in perf regression test

### DIFF
--- a/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
+++ b/src/lib/providers/cloudflare/__tests__/CloudflarePerformanceBenchmarks.test.ts
@@ -600,7 +600,8 @@ describe('Cloudflare Performance Benchmarks', () => {
   describe('Memory Usage and Performance Regression', () => {
     /**
      * Test performance consistency across multiple operations
-     * Ensures no memory leaks or performance degradation over time
+     * Ensures repeated use doesn't hang or blow up, without asserting on
+     * relative call-to-call timing (see comment below on why).
      */
     it('should maintain consistent performance across multiple operations', async () => {
       const mockRuleset = TestDataGenerator.generateCloudflareRuleset(20)
@@ -642,18 +643,19 @@ describe('Cloudflare Performance Benchmarks', () => {
         durations.push(duration)
       }
 
-      // Check for performance regression (later operations shouldn't be significantly slower)
-      const firstHalf = durations.slice(0, 5)
-      const secondHalf = durations.slice(5)
-      const firstHalfAvg = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length
-      const secondHalfAvg = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length
+      // Previously this compared first-half vs second-half averages and
+      // failed if the second half was >3x slower. Removed: repeated local
+      // runs show the first 2-3 calls are always ~100x faster than the rest
+      // (interpreter/GC warm-up in the benchmark loop, not fetchConfig()
+      // itself), so whichever half absorbs that warm-up boundary swings its
+      // average unpredictably — the assertion passed or failed at random. An
+      // absolute per-call ceiling still catches a real regression (a hang,
+      // or an accidental O(n^2) over repeated calls) without that noise.
+      for (const duration of durations) {
+        expect(duration).toBeLessThan(10000) // 10 seconds, matches the fetch SLA above
+      }
 
-      // Second half shouldn't be more than 3x slower than first half (generous margin for CI)
-      expect(secondHalfAvg).toBeLessThan(firstHalfAvg * 3)
-
-      console.log(
-        `Performance regression test - First half avg: ${firstHalfAvg.toFixed(2)}ms, Second half avg: ${secondHalfAvg.toFixed(2)}ms`,
-      )
+      console.log(`Performance regression test - durations: ${durations.map((d) => `${d.toFixed(2)}ms`).join(', ')}`)
     })
 
     /**


### PR DESCRIPTION
## Summary
- The "should maintain consistent performance across multiple operations" test compared the average duration of the first 5 vs. last 5 of 10 consecutive `fetchConfig()` calls, failing if the second half was >3x slower.
- This was flaky in a way that plain re-tuning the threshold wouldn't fix: repeated local runs (8 isolated runs, full durations logged) show the first 2-3 calls are consistently ~100x faster than the rest — interpreter/GC warm-up in the benchmark loop itself, not `fetchConfig()`. Whichever half absorbed that warm-up boundary swung its average unpredictably, so the ratio assertion passed or failed close to at random depending on system load.
- Tried switching to a median-based comparison (the natural "make it statistical" fix) — it's worse, not better: 10-27x ratio on every single run, because the warm-up split confounds any first-half/second-half comparison regardless of which statistic is used. No threshold or statistic fixes a structural confound in the benchmark design.
- `fetchConfig()` has no accumulating per-call state that could cause a real slowdown across repeated calls (confirmed by reading `CloudflareFirewallService`/`CloudflareClient` — its internal `ApiCache` would make repeat calls faster, not slower).
- Replaced the relative comparison with a per-call absolute ceiling (reusing the existing 10s fetch SLA constant already used elsewhere in this file), which still catches a real regression (a hang, or an accidental O(n²) over repeated calls) without being sensitive to warm-up noise.

## Test plan
- [x] Target test run standalone 10x in a row — 10/10 pass
- [x] Full test file run 8x in a row — 19/19 tests pass each time
- [x] Full `cloudflare/__tests__/` directory run 3x in a row — 506/506 tests pass each time
- [x] `--ci` mode run once — 19/19 pass
- [x] `eslint` on the changed file — 0 errors (pre-existing `no-console` warnings only, not introduced by this change)
- [x] `tsc --noEmit` — clean