### PR TITLE
docs: update SKILL.md now that #261/#262 (Vercel operator/action gaps) are fixed

### DIFF
--- a/skills/doorman/SKILL.md
+++ b/skills/doorman/SKILL.md
@@ -129,9 +129,9 @@ Two different rule shapes, picked by whether the config has `provider`/`provider
 
 **Condition fields**: `ip`, `country`, `region`, `city`, `asn`, `path`, `host`, `method`, `header`, `query`, `cookie`, `user_agent`, `referer`, `scheme`, `port` — support varies by provider, see [references/cloudflare.md](references/cloudflare.md)/[references/fastly.md](references/fastly.md)/[references/gcp.md](references/gcp.md)
 
-**Operators**: `eq`, `ne`, `contains`, `not_contains`, `starts_with`, `ends_with`, `matches`, `in`, `not_in`, `gt`, `ge`, `lt`, `le`, `exists`, `not_exists` — **on Vercel specifically, `ne`/`not_contains`/`not_in`/`gt`/`ge`/`lt`/`le` currently degrade silently to `eq` (known bug, [doorman#261](https://github.com/gfargo/doorman/issues/261)) — avoid them in a Vercel-targeted config until that's fixed.**
+**Operators**: `eq`, `ne`, `contains`, `not_contains`, `starts_with`, `ends_with`, `matches`, `in`, `not_in`, `gt`, `ge`, `lt`, `le`, `exists`, `not_exists` — on Vercel, `gt`/`ge`/`lt`/`le` have no native equivalent and are dropped with a warning (Vercel has no numeric-comparison operator at all); every other operator, including `ne`/`not_contains`/`not_in`, is fully supported there.
 
-**Actions**: `log`, `deny`, `challenge`, `bypass`, `rate_limit`, `redirect`, `allow`, `block` — **`allow`/`block` are invalid on Vercel specifically ([doorman#262](https://github.com/gfargo/doorman/issues/262)); use `bypass`/`deny` there instead.**
+**Actions**: `log`, `deny`, `challenge`, `bypass`, `rate_limit`, `redirect`, `allow`, `block` — on Vercel, `allow`/`block` are automatically mapped to `bypass`/`deny` (its nearest native equivalents).
 
 ## When to Read Each Reference
 


### PR DESCRIPTION
## Summary

`SKILL.md` (loaded by any AI agent using the doorman skill) told users to *avoid* `ne`/`not_contains`/`not_in`/`gt`/`ge`/`lt`/`le` and `allow`/`block` in a Vercel-targeted config, citing #261/#262 as known bugs. Both were fixed and merged yesterday (#279, #280) — leaving the warnings in place would actively steer people away from functionality that now works correctly.

Updated both bold-warning lines to reflect current, accurate behavior:
- `ne`/`not_contains`/`not_in` are now fully supported on Vercel (via its positive-operator + `neg`-flag model).
- `gt`/`ge`/`lt`/`le` remain unsupported — that part hasn't changed — but reframed as a genuine platform limitation (Vercel has no numeric-comparison operator at all, safely dropped-with-warning) rather than a bug to avoid.
- `allow`/`block` are now automatically mapped to `bypass`/`deny` — no workaround needed.

Also audited the rest of `skills/doorman/references/*.md` and the GitHub Wiki's `Configuration.md` for the same class of staleness from today's other fixes (#263/#269/#270/#271): `cloudflare.md`'s keyed-query-condition docs and the rate-limit field table in `rules.md` were already accurate (updated by the PRs that shipped those fixes) — no changes needed there. `Configuration.md` (wiki) had the identical #261/#262 staleness plus a stale `key` note for #263's query fix; pushed that correction directly to the wiki (no PR flow there) in a separate commit.

Docs-only change, no code/test/schema touched.