### PR TITLE
docs(skills): fix Vercel-only condition-type categorization in rules.md

### DIFF
--- a/skills/doorman/references/rules.md
+++ b/skills/doorman/references/rules.md
@@ -73,30 +73,33 @@ Each condition has:
 
 ### Condition Types
 
-| Type                 | Description                      | Example Value           |
-| -------------------- | -------------------------------- | ----------------------- |
-| `path`               | URL path                         | `"/api/users"`          |
-| `method`             | HTTP method                      | `"POST"`                |
-| `host`               | Hostname                         | `"example.com"`         |
-| `user_agent`         | User-Agent header                | `"Googlebot"`           |
-| `ip_address`         | Client IP                        | `"192.168.1.1"`         |
-| `header`             | HTTP header (requires `key`)     | `"application/json"`    |
-| `query`              | Query parameter (requires `key`) | `"true"`                |
-| `cookie`             | Cookie value (requires `key`)    | `"session_abc"`         |
-| `geo_country`        | Country code (ISO 3166-1)        | `"US"` or `["US","CA"]` |
-| `geo_city`           | City name                        | `"New York"`            |
-| `geo_continent`      | Continent code                   | `"NA"`                  |
-| `geo_country_region` | Region/state code                | `"CA"`                  |
-| `geo_as_number`      | ASN number                       | `13335`                 |
-| `scheme`             | URL scheme                       | `"https"`               |
-| `protocol`           | HTTP protocol version            | `"HTTP/2"`              |
+These translate cleanly to the unified format's condition fields (`mapVercelTypeToUnified` in `src/lib/providers/vercel/translator.ts`), so a rule built from them survives migration to Cloudflare or Fastly:
 
-**Vercel-only types** (not available on Cloudflare):
+| Type            | Description                      | Example Value           |
+| --------------- | -------------------------------- | ----------------------- |
+| `path`          | URL path                         | `"/api/users"`          |
+| `method`        | HTTP method                      | `"POST"`                |
+| `host`          | Hostname                         | `"example.com"`         |
+| `user_agent`    | User-Agent header                | `"Googlebot"`           |
+| `ip_address`    | Client IP                        | `"192.168.1.1"`         |
+| `header`        | HTTP header (requires `key`)     | `"application/json"`    |
+| `query`         | Query parameter (requires `key`) | `"true"`                |
+| `cookie`        | Cookie value (requires `key`)    | `"session_abc"`         |
+| `geo_country`   | Country code (ISO 3166-1)        | `"US"` or `["US","CA"]` |
+| `geo_city`      | City name                        | `"New York"`            |
+| `geo_as_number` | ASN number                       | `13335`                 |
+| `scheme`        | URL scheme                       | `"https"`               |
 
+**Vercel-only types** — these round-trip fine between the legacy shape and the unified format (Vercel stays Vercel), but have no _other_ provider's equivalent: migrating to Fastly drops them with a translation warning, while migrating to Cloudflare currently produces a broken filter expression with no warning at all (`mapUnifiedFieldToCloudflare` in `src/lib/translators/ExpressionBuilder.ts` has no entry for them and falls through to the bare field name, which isn't valid Wirefilter syntax) — avoid these in a rule you intend to sync to Cloudflare:
+
+- `geo_continent` — continent code (`"NA"`)
+- `geo_country_region` — region/state code (`"CA"`) — distinct from `region` below, not interchangeable
+- `protocol` — HTTP protocol version (`"HTTP/2"`) — distinct from `scheme` above, not interchangeable
+- `target_path` — URL path, alternate to `path` (no unified mapping despite the similar name)
+- `region` — Vercel edge region (e.g. `"sfo1"`)
 - `environment` — deployment environment (`"production"`, `"preview"`)
 - `ja3_digest` — TLS fingerprint
 - `ja4_digest` — TLS fingerprint v4
-- `region` — Vercel edge region
 - `rate_limit_api_id` — rate limit API identifier
 
 ### Operators


### PR DESCRIPTION
## Summary

- `rules.md`'s legacy-shape condition-type table listed `geo_continent`, `geo_country_region`, and `protocol` alongside genuinely portable fields, and omitted `target_path` entirely.
- Verified against the live translator (`mapVercelTypeToUnified`/`mapUnifiedFieldToCloudflare`, not just the old table): none of these 4 have a working mapping out of the legacy shape — same situation as the 5 fields already called out as "Vercel-only." Moved all 9 into that callout and clarified what actually happens when a rule using one of them gets migrated.
- The doc's underlying premise (comparing it against `FieldType` in `src/lib/types/common.ts`) was a category error — `rules.md` correctly documents the legacy Vercel-only shape's own vocabulary (`VercelRuleType`), not the unified shape's `FieldType`. `SKILL.md` already gets that split right; only `rules.md`'s internal "which of these are portable" claim was wrong.

## Related

While verifying this against the live translator, found two real (separately filed, not fixed here — out of scope for a docs PR) Cloudflare translator bugs:
- #270 — a legacy Vercel `region` condition silently collides with the unified schema's differently-meaning `region` field, producing a valid-but-semantically-wrong Cloudflare filter with no warning.
- #271 — the other 8 legacy-only fields produce outright invalid Cloudflare filter syntax, also with no warning.

## Test plan

- [x] `npx prettier --check skills/doorman/references/rules.md`
- [x] Manually re-read the full diff for stray/unintended changes
- [x] Confirmed via `npx tsx` against the real `vercelToUnified`/`unifiedToCloudflare` functions that the 9 reclassified fields do in fact fail to translate (see #270/#271 for the transcripts)