### PR TITLE
fix: map unified allow/block to valid Vercel actions instead of passing through

### DIFF
--- a/src/lib/providers/vercel/__tests__/translator.test.ts
+++ b/src/lib/providers/vercel/__tests__/translator.test.ts
@@ -253,6 +253,35 @@ describe('vercel/translator', () => {
       expect(result.conditionGroup[0]!.conditions).toHaveLength(1)
     })
 
+    // Regression tests for #262: unifiedToVercel previously used
+    // `rule.action.type` directly with no mapping, so a rule with
+    // `action: {type: 'allow'}`/`{type: 'block'}` passed doorman's own
+    // local validation and reached Vercel's real API carrying an action
+    // value its own native schema (log/deny/challenge/bypass/rate_limit/
+    // redirect only) says is invalid.
+    it('maps unified allow to Vercel bypass and block to Vercel deny, not the invalid native values', () => {
+      const mappings = [
+        { unified: 'allow', vercel: 'bypass' },
+        { unified: 'block', vercel: 'deny' },
+      ] as const
+
+      for (const { unified, vercel } of mappings) {
+        const rule = makeUnifiedRule({ action: { type: unified } })
+        const { result } = unifiedToVercel(rule)
+        expect(result.action.mitigate.action).toBe(vercel)
+      }
+    })
+
+    it('passes the 6 already-native Vercel action types through unchanged', () => {
+      const nativeActions = ['log', 'deny', 'challenge', 'bypass', 'rate_limit', 'redirect'] as const
+
+      for (const action of nativeActions) {
+        const rule = makeUnifiedRule({ action: { type: action } })
+        const { result } = unifiedToVercel(rule)
+        expect(result.action.mitigate.action).toBe(action)
+      }
+    })
+
     it('translates unified operators back to Vercel operators', () => {
       const ops = [
         { unified: 'eq', vercel: 'eq' },

--- a/src/lib/providers/vercel/translator.ts
+++ b/src/lib/providers/vercel/translator.ts
@@ -5,9 +5,10 @@ import type {
   VercelRuleCondition,
   VercelRuleOperator,
   VercelRuleType,
+  VercelActionType,
 } from '../../types/vercel'
 import type { UnifiedRule, UnifiedIPRule, UnifiedCondition, UnifiedAction } from '../../types/unified'
-import type { Operator } from '../../types/common'
+import type { Operator, ActionType } from '../../types/common'
 import type { TranslationResult, TranslationWarning } from '../../translators/TranslationTypes'
 import { TranslationWarningSystem } from '../../translators/TranslationWarningSystem'
 
@@ -166,7 +167,7 @@ export function unifiedToVercel(rule: UnifiedRule): TranslationResult<VercelCust
     conditionGroup: conditionGroups,
     action: {
       mitigate: {
-        action: rule.action.type,
+        action: mapUnifiedActionToVercel(rule.action.type),
         rateLimit: rule.action.rateLimit
           ? {
               requests: rule.action.rateLimit.requests,
@@ -345,6 +346,37 @@ function mapUnifiedOperatorToVercel(op: Operator): { op: VercelRuleOperator; for
   }
 
   return mapping[op] ?? null
+}
+
+/**
+ * Maps a unified action type to Vercel's native action enum
+ * (`VercelActionType`, types/vercel.ts) — a strict subset of the unified
+ * `ActionType`. Previously `unifiedToVercel` used `rule.action.type`
+ * directly with no mapping at all, so a rule with `action: {type: 'allow'}`
+ * or `{type: 'block'}` passed doorman's own local validation (against the
+ * wider unified schema) and was dispatched to Vercel's real API carrying a
+ * `mitigate.action` value Vercel's own native schema says is invalid. See
+ * #262.
+ *
+ * `allow` -> `bypass` (Vercel's closest equivalent: skip further mitigation,
+ * i.e. let the request through) and `block` -> `deny` (Vercel's actual
+ * block-like action) — both unconditional, meaning-preserving remaps rather
+ * than lossy drops, so every unified `ActionType` has a real Vercel action
+ * to land on and this never needs to warn or throw.
+ */
+function mapUnifiedActionToVercel(type: ActionType): VercelActionType {
+  const mapping: Record<ActionType, VercelActionType> = {
+    log: 'log',
+    deny: 'deny',
+    challenge: 'challenge',
+    bypass: 'bypass',
+    rate_limit: 'rate_limit',
+    redirect: 'redirect',
+    allow: 'bypass',
+    block: 'deny',
+  }
+
+  return mapping[type]
 }
 
 /**

--- a/src/lib/types/vercel.ts
+++ b/src/lib/types/vercel.ts
@@ -3,7 +3,17 @@
  * These types map directly to Vercel's Firewall API
  */
 
-import type { ActionType } from './common'
+/**
+ * Vercel's native mitigation-action vocabulary — a strict subset of the
+ * unified `ActionType` (which also has `allow`/`block`, valid on
+ * Cloudflare/Fastly but not natively representable on Vercel; see
+ * `mapUnifiedActionToVercel` in providers/vercel/translator.ts, #262).
+ * Mirrors `actionTypeSchema` in schemas/firewallSchemas.ts — keep the two in
+ * sync. `CloudflareAction`/`FastlyRequestActionType` (types/cloudflare.ts,
+ * types/fastly.ts) already follow this same "dedicated native type, not the
+ * shared unified one" pattern; this brings Vercel in line with them.
+ */
+export type VercelActionType = 'log' | 'deny' | 'challenge' | 'bypass' | 'rate_limit' | 'redirect'
 
 /**
  * Vercel rule operators
@@ -85,7 +95,7 @@ export interface VercelRedirect {
  * Vercel mitigation action
  */
 export interface VercelMitigationAction {
-  action: ActionType
+  action: VercelActionType
   rateLimit?: VercelRateLimit | null
   redirect?: VercelRedirect | null
   actionDuration?: string | null // e.g., "1h", "1d", "permanent"


### PR DESCRIPTION
Fixes #262

## Summary

`unifiedToVercel` used `rule.action.type` directly with no mapping at all — so a rule with `action: {type: 'allow'}` or `{type: 'block'}` passed doorman's own local validation (against the wider 8-value unified `ActionType`) and was dispatched to Vercel's real API carrying a `mitigate.action` value Vercel's own native schema (`log, deny, challenge, bypass, rate_limit, redirect` — 6 values, no `allow`/`block`) says is invalid.

Added `VercelActionType` (`types/vercel.ts`), Vercel's actual native action vocabulary — previously `VercelMitigationAction.action` reused the wider unified `ActionType` directly, so TypeScript never caught the mismatch either. This matches the pattern `CloudflareAction`/`FastlyRequestActionType` already establish: a dedicated native type per provider, not the shared unified one (confirmed both other providers already follow this; Vercel was the outlier). Narrowing this type surfaced exactly the one call site that needed fixing — nothing else broke.

`mapUnifiedActionToVercel` maps `allow` → `bypass` (skip further mitigation — Vercel's closest equivalent to letting a request through) and `block` → `deny` (Vercel's actual block-like action); the other 6 unified action types are already valid Vercel actions and pass through unchanged. Every unified `ActionType` has a real Vercel action to land on, so — unlike #261's operator fix — this never needs to warn or drop a condition.

## Test plan

- [x] Regression tests for `allow`→`bypass`, `block`→`deny`, and all 6 already-native actions passing through unchanged
- [x] Two mutation-verification passes (reverting to the raw passthrough, and separately corrupting just the `allow`/`block` mapping values while keeping the function wired up) — each confirmed the right tests fail with a clear message, restored
- [x] `pnpm compile && pnpm test && pnpm lint` all pass (1781 tests, 0 lint errors)